### PR TITLE
Fix alcohol-free beer sharing budget with regular beer in shopping list

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -7,7 +7,7 @@ import {
   subscribeToCustomDrinks,
   subscribeToGuestProfiles,
 } from '../utils/eventsFirestore';
-import { getDrinkParentCategoryId } from '../utils/drinkCategories';
+import { getDrinkParentCategoryId, categoryHasOwnBudget } from '../utils/drinkCategories';
 import { computeGuestPreferenceMultipliers, getGuestDisplayName } from '../utils/guestPreferences';
 
 const CATEGORY_LABELS = {
@@ -141,7 +141,9 @@ function EventForm({ onSaved, onCancel, currentUser, onManageDrinks, initialEven
         customDrinkIds
           .map((drinkId) => customDrinks.find((drink) => drink.id === drinkId)?.kategorie)
           .filter(Boolean)
-          .map((categoryId) => getDrinkParentCategoryId(categoryId) || categoryId),
+          .map((categoryId) =>
+            categoryHasOwnBudget(categoryId) ? categoryId : getDrinkParentCategoryId(categoryId) || categoryId
+          ),
       )];
 
       const event = {

--- a/src/components/EventForm.test.js
+++ b/src/components/EventForm.test.js
@@ -99,7 +99,7 @@ describe('EventForm', () => {
     await waitFor(() => expect(mockCalculateEventDrinks).toHaveBeenCalledTimes(1));
     const [event] = mockCalculateEventDrinks.mock.calls[0];
     expect(event.customDrinkIds).toEqual(['custom-wasser', 'custom-bier']);
-    expect(event.categories).toEqual(['wasser', 'bier']);
+    expect(event.categories).toEqual(['wasser', 'bier_alkoholfrei']);
   });
 
   test('does not show Getränke verwalten link when onManageDrinks is not provided', () => {

--- a/src/utils/drinkCategories.js
+++ b/src/utils/drinkCategories.js
@@ -9,7 +9,7 @@ export const DRINK_CATEGORIES = [
       { id: 'bier_koelsch', label: 'Kölsch' },
       { id: 'bier_pils', label: 'Pils' },
       { id: 'bier_weizen', label: 'Weizen' },
-      { id: 'bier_alkoholfrei', label: 'Alkoholfreies Bier' },
+      { id: 'bier_alkoholfrei', label: 'Alkoholfreies Bier', hasOwnBudget: true },
     ],
   },
   {
@@ -45,4 +45,15 @@ export const getDrinkParentCategoryId = (subcategoryId) => {
     }
   }
   return null;
+};
+
+// Subcategories flagged hasOwnBudget have a dedicated rate/weight entry on the
+// backend (functions/drinkRates.js) and must be kept as-is instead of being
+// collapsed into their parent category when building an event's category list.
+export const categoryHasOwnBudget = (categoryId) => {
+  for (const cat of DRINK_CATEGORIES) {
+    const sub = cat.subcategories?.find((s) => s.id === categoryId);
+    if (sub) return Boolean(sub.hasOwnBudget);
+  }
+  return false;
 };

--- a/src/utils/guestPreferences.js
+++ b/src/utils/guestPreferences.js
@@ -1,6 +1,7 @@
 import { DRINK_CATEGORIES, getDrinkParentCategoryId } from './drinkCategories';
 
 const ALCOHOLIC_CATEGORY_IDS = ['bier', 'wein', 'sekt', 'spirituosen'];
+const NON_ALCOHOLIC_SUBCATEGORY_IDS = ['bier_alkoholfrei'];
 
 const ALLOWED_PREFERENCE_FACTORS = [0, 0.25, 0.5, 0.75, 1];
 
@@ -25,6 +26,7 @@ const isDrinkCategoryPreferred = (drinkKategorie, preferredCategoryIds) => {
 
 const isDrinkAlcoholic = (drinkId, drinkKategorie) => {
   if (drinkKategorie) {
+    if (NON_ALCOHOLIC_SUBCATEGORY_IDS.includes(drinkKategorie)) return false;
     if (ALCOHOLIC_CATEGORY_IDS.includes(drinkKategorie)) return true;
     const parentId = getDrinkParentCategoryId(drinkKategorie);
     if (parentId && ALCOHOLIC_CATEGORY_IDS.includes(parentId)) return true;


### PR DESCRIPTION
EventForm collapsed every beer subcategory (Kölsch, Pils, alkoholfrei, ...)
into the generic "bier" category before sending it to calculateEventDrinks,
so alcohol-free beer lost its own (much smaller) weight and simply split the
regular beer budget 50/50 with alcoholic beer. Keep bier_alkoholfrei
uncollapsed so the backend's existing dedicated weighting applies, and stop
guestPreferences from treating alcohol-free beer as alcoholic when applying
a guest's "no alcohol" preference.