### PR TITLE
Add persistent per-card swipe hints to Atelier swipe trainer (slide 3)

### DIFF
--- a/src/components/AtelierSwipeTrainerOverlay.css
+++ b/src/components/AtelierSwipeTrainerOverlay.css
@@ -99,12 +99,18 @@
 }
 
 .atelier-swipe-trainer-photo img {
+  width: 72%;
+  height: 88%;
   object-fit: contain;
   pointer-events: none;
 }
 
 .atelier-swipe-trainer-body--recipe {
-  padding: 16px 18px;
+  padding: 14px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .atelier-swipe-trainer-name {
@@ -136,6 +142,10 @@
 
 .atelier-swipe-trainer-body--note {
   padding: 14px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .atelier-swipe-trainer-note-tag {
@@ -167,7 +177,11 @@
 }
 
 .atelier-swipe-trainer-body--final {
-  padding: 12px 16px 14px;
+  padding: 14px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .atelier-swipe-trainer-final-tag {
@@ -191,7 +205,6 @@
   font-weight: 300;
   color: #6B6B65;
   line-height: 1.55;
-  margin-bottom: 10px;
 }
 
 .atelier-swipe-trainer-final-body strong {
@@ -199,25 +212,30 @@
   font-weight: 600;
 }
 
-.atelier-swipe-trainer-final-divider {
+.atelier-swipe-trainer-hints {
+  margin-top: auto;
+  padding-top: 12px;
+}
+
+.atelier-swipe-trainer-hints-divider {
   height: 1px;
   background: #f0f0ee;
   margin-bottom: 10px;
 }
 
-.atelier-swipe-trainer-final-legend {
+.atelier-swipe-trainer-hints-rows {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.atelier-swipe-trainer-final-legend-row {
+.atelier-swipe-trainer-hint-row {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.atelier-swipe-trainer-final-legend-icon {
+.atelier-swipe-trainer-hint-icon {
   width: 28px;
   height: 28px;
   border-radius: 50%;
@@ -228,13 +246,13 @@
   flex-shrink: 0;
 }
 
-.atelier-swipe-trainer-final-legend-title {
+.atelier-swipe-trainer-hint-title {
   font-size: 12px;
   font-weight: 700;
   color: #1A1A18;
 }
 
-.atelier-swipe-trainer-final-legend-sub {
+.atelier-swipe-trainer-hint-sub {
   font-size: 10px;
   color: #6B6B65;
   font-weight: 300;
@@ -332,15 +350,15 @@
   color: #F0EAE0;
 }
 
-[data-theme="dark"] .atelier-swipe-trainer-final-divider {
+[data-theme="dark"] .atelier-swipe-trainer-hints-divider {
   background: #3A3A35;
 }
 
-[data-theme="dark"] .atelier-swipe-trainer-final-legend-title {
+[data-theme="dark"] .atelier-swipe-trainer-hint-title {
   color: #F0EAE0;
 }
 
-[data-theme="dark"] .atelier-swipe-trainer-final-legend-sub {
+[data-theme="dark"] .atelier-swipe-trainer-hint-sub {
   color: #B0A898;
 }
 

--- a/src/components/AtelierSwipeTrainerOverlay.js
+++ b/src/components/AtelierSwipeTrainerOverlay.js
@@ -36,7 +36,7 @@ const SLOT_CONTENT = [
     author: 'Benjamin',
     tags: ['Vegetarisch', '5 Min.'],
     imgAlt: 'Mango Cocktail',
-    imgStyle: { width: '72%', height: '88%' },
+    hints: [{ icon: '→', bg: '#FDF3E3', title: 'Parken', sub: 'Swipe nach rechts' }],
   },
   {
     type: 'note',
@@ -50,7 +50,7 @@ const SLOT_CONTENT = [
       </>
     ),
     imgAlt: 'Mango Cocktail',
-    imgStyle: { width: '72%', height: '88%' },
+    hints: [{ icon: '←', bg: '#F0F0EE', title: 'Archivieren', sub: 'Swipe nach links' }],
   },
   {
     type: 'note',
@@ -64,7 +64,7 @@ const SLOT_CONTENT = [
       </>
     ),
     imgAlt: 'Mango Cocktail',
-    imgStyle: { width: '72%', height: '88%' },
+    hints: [{ icon: '↑', bg: '#EDF2EE', title: 'Kochen', sub: 'Swipe nach oben' }],
   },
   {
     type: 'final',
@@ -77,21 +77,41 @@ const SLOT_CONTENT = [
         langweilig und es ist wieder Platz für neue Rezepte.
       </>
     ),
-    imgStyle: { width: '60%', height: '80%', opacity: 0.35 },
+    imgAlt: 'Mango Cocktail',
+    hints: [
+      { icon: '↑', bg: '#EDF2EE', title: 'Weiter', sub: 'Swipe nach oben' },
+      { icon: '→', bg: '#FDF3E3', title: 'Nochmal ansehen', sub: 'Swipe nach rechts' },
+      { icon: '←', bg: '#F0F0EE', title: 'Direkt ins Kochatelier', sub: 'Swipe nach links' },
+    ],
   },
 ];
 
-const FINAL_LEGEND_ROWS = [
-  { icon: '↑', bg: '#EDF2EE', title: 'Weiter', sub: 'Swipe nach oben' },
-  { icon: '→', bg: '#FDF3E3', title: 'Nochmal ansehen', sub: 'Swipe nach rechts' },
-  { icon: '←', bg: '#F0F0EE', title: 'Direkt ins Kochatelier', sub: 'Swipe nach links' },
-];
+function CardHints({ hints }) {
+  return (
+    <div className="atelier-swipe-trainer-hints">
+      <div className="atelier-swipe-trainer-hints-divider" />
+      <div className="atelier-swipe-trainer-hints-rows">
+        {hints.map((hint) => (
+          <div key={hint.title} className="atelier-swipe-trainer-hint-row">
+            <div className="atelier-swipe-trainer-hint-icon" style={{ background: hint.bg }}>
+              {hint.icon}
+            </div>
+            <div>
+              <div className="atelier-swipe-trainer-hint-title">{hint.title}</div>
+              <div className="atelier-swipe-trainer-hint-sub">{hint.sub}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function CardContent({ slot }) {
   return (
     <>
       <div className="atelier-swipe-trainer-photo">
-        <img src={cocktailPlaceholder} alt={slot.imgAlt || ''} style={slot.imgStyle} draggable="false" />
+        <img src={cocktailPlaceholder} alt={slot.imgAlt || ''} draggable="false" />
       </div>
       {slot.type === 'recipe' && (
         <div className="atelier-swipe-trainer-body--recipe">
@@ -102,6 +122,7 @@ function CardContent({ slot }) {
               <span key={tag} className="atelier-swipe-trainer-tag">{tag}</span>
             ))}
           </div>
+          <CardHints hints={slot.hints} />
         </div>
       )}
       {slot.type === 'note' && (
@@ -109,6 +130,7 @@ function CardContent({ slot }) {
           <p className="atelier-swipe-trainer-note-tag">{slot.tag}</p>
           <p className="atelier-swipe-trainer-note-title">{slot.title}</p>
           <p className="atelier-swipe-trainer-note-body">{slot.body}</p>
+          <CardHints hints={slot.hints} />
         </div>
       )}
       {slot.type === 'final' && (
@@ -116,20 +138,7 @@ function CardContent({ slot }) {
           <p className="atelier-swipe-trainer-final-tag">{slot.tag}</p>
           <p className="atelier-swipe-trainer-final-title">{slot.title}</p>
           <p className="atelier-swipe-trainer-final-body">{slot.body}</p>
-          <div className="atelier-swipe-trainer-final-divider" />
-          <div className="atelier-swipe-trainer-final-legend">
-            {FINAL_LEGEND_ROWS.map((row) => (
-              <div key={row.title} className="atelier-swipe-trainer-final-legend-row">
-                <div className="atelier-swipe-trainer-final-legend-icon" style={{ background: row.bg }}>
-                  {row.icon}
-                </div>
-                <div>
-                  <div className="atelier-swipe-trainer-final-legend-title">{row.title}</div>
-                  <div className="atelier-swipe-trainer-final-legend-sub">{row.sub}</div>
-                </div>
-              </div>
-            ))}
-          </div>
+          <CardHints hints={slot.hints} />
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- The previous PR (#2655) reverted two doomed attempts to fix onboarding slide 3 that edited `docs/broubook-onboarding-*.html` — files confirmed unreferenced anywhere in the app build (pure design mockups).
- The real renderer is `src/components/AtelierSwipeTrainerOverlay.js`, wired into `src/App.js`'s onboarding flow (Atelier spotlight → category selection → swipe trainer). It was already close to the reference design (thresholds, floating drag labels, 7-dot progress, colors) but was missing the **persistent per-card hint row** the reference pins to the bottom of each teaching card (icon circle + direction title + "Swipe nach …" subtext, e.g. "→ Parken / Swipe nach rechts") — that was the actual visible gap the user reported ("alte Version").
- The final "It's a Match" card's photo was also incorrectly shrunk/dimmed (`60%/80%`, `opacity:0.35`) instead of matching the other cards' `72%/88%`.

## Changes
- `src/components/AtelierSwipeTrainerOverlay.js`: added a `hints` array per card slot and a new `CardHints` component rendering the icon+title+sub row(s); the final card's 3-row legend now reuses the same component instead of bespoke markup; unified image sizing across all card types.
- `src/components/AtelierSwipeTrainerOverlay.css`: card bodies switched to `flex:1; flex-direction:column` so the hint row docks to the bottom via `margin-top:auto`; renamed `.final-legend-*` classes to generic `.hint-*` classes (including dark-mode overrides).

## Test plan
- [x] `npx react-scripts test src/components/AtelierSwipeTrainerOverlay.test.js` — 7/7 passing
- [x] `npm run build` succeeds; verified new hint classes/text ("Parken", "Kochen", `atelier-swipe-trainer-hint-row`) are present in the build output
- [ ] Manual check in onboarding testmode after deploy: hint row visible under each of the 3 teaching cards, final card photo matches sizing of the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jsKFhn6e9sgjin91nHN64

---
_Generated by [Claude Code](https://claude.ai/code/session_016jsKFhn6e9sgjin91nHN64)_