### PR TITLE
Hide redundant category rows in event shopping list

### DIFF
--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -253,6 +253,14 @@ function calculate(event, ratesDb, customDrinksMap) {
     }
   }
 
+  // Kategorie-Zeilen markieren, deren Bedarf bereits durch benutzerdefinierte
+  // Getraenke abgedeckt ist -- diese Zeilen sind fuer die Einkaufsliste redundant.
+  for (const item of ergebnis) {
+    if (!item.isCustomDrink) {
+      item.hasCustomDrinkCoverage = (drinkCountByCategory[item.kategorie] || 0) > 0;
+    }
+  }
+
   // --- Custom drinks ---
   for (const drinkId of customDrinkIds) {
     const entry = allCustomDrinks[drinkId];

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -208,14 +208,16 @@ function EventsPage({ onBack, currentUser, pendingEventReminderId, onPendingEven
                 </tr>
               </thead>
               <tbody>
-                {(berechnung?.ergebnis || []).map((row) => (
-                  <tr key={row.kategorie}>
-                    <td>{row.isCustomDrink && row.drinkLabel ? row.drinkLabel : (CATEGORY_LABELS[row.kategorie] || row.kategorie)}</td>
-                    <td>{row.literMitPuffer} L</td>
-                    <td>{row.gebinde || '-'}</td>
-                    <td>{row.anzahlGebinde ?? '-'}</td>
-                  </tr>
-                ))}
+                {(berechnung?.ergebnis || [])
+                  .filter((row) => row.isCustomDrink || !row.hasCustomDrinkCoverage)
+                  .map((row) => (
+                    <tr key={row.kategorie}>
+                      <td>{row.isCustomDrink && row.drinkLabel ? row.drinkLabel : (CATEGORY_LABELS[row.kategorie] || row.kategorie)}</td>
+                      <td>{row.literMitPuffer} L</td>
+                      <td>{row.gebinde || '-'}</td>
+                      <td>{row.anzahlGebinde ?? '-'}</td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
When a category's beverage budget is fully distributed across custom
drinks, the shopping list on the event card showed both the generic
category total and the identical custom-drink totals. Mark covered
category rows in the calculation and filter them out of the display,
keeping category rows only for categories without custom drinks.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CazBEj3kMdNT1cQiRGXa5W