### PR TITLE
Add category-weighted drink pre-estimate with season/time-of-day deltas

### DIFF
--- a/functions/calculateDrinkAmounts.js
+++ b/functions/calculateDrinkAmounts.js
@@ -1,0 +1,158 @@
+const {
+  BASISWERT_LITER_PRO_PERSON_STUNDE,
+  TAGESZEIT_KIPPPUNKT_STUNDE,
+  DRINK_WEIGHT_CATEGORIES,
+} = require('./drinkWeights');
+
+/**
+ * Parst "HH:MM" in Dezimalstunden.
+ * @param {string} time Uhrzeit im Format "HH:MM".
+ * @return {number} Stunden seit Mitternacht (dezimal).
+ */
+function parseTimeToHours(time) {
+  const [hours, minutes] = time.split(':').map(Number);
+  return hours + minutes / 60;
+}
+
+/**
+ * Teilt die Eventdauer an einem taeglich wiederkehrenden Kipppunkt
+ * (z.B. 18 Uhr) in "vorher"- und "nachher"-Stunden auf. Reine
+ * Stufenfunktion, kein gradueller Uebergang.
+ *
+ * Liegt endHours <= startHours, wird das Event als ueber Mitternacht
+ * hinausgehend behandelt (Ende + 24h). Bei mehrtaegigen Events wird der
+ * Kipppunkt fuer jeden ueberstrichenen Tag erneut angewendet.
+ * @param {number} startHours Start in Dezimalstunden.
+ * @param {number} endHours Ende in Dezimalstunden (vor Mitternachts-Korrektur).
+ * @param {number} tippingHour Taeglicher Kipppunkt in Dezimalstunden.
+ * @return {{vorher: number, nachher: number}} Aufsummierte Stunden je Fenster.
+ */
+function splitHoursByTippingPoint(startHours, endHours, tippingHour) {
+  const end = endHours <= startHours ? endHours + 24 : endHours;
+
+  let vorher = 0;
+  let nachher = 0;
+  let cursor = startHours;
+  while (cursor < end) {
+    const dayStart = Math.floor(cursor / 24) * 24;
+    const tipToday = dayStart + tippingHour;
+    if (cursor < tipToday) {
+      const segmentEnd = Math.min(end, tipToday);
+      vorher += segmentEnd - cursor;
+      cursor = segmentEnd;
+    } else {
+      const segmentEnd = Math.min(end, dayStart + 24);
+      nachher += segmentEnd - cursor;
+      cursor = segmentEnd;
+    }
+  }
+  return {vorher, nachher};
+}
+
+/**
+ * Ermittelt das saisonale Delta einer Kategorie.
+ * @param {object} entry Eintrag aus DRINK_WEIGHT_CATEGORIES.
+ * @param {string} season "winter" | "uebergang" | "sommer".
+ * @return {number} Delta.
+ */
+function seasonDelta(entry, season) {
+  if (season === 'winter') return entry.deltaWinter;
+  if (season === 'sommer') return entry.deltaSommer;
+  return 0; // uebergang: kein Delta
+}
+
+/**
+ * Berechnet die effektiven Gewichte je Kategorie fuer Nachmittags- und
+ * Abendstunden getrennt (Basis + Saison-Delta [+ Nachmittags-Delta]).
+ * @param {string} season "winter" | "uebergang" | "sommer".
+ * @return {{nachmittag: object, abend: object}} Gewichte je Kategorie.
+ */
+function computeEffectiveWeights(season) {
+  const nachmittag = {};
+  const abend = {};
+  for (const [kategorie, entry] of Object.entries(DRINK_WEIGHT_CATEGORIES)) {
+    const basisPlusSaison = entry.basis + seasonDelta(entry, season);
+    abend[kategorie] = basisPlusSaison;
+    nachmittag[kategorie] = basisPlusSaison + entry.deltaNachmittag;
+  }
+  return {nachmittag, abend};
+}
+
+/**
+ * Verteilt das Gewicht nicht angebotener Kategorien gleichmaessig auf die
+ * verbleibenden Kategorien (flat, nicht anteilig gewichtet).
+ * @param {object} weights Gewichte je Kategorie (bereits saison-/tageszeitkorrigiert).
+ * @param {string[]} excludedCategories Nicht angebotene Kategorien.
+ * @return {object} Gewichte der verbleibenden Kategorien nach Redistribution.
+ */
+function redistributeWeights(weights, excludedCategories) {
+  const remaining = Object.keys(weights).filter((k) => !excludedCategories.includes(k));
+  if (remaining.length === 0) {
+    throw new Error('Mindestens eine Kategorie muss angeboten werden.');
+  }
+
+  const excludedSum = Object.keys(weights)
+      .filter((k) => excludedCategories.includes(k))
+      .reduce((sum, k) => sum + weights[k], 0);
+  const zusatzgewicht = excludedSum / remaining.length;
+
+  const result = {};
+  for (const kategorie of remaining) {
+    result[kategorie] = weights[kategorie] + zusatzgewicht;
+  }
+  return result;
+}
+
+/**
+ * Vorab-Schaetzung des Getraenkebedarfs je Kategorie, basierend auf
+ * Kategorie-Gewichten mit Saison-/Tageszeit-Korrektur und Redistribution
+ * bei Kategorie-Wegfall (siehe drinkWeights.js).
+ *
+ * Ersetzt NICHT die Kalibrierung aus Realdaten (calculateEventDrinks.js /
+ * submitConsumption.js) -- dies ist die Vorab-Schaetzung, auf die jene
+ * Kalibrierung aufsetzt.
+ * @param {object} params Parameter.
+ * @param {number} params.guests Anzahl Gaeste.
+ * @param {string} params.startTime Start des Events, "HH:MM".
+ * @param {string} params.endTime Ende des Events, "HH:MM".
+ * @param {string} params.season "winter" | "uebergang" | "sommer".
+ * @param {string[]} [params.excludedCategories] Nicht angebotene Kategorien.
+ * @param {number} [params.baseLitersPerHour] Basiswert L/Person/Stunde.
+ * @return {object} Menge in Litern je angebotener Kategorie.
+ */
+function calculateDrinkAmounts({
+  guests,
+  startTime,
+  endTime,
+  season,
+  excludedCategories = [],
+  baseLitersPerHour = BASISWERT_LITER_PRO_PERSON_STUNDE,
+}) {
+  const startHours = parseTimeToHours(startTime);
+  const endHours = parseTimeToHours(endTime);
+  const {vorher: nachmittagStunden, nachher: abendStunden} =
+      splitHoursByTippingPoint(startHours, endHours, TAGESZEIT_KIPPPUNKT_STUNDE);
+
+  const {nachmittag, abend} = computeEffectiveWeights(season);
+  const nachmittagVerteilt = redistributeWeights(nachmittag, excludedCategories);
+  const abendVerteilt = redistributeWeights(abend, excludedCategories);
+
+  const ergebnis = {};
+  for (const kategorie of Object.keys(abendVerteilt)) {
+    const literNachmittag =
+        baseLitersPerHour * nachmittagVerteilt[kategorie] * nachmittagStunden * guests;
+    const literAbend = baseLitersPerHour * abendVerteilt[kategorie] * abendStunden * guests;
+    ergebnis[kategorie] = literNachmittag + literAbend;
+  }
+  return ergebnis;
+}
+
+module.exports = {
+  calculateDrinkAmounts,
+  _internal: {
+    parseTimeToHours,
+    splitHoursByTippingPoint,
+    computeEffectiveWeights,
+    redistributeWeights,
+  },
+};

