### PR TITLE
Fix swipe-delete on event drink selection page and align icon with recipe form

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -1,6 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './EventsPage.css';
 import UnitChip from './UnitChip';
+import { getEffectiveIcon, DEFAULT_BUTTON_ICONS } from '../utils/customLists';
+import { isBase64Image } from '../utils/imageUtils';
 
 const MIN_DISTRIBUTION_FACTOR = 0.1;
 const MAX_DISTRIBUTION_FACTOR = 2.0;
@@ -123,6 +125,7 @@ function DrinkRow({
   onSwipeDeleteHidden,
   minFactor,
   maxFactor,
+  swipeDeleteIcon,
 }) {
   const touchStartXRef = useRef(null);
   const touchStartYRef = useRef(null);
@@ -146,12 +149,7 @@ function DrinkRow({
   const handleTouchStart = (e) => {
     const touch = e.touches?.[0];
     if (!touch) return;
-    if (isDeleteVisible) {
-      const target = e.target;
-      const isDeleteButton = target.closest('.events-drink-row-swipe-action');
-      if (isDeleteButton) return;
-      onSwipeDeleteHidden();
-    }
+    if (isDeleteVisible) onSwipeDeleteHidden();
     touchStartXRef.current = touch.clientX;
     touchStartYRef.current = touch.clientY;
     swipeDirectionLockedRef.current = null;
@@ -200,9 +198,6 @@ function DrinkRow({
   return (
     <div
       className={`events-drink-row${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
     >
       <div className="events-drink-row-swipe-background" aria-hidden={!isDeleteVisible}>
         {isDeleteVisible && (
@@ -212,11 +207,22 @@ function DrinkRow({
             onClick={handleSwipeDeleteClick}
             aria-label={`${drink.name} entfernen`}
           >
-            <span>🗑</span>
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
           </button>
         )}
       </div>
-      <div className="events-drink-row-content" style={swipeContentStyle}>
+      <div
+        className="events-drink-row-content"
+        style={swipeContentStyle}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={resetSwipe}
+      >
         <div className="events-drink-row-name">{drink.name}</div>
         <div className="events-drink-row-details">
           <div className="events-drink-row-einheiten">
@@ -268,7 +274,10 @@ function EventDrinkSelectionPage({
   drinkSelectedEinheiten: initialDrinkSelectedEinheiten,
   onSave,
   onBack,
+  buttonIcons,
+  isDarkMode,
 }) {
+  const swipeDeleteIcon = getEffectiveIcon(buttonIcons || DEFAULT_BUTTON_ICONS, 'swipeDelete', isDarkMode) || '🗑';
   const [customDrinkIds, setCustomDrinkIds] = useState(initialCustomDrinkIds ?? []);
   const [drinkDistributionFactors, setDrinkDistributionFactors] = useState(
     initialDrinkDistributionFactors ?? {},
@@ -414,6 +423,7 @@ function EventDrinkSelectionPage({
                         onSwipeDeleteHidden={() => setSwipeDeleteVisibleId((prev) => prev === drink.id ? null : prev)}
                         minFactor={MIN_DISTRIBUTION_FACTOR}
                         maxFactor={MAX_DISTRIBUTION_FACTOR}
+                        swipeDeleteIcon={swipeDeleteIcon}
                       />
                     );
                   })}

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -129,17 +129,17 @@ describe('EventDrinkSelectionPage', () => {
       />,
     );
 
-    const wasserRow = screen.getByText('Wasser (eigen)').closest('.events-drink-row');
-    fireEvent.touchStart(wasserRow, { touches: [{ clientX: 200, clientY: 100 }] });
-    fireEvent.touchMove(wasserRow, { touches: [{ clientX: 80, clientY: 100 }] });
-    fireEvent.touchEnd(wasserRow);
+    const wasserRowContent = screen.getByText('Wasser (eigen)').closest('.events-drink-row-content');
+    fireEvent.touchStart(wasserRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
+    fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
+    fireEvent.touchEnd(wasserRowContent);
     fireEvent.click(screen.getByLabelText('Wasser (eigen) entfernen'));
 
     expect(screen.queryByText('Wasser (eigen)', { selector: '.events-drink-row-name' })).not.toBeInTheDocument();
     expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
   });
 
-  test('deletes drink when delete button receives touchstart before click (regression: Faktor activates instead)', () => {
+  test('deletes drink when delete button receives touchstart before click (regression: touchend hid the button before click landed)', () => {
     render(
       <EventDrinkSelectionPage
         customDrinks={customDrinks}
@@ -151,20 +151,45 @@ describe('EventDrinkSelectionPage', () => {
       />,
     );
 
-    const wasserRow = screen.getByText('Wasser (eigen)').closest('.events-drink-row');
+    const wasserRowContent = screen.getByText('Wasser (eigen)').closest('.events-drink-row-content');
     // First: swipe left to reveal delete button
-    fireEvent.touchStart(wasserRow, { touches: [{ clientX: 200, clientY: 100 }] });
-    fireEvent.touchMove(wasserRow, { touches: [{ clientX: 80, clientY: 100 }] });
-    fireEvent.touchEnd(wasserRow);
+    fireEvent.touchStart(wasserRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
+    fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
+    fireEvent.touchEnd(wasserRowContent);
 
     const deleteButton = screen.getByLabelText('Wasser (eigen) entfernen');
 
-    // Simulate touch tap on the delete button: touchstart fires on the row first, then click on button
+    // Simulate a real tap on the delete button: touchstart, touchend, then click all target the
+    // button itself. Since touch handlers only live on the content element (not the row or the
+    // delete button), this sequence must not hide the button before the click can register.
     fireEvent.touchStart(deleteButton, { touches: [{ clientX: 10, clientY: 10 }] });
+    fireEvent.touchEnd(deleteButton);
     fireEvent.click(deleteButton);
 
     expect(screen.queryByText('Wasser (eigen)', { selector: '.events-drink-row-name' })).not.toBeInTheDocument();
     expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
+  });
+
+  test('swipe-delete button uses the configured swipeDelete icon (same as RecipeForm ingredient delete)', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={['custom-wasser']}
+        guestPreferenceMultipliers={{}}
+        selectedGuestIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+        buttonIcons={{ swipeDelete: '❌' }}
+        isDarkMode={false}
+      />,
+    );
+
+    const wasserRowContent = screen.getByText('Wasser (eigen)').closest('.events-drink-row-content');
+    fireEvent.touchStart(wasserRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
+    fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
+    fireEvent.touchEnd(wasserRowContent);
+
+    expect(screen.getByLabelText('Wasser (eigen) entfernen')).toHaveTextContent('❌');
   });
 
   test('adds a drink via the dropdown', () => {

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -237,6 +237,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         customDrinkIds={customDrinkIds}
         drinkDistributionFactors={drinkDistributionFactors}
         drinkSelectedEinheiten={drinkSelectedEinheiten}
+        buttonIcons={buttonIcons}
+        isDarkMode={isDarkMode}
         onSave={(newDrinkIds, newDrinkDistributionFactors, newDrinkSelectedEinheiten) => {
           setCustomDrinkIds(newDrinkIds);
           setDrinkDistributionFactors(newDrinkDistributionFactors || {});


### PR DESCRIPTION
The delete button appeared after a left swipe on the event's "Getränke
verwalten" page, but tapping it did nothing: touch handlers were attached
to the whole row (including the swipe-revealed delete button), so the
touchend from tapping the button itself hid the button again before the
click event could land. Move the touch handlers to the row's content
element only, matching the pattern already used in DrinkManagementPage
and RecipeForm's ingredient rows.

Also switch the hardcoded 🗑 emoji to the shared swipeDelete button icon
(getEffectiveIcon), so it matches the delete icon used for ingredient
swipe-delete on the recipe edit page.