### PR TITLE
feat: move Atelier category selection before swipe trainer in onboarding

### DIFF
--- a/src/App.auth.test.js
+++ b/src/App.auth.test.js
@@ -699,7 +699,7 @@ describe('App authentication view handling', () => {
     expect(screen.queryByRole('dialog', { name: 'Atelier Onboarding' })).not.toBeInTheDocument();
   });
 
-  test('linksswipe auf der vierten atelier-karte öffnet die kategorien-auswahl vor dem kochatelier und übernimmt die auswahl', async () => {
+  test('kategorien-auswahl erscheint nach dem onboarding-overlay vor dem swipe-training und übernimmt die auswahl', async () => {
     mockGetRolePermissions.mockResolvedValue({ user: { startseite: true, onboardingTestmode: true } });
     mockGetOnboardingTestmodeActive.mockResolvedValue(true);
     mockSubscribeToGroups.mockImplementation((_userId, callback) => {
@@ -741,18 +741,19 @@ describe('App authentication view handling', () => {
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
+
+    expect(screen.getByTestId('atelier-category-selection-view')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Swipe-Training' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dessert' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kochatelier öffnen' }));
+
     expect(screen.getByRole('dialog', { name: 'Swipe-Training' })).toBeInTheDocument();
 
     swipeTrainerRight();
     swipeTrainerLeft();
     swipeTrainerUp();
     swipeTrainerLeft();
-
-    expect(screen.getByTestId('atelier-category-selection-view')).toBeInTheDocument();
-    expect(screen.queryByTestId('tagesmenu-view')).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Dessert' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Kochatelier öffnen' }));
 
     expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
     expect(mockTagesmenuProps.mock.lastCall[0].selectedCategories).toEqual(['Dessert']);

--- a/src/App.js
+++ b/src/App.js
@@ -1181,6 +1181,10 @@ function App() {
 
   const handleAtelierOnboardingConfirm = () => {
     setShowAtelierOnboarding(false);
+    handleOpenAtelierCategorySelection();
+  };
+
+  const handleAtelierCategorySelectionContinue = () => {
     setShowAtelierSwipeTrainer(true);
   };
 
@@ -1199,13 +1203,9 @@ function App() {
     window.scrollTo(0, 0);
   };
 
-  const handleAtelierSwipeTrainerComplete = (finalSwipeDirection) => {
+  const handleAtelierSwipeTrainerComplete = () => {
     localStorage.setItem(ATELIER_ONBOARDING_KEY, 'true');
     setShowAtelierSwipeTrainer(false);
-    if (finalSwipeDirection === 'l') {
-      handleOpenAtelierCategorySelection();
-      return;
-    }
     handleOpenAtelier();
   };
 
@@ -2022,7 +2022,7 @@ function App() {
           categoryOptions={atelierCategoryOptions}
           selectedCategories={atelierSelectedCategories}
           onSelectedCategoriesChange={setAtelierSelectedCategories}
-          onContinue={handleOpenAtelier}
+          onContinue={handleAtelierCategorySelectionContinue}
         />
         ) : currentView === 'kueche' ? (
         <Kueche


### PR DESCRIPTION
The category-selection step now runs directly after the Atelier
onboarding overlay ("Weiter") and before the swipe-training, matching
the intended Atelier Overlay -> Kategorie-Auswahl -> Swipe-Training
sequence. The previous optional path (left-swipe on the final trainer
card revealing category selection) is removed since the selection now
already happens earlier in the flow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019YQ6FspdsvnEEHyH5K7kna