### PR TITLE
Revert "fix: splash screen stays visible when Firestore updates recipes during preload"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17054,6 +17054,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18376,7 +18377,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/App.js
+++ b/src/App.js
@@ -377,8 +377,7 @@ function App() {
 
     doPreload();
     return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentUser, recipesLoaded]);
+  }, [currentUser, recipesLoaded, recipes]);
 
   // Hide splash screen once auth is done and all resources are ready
   useEffect(() => {


### PR DESCRIPTION
Reverts brou-cgn/recipebook#1241