### PR TITLE
Insert Atelier taste/rating intro overlay after swipe trainer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import MobileSearchOverlay from './components/MobileSearchOverlay';
 import BottomNavigation from './components/BottomNavigation';
 import AtelierOnboardingOverlay from './components/AtelierOnboardingOverlay';
 import AtelierSwipeTrainerOverlay from './components/AtelierSwipeTrainerOverlay';
+import AtelierTasteIntroOverlay from './components/AtelierTasteIntroOverlay';
 import AtelierCategorySelectionPage from './components/AtelierCategorySelectionPage';
 import { 
   loginUser, 
@@ -369,6 +370,7 @@ function App() {
   const [isKuechePersonalDataOpen, setIsKuechePersonalDataOpen] = useState(false);
   const [showAtelierOnboarding, setShowAtelierOnboarding] = useState(false);
   const [showAtelierSwipeTrainer, setShowAtelierSwipeTrainer] = useState(false);
+  const [showAtelierTasteIntro, setShowAtelierTasteIntro] = useState(false);
   const [atelierSelectedCategories, setAtelierSelectedCategories] = useState([]);
   const [onboardingTestmodeActive, setOnboardingTestmodeActive] = useState(false);
   // Capture the webimportAuthor URL param synchronously on mount (alongside pendingWebimportUrl)
@@ -1240,10 +1242,17 @@ function App() {
     window.scrollTo(0, 0);
   };
 
-  const handleAtelierSwipeTrainerComplete = () => {
+  const handleAtelierSwipeTrainerComplete = (direction) => {
     localStorage.setItem(ATELIER_ONBOARDING_KEY, 'true');
     setShowAtelierSwipeTrainer(false);
     handleOpenAtelier();
+    if (direction === 'u') {
+      setShowAtelierTasteIntro(true);
+    }
+  };
+
+  const handleAtelierTasteIntroContinue = () => {
+    setShowAtelierTasteIntro(false);
   };
 
   const handleOpenPrivateListRecipes = (groupId) => {
@@ -2232,6 +2241,9 @@ function App() {
         )}
         {showAtelierSwipeTrainer && (
           <AtelierSwipeTrainerOverlay onComplete={handleAtelierSwipeTrainerComplete} />
+        )}
+        {showAtelierTasteIntro && (
+          <AtelierTasteIntroOverlay onContinue={handleAtelierTasteIntroContinue} />
         )}
       </div>
     </NutritionReferenceProvider>

--- a/src/components/AtelierTasteIntroOverlay.css
+++ b/src/components/AtelierTasteIntroOverlay.css
@@ -1,0 +1,122 @@
+.atelier-taste-intro-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  pointer-events: all;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px calc(24px + env(safe-area-inset-bottom, 0px));
+}
+
+.atelier-taste-intro-overlay__scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.62);
+  z-index: -1;
+}
+
+.atelier-taste-intro-overlay__spotlight {
+  position: fixed;
+  border: 2.5px solid rgba(212, 130, 10, 0.95);
+  background: transparent;
+  border-radius: 14px;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.62);
+  animation: atelier-taste-intro-glow 1.8s ease-in-out infinite;
+  pointer-events: none;
+  z-index: -1;
+}
+
+@keyframes atelier-taste-intro-glow {
+  0%, 100% {
+    border-color: rgba(212, 130, 10, 0.85);
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.62);
+  }
+  50% {
+    border-color: rgba(212, 130, 10, 1);
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.62), 0 0 0 5px rgba(212, 130, 10, 0.18);
+  }
+}
+
+.atelier-taste-intro-card {
+  width: 100%;
+  max-width: 400px;
+  background: #fff;
+  border-radius: 20px;
+  padding: 22px 20px 24px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+  margin-bottom: 16px;
+  animation: atelier-taste-intro-pop-in 0.35s cubic-bezier(0.34, 1.4, 0.64, 1) forwards;
+}
+
+@keyframes atelier-taste-intro-pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.atelier-taste-intro-card__tag {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #D4820A;
+  margin-bottom: 5px;
+}
+
+.atelier-taste-intro-card__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1A1A18;
+  margin-bottom: 8px;
+  line-height: 1.25;
+}
+
+.atelier-taste-intro-card__body {
+  font-size: 13px;
+  font-weight: 300;
+  color: #6B6B65;
+  line-height: 1.6;
+}
+
+.atelier-taste-intro-card__body--tappable {
+  cursor: pointer;
+}
+
+.atelier-taste-intro-overlay__btn {
+  width: 100%;
+  max-width: 400px;
+  padding: 14px;
+  background: #D4820A;
+  color: #fff;
+  border: none;
+  border-radius: 14px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform 0.1s, background 0.15s;
+}
+
+.atelier-taste-intro-overlay__btn:active {
+  transform: scale(0.98);
+  background: #c07508;
+}
+
+[data-theme="dark"] .atelier-taste-intro-card {
+  background: #2A2A28;
+}
+
+[data-theme="dark"] .atelier-taste-intro-card__title {
+  color: #F0EAE0;
+}
+
+[data-theme="dark"] .atelier-taste-intro-card__body {
+  color: #B0A898;
+}

--- a/src/components/AtelierTasteIntroOverlay.js
+++ b/src/components/AtelierTasteIntroOverlay.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import './AtelierTasteIntroOverlay.css';
+
+const PADDING = 6;
+
+function AtelierTasteIntroOverlay({ onContinue }) {
+  const [phase, setPhase] = useState('taste'); // 'taste' | 'bite'
+  const [spotlightStyle, setSpotlightStyle] = useState(null);
+
+  useEffect(() => {
+    if (phase !== 'bite') return;
+    const btn = document.querySelector('[aria-label="Suche"]');
+    if (btn) {
+      const rect = btn.getBoundingClientRect();
+      setSpotlightStyle({
+        left: rect.left - PADDING,
+        top: rect.top - PADDING,
+        width: rect.width + PADDING * 2,
+        height: rect.height + PADDING * 2,
+      });
+    }
+  }, [phase]);
+
+  return (
+    <div className="atelier-taste-intro-overlay" role="dialog" aria-modal="true" aria-label="Onboarding: Nach dem Kochen">
+      {phase === 'taste' && <div className="atelier-taste-intro-overlay__scrim" />}
+      {phase === 'bite' && spotlightStyle && (
+        <div
+          className="atelier-taste-intro-overlay__spotlight"
+          style={spotlightStyle}
+          data-testid="atelier-taste-intro-spotlight"
+        />
+      )}
+
+      {phase === 'taste' ? (
+        <div className="atelier-taste-intro-card" data-testid="atelier-taste-intro-card-taste">
+          <p className="atelier-taste-intro-card__tag">Let&apos;s Taste</p>
+          <h2 className="atelier-taste-intro-card__title">7 Tage, 6 Rezepte</h2>
+          <p
+            className="atelier-taste-intro-card__body atelier-taste-intro-card__body--tappable"
+            onClick={() => setPhase('bite')}
+          >
+            Weniger ist mehr – das Atelier-Grid zeigt dir maximal 6 Rezepte. Kein Scrollen durch
+            deine Merklisten, keine Kochbücher durchblättern, du behältst auch hier immer den
+            Überblick.
+          </p>
+        </div>
+      ) : (
+        <div className="atelier-taste-intro-card" data-testid="atelier-taste-intro-card-bite">
+          <p className="atelier-taste-intro-card__tag">The Final Bite</p>
+          <h2 className="atelier-taste-intro-card__title">Ein Rezept, dein Urteil</h2>
+          <p className="atelier-taste-intro-card__body">
+            Du hast gekocht, probiert, vielleicht sogar den Teller abgeleckt?! Jetzt fehlt nur
+            noch deine Bewertung – sie entscheidet, ob das Rezept wieder auf deinem Tisch landet.
+          </p>
+        </div>
+      )}
+
+      <button
+        className="atelier-taste-intro-overlay__btn"
+        onClick={onContinue}
+        type="button"
+      >
+        Weiter: Nach dem Kochen
+      </button>
+    </div>
+  );
+}
+
+export default AtelierTasteIntroOverlay;

--- a/src/components/AtelierTasteIntroOverlay.test.js
+++ b/src/components/AtelierTasteIntroOverlay.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AtelierTasteIntroOverlay from './AtelierTasteIntroOverlay';
+
+describe('AtelierTasteIntroOverlay', () => {
+  test('renders the first card (Let\'s Taste) and the continue button', () => {
+    render(<AtelierTasteIntroOverlay onContinue={() => {}} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText("Let's Taste")).toBeInTheDocument();
+    expect(screen.getByText('7 Tage, 6 Rezepte')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Weiter: Nach dem Kochen/i })).toBeInTheDocument();
+  });
+
+  test('tapping the body text switches to the second card (The Final Bite)', () => {
+    render(<AtelierTasteIntroOverlay onContinue={() => {}} />);
+
+    fireEvent.click(screen.getByText(/Atelier-Grid/));
+
+    expect(screen.getByText('The Final Bite')).toBeInTheDocument();
+    expect(screen.getByText('Ein Rezept, dein Urteil')).toBeInTheDocument();
+    expect(screen.queryByText("Let's Taste")).not.toBeInTheDocument();
+  });
+
+  test('shows a spotlight around the search button once the second card is active', () => {
+    const mockBtn = document.createElement('button');
+    mockBtn.setAttribute('aria-label', 'Suche');
+    mockBtn.getBoundingClientRect = () => ({
+      left: 300, top: 20, width: 32, height: 32, right: 332, bottom: 52,
+    });
+    document.body.appendChild(mockBtn);
+
+    const { container } = render(<AtelierTasteIntroOverlay onContinue={() => {}} />);
+    expect(container.querySelector('[data-testid="atelier-taste-intro-spotlight"]')).toBeNull();
+
+    fireEvent.click(screen.getByText(/Atelier-Grid/));
+
+    expect(container.querySelector('[data-testid="atelier-taste-intro-spotlight"]')).toBeTruthy();
+
+    document.body.removeChild(mockBtn);
+  });
+
+  test('calls onContinue when the button is clicked', () => {
+    const onContinue = jest.fn();
+    render(<AtelierTasteIntroOverlay onContinue={onContinue} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Weiter: Nach dem Kochen/i }));
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Swiping up on the swipe trainer's final card ("Weiter") previously
did the exact same thing as swiping left ("Direkt ins Kochatelier") -
both jumped straight into the Atelier. Now swipe-up shows a new
two-step info overlay (Let's Taste / The Final Bite) explaining the
Atelier grid limit and post-cooking rating, with a spotlight on the
real search button, before continuing into the already-opened Atelier.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ghr9fmrN85MVSjwy5kqYQt