--- a/functions/calculateDrinkAmounts.test.js
+++ b/functions/calculateDrinkAmounts.test.js
@@ -1,0 +1,115 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {calculateDrinkAmounts, _internal} = require('./calculateDrinkAmounts');
+const {DRINK_WEIGHT_CATEGORIES} = require('./drinkWeights');
+
+const KATEGORIEN = Object.keys(DRINK_WEIGHT_CATEGORIES);
+
+/**
+ * Summiert die Werte eines Gewichte-Objekts.
+ * @param {object} weights Gewichte je Kategorie.
+ * @return {number} Summe.
+ */
+function sum(weights) {
+  return Object.values(weights).reduce((a, b) => a + b, 0);
+}
+
+test('effektive Gewichte (Saison + Nachmittag, vor Redistribution) summieren auf 1,0', () => {
+  for (const season of ['winter', 'uebergang', 'sommer']) {
+    const {nachmittag, abend} = _internal.computeEffectiveWeights(season);
+    assert.ok(Math.abs(sum(nachmittag) - 1) < 1e-9, `nachmittag/${season}`);
+    assert.ok(Math.abs(sum(abend) - 1) < 1e-9, `abend/${season}`);
+  }
+});
+
+test('Gewichte summieren nach Redistribution weiterhin auf 1,0', () => {
+  const {nachmittag} = _internal.computeEffectiveWeights('sommer');
+  const verteilt = _internal.redistributeWeights(nachmittag, ['wein', 'tee']);
+  assert.equal(Object.keys(verteilt).length, KATEGORIEN.length - 2);
+  assert.ok(Math.abs(sum(verteilt) - 1) < 1e-9);
+});
+
+test('Rechenbeispiel 15-21 Uhr: 3h Nachmittag, 3h Abend', () => {
+  const {vorher, nachher} = _internal.splitHoursByTippingPoint(15, 21, 18);
+  assert.equal(vorher, 3);
+  assert.equal(nachher, 3);
+});
+
+test('Event komplett vor 18 Uhr: nur Nachmittagsstunden', () => {
+  const {vorher, nachher} = _internal.splitHoursByTippingPoint(10, 14, 18);
+  assert.equal(vorher, 4);
+  assert.equal(nachher, 0);
+});
+
+test('Event komplett nach 18 Uhr: nur Abendstunden', () => {
+  const {vorher, nachher} = _internal.splitHoursByTippingPoint(19, 23, 18);
+  assert.equal(vorher, 0);
+  assert.equal(nachher, 4);
+});
+
+test('Event ueber Mitternacht hinaus: Stunden werden ueber beide Tage korrekt aufgeteilt', () => {
+  // 22:00 - 02:00 -> 22-24 Uhr (abend, 2h) + 00-02 Uhr naechster Tag (vor 18 Uhr, 2h)
+  const {vorher, nachher} = _internal.splitHoursByTippingPoint(22, 2, 18);
+  assert.equal(vorher, 2);
+  assert.equal(nachher, 2);
+});
+
+test('Redistribution: eine Kategorie ausschliessen, Gewicht gleichmaessig auf die restlichen 6 verteilt', () => {
+  const {abend} = _internal.computeEffectiveWeights('uebergang');
+  const bierGewichtVorher = abend.bier;
+  const verteilt = _internal.redistributeWeights(abend, ['bier']);
+  const erwarteteZusatz = bierGewichtVorher / (KATEGORIEN.length - 1);
+  for (const kategorie of KATEGORIEN.filter((k) => k !== 'bier')) {
+    assert.ok(Math.abs(verteilt[kategorie] - (abend[kategorie] + erwarteteZusatz)) < 1e-9);
+  }
+  assert.equal(verteilt.bier, undefined);
+});
+
+test('Grenzfall: alle Kategorien bis auf eine ausgeschlossen -> verbleibende bekommt Gewicht 1,0', () => {
+  const {abend} = _internal.computeEffectiveWeights('winter');
+  const ausgeschlossen = KATEGORIEN.filter((k) => k !== 'wasser');
+  const verteilt = _internal.redistributeWeights(abend, ausgeschlossen);
+  assert.deepEqual(Object.keys(verteilt), ['wasser']);
+  assert.ok(Math.abs(verteilt.wasser - 1) < 1e-9);
+});
+
+test('Leere excludedCategories: keine Redistribution noetig, Gewichte unveraendert', () => {
+  const {nachmittag} = _internal.computeEffectiveWeights('sommer');
+  const verteilt = _internal.redistributeWeights(nachmittag, []);
+  assert.deepEqual(verteilt, nachmittag);
+});
+
+test('calculateDrinkAmounts: liefert fuer jede angebotene Kategorie eine Literangabe', () => {
+  const ergebnis = calculateDrinkAmounts({
+    guests: 20,
+    startTime: '15:00',
+    endTime: '21:00',
+    season: 'sommer',
+  });
+
+  assert.equal(Object.keys(ergebnis).length, KATEGORIEN.length);
+  for (const kategorie of KATEGORIEN) {
+    assert.ok(ergebnis[kategorie] > 0, kategorie);
+  }
+
+  // Kontrolle Gesamtmenge: Basiswert * Gesamtgewicht(1.0 je Fenster) * Stunden * Gaeste,
+  // aufgeteilt auf 3h Nachmittag + 3h Abend.
+  const gesamt = Object.values(ergebnis).reduce((a, b) => a + b, 0);
+  const erwartet = 0.5 * 1 * 3 * 20 + 0.5 * 1 * 3 * 20;
+  assert.ok(Math.abs(gesamt - erwartet) < 1e-9);
+});
+
+test('calculateDrinkAmounts: ausgeschlossene Kategorien tauchen nicht im Ergebnis auf', () => {
+  const ergebnis = calculateDrinkAmounts({
+    guests: 10,
+    startTime: '18:00',
+    endTime: '22:00',
+    season: 'winter',
+    excludedCategories: ['spirituosen', 'tee'],
+  });
+
+  assert.equal(Object.keys(ergebnis).length, KATEGORIEN.length - 2);
+  assert.equal(ergebnis.spirituosen, undefined);
+  assert.equal(ergebnis.tee, undefined);
+});

--- a/functions/drinkWeights.js
+++ b/functions/drinkWeights.js
@@ -1,0 +1,44 @@
+/**
+ * Kategorie-Gewichte fuer die Getraenke-Vorab-Schaetzung
+ * (siehe calculateDrinkAmounts.js).
+ *
+ * Dies ist ein eigenstaendiges Gewichtungsmodell (Kategorie-Anteil an der
+ * Gesamtmenge), unabhaengig von den absoluten L/Person/Stunde-Faustwerten
+ * in drinkRates.js. Es dient als schnelle Vorab-Schaetzung, auf die die
+ * spaetere Kalibrierung aus Realdaten (siehe submitConsumption.js /
+ * calculateEventDrinks.js) aufsetzt -- beide Pfade bleiben getrennt.
+ */
+
+// Referenzklima Uebergangszeit (~15-20 Grad), Basiswert siehe calculateDrinkAmounts.js.
+const BASISWERT_LITER_PRO_PERSON_STUNDE = 0.5;
+
+// Kipppunkt der Tageszeit-Stufenfunktion (Stunden vor 18 Uhr = "Nachmittag").
+const TAGESZEIT_KIPPPUNKT_STUNDE = 18;
+
+/**
+ * Basis-Gewicht je Kategorie (Summe = 1,0) sowie Deltas fuer Winter, Sommer
+ * und Nachmittagsstunden. Die Delta-Spalten muessen sich jeweils exakt zu
+ * 0,000 aufsummieren (Kontrollsumme), damit die effektiven Gewichte nach
+ * Korrektur weiterhin 1,0 ergeben.
+ *
+ * Hinweis: In der Vorlage summierten sich Winter- und Sommer-Spalte auf
+ * +0,001 bzw. -0,001 statt 0 (Rundungsfehler der Ausgangsdaten). Das
+ * deltaWinter/deltaSommer von "wasser" wurde daher um 0,001 korrigiert
+ * (-0,051 -> -0,052 bzw. +0,050 -> +0,051), alle anderen Werte sind
+ * unveraendert aus der Vorgabe uebernommen.
+ */
+const DRINK_WEIGHT_CATEGORIES = {
+  bier: {basis: 0.260, deltaWinter: -0.018, deltaSommer: 0.014, deltaNachmittag: -0.035},
+  wein: {basis: 0.150, deltaWinter: 0.042, deltaSommer: -0.053, deltaNachmittag: -0.020},
+  softdrinks: {basis: 0.260, deltaWinter: -0.048, deltaSommer: 0.056, deltaNachmittag: 0.020},
+  spirituosen: {basis: 0.030, deltaWinter: 0.005, deltaSommer: -0.008, deltaNachmittag: -0.015},
+  kaffee: {basis: 0.090, deltaWinter: 0.046, deltaSommer: -0.039, deltaNachmittag: 0.035},
+  tee: {basis: 0.040, deltaWinter: 0.025, deltaSommer: -0.021, deltaNachmittag: 0.015},
+  wasser: {basis: 0.170, deltaWinter: -0.052, deltaSommer: 0.051, deltaNachmittag: 0.000},
+};
+
+module.exports = {
+  BASISWERT_LITER_PRO_PERSON_STUNDE,
+  TAGESZEIT_KIPPPUNKT_STUNDE,
+  DRINK_WEIGHT_CATEGORIES,
+};


### PR DESCRIPTION
Adds calculateDrinkAmounts (functions/) as a standalone pre-event
liter estimate based on category weight shares, corrected for season
and a hard 18:00 afternoon/evening tipping point, with even
redistribution of excluded categories' weight onto the remaining
ones. Kept separate from the existing rate-based calibration path
(calculateEventDrinks.js / submitConsumption.js), which this feeds
into as a rough starting estimate.

Corrected wasser's winter/sommer deltas by 0.001 so each delta column
sums exactly to 0 (source data was off by that amount), preserving
the control-sum invariant the effective weights rely on.