### PR TITLE
Auto-deploy: Update Standard-Einheiten und -Adjektive

### DIFF
--- a/src/config/ingredientMatching.json
+++ b/src/config/ingredientMatching.json
@@ -1,9 +1,9 @@
 {
-  "requestId": "ingredient-matching-1780589877628",
-  "requestedBy": "WXG6Z8bh5yX1Ge1ZQCZ3Q0nnT3o2",
-  "generatedAt": "2026-06-04T16:18:00.223Z",
-  "customUnits": [
-    "Kästchen"
-  ],
-  "customIngredientAdjectives": []
+  "requestId": "ingredient-matching-1780596079126",
+  "requestedBy": "4C0VO5hdk7bKQnrP570zO01GILO2",
+  "generatedAt": "2026-06-04T18:01:22.436Z",
+  "customUnits": [],
+  "customIngredientAdjectives": [
+    "kochendheiße"
+  ]
 }


### PR DESCRIPTION
Automatisch generierter PR aus dem Entwicklungspfad.

Request-ID: `ingredient-matching-1780596079126`
Requested by: `4C0VO5hdk7bKQnrP570zO01GILO2`

### Standard-Einheiten
- (leer)

### Standard-Adjektive
- kochendheiße