### PR TITLE
Redesign Getränke screen with minimal/clean styling, fix Mengen-input overflow

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -14,15 +14,18 @@ const normalizeDistributionFactor = (value) => {
   return parsed;
 };
 
-const getEinheitLabel = (einheit) => {
+const getEinheitSizeLabel = (einheit) => {
   if (!einheit) return '';
   const liters = Number(einheit.einheitsgroesse);
-  let sizeLabel;
   if (liters < 1) {
-    sizeLabel = `${Math.round(liters * 1000)} ml`;
-  } else {
-    sizeLabel = `${liters.toFixed(1).replace('.', ',')} l`;
+    return `${Math.round(liters * 1000)} ml`;
   }
+  return `${liters.toFixed(1).replace('.', ',')} l`;
+};
+
+const getEinheitLabel = (einheit) => {
+  if (!einheit) return '';
+  const sizeLabel = getEinheitSizeLabel(einheit);
   return einheit.gebindeinheit ? `${sizeLabel} (${einheit.gebindeinheit})` : sizeLabel;
 };
 
@@ -234,7 +237,8 @@ function DrinkRow({
                   .map(({ einheit, idx }) => (
                     <UnitChip
                       key={idx}
-                      label={getEinheitLabel(einheit)}
+                      label={getEinheitSizeLabel(einheit)}
+                      ariaLabel={getEinheitLabel(einheit)}
                       selected={true}
                       onToggle={() => onToggleEinheit(idx)}
                     />
@@ -246,8 +250,10 @@ function DrinkRow({
                   drinkName={drink.name}
                 />
               </div>
+            ) : einheiten.length === 1 ? (
+              <span className="events-drink-row-single-unit">{getEinheitLabel(einheiten[0])}</span>
             ) : (
-              <span>{einheiten.length === 1 ? getEinheitLabel(einheiten[0]) : '–'}</span>
+              <span className="events-drink-row-empty-label">Keine Einheit ausgewählt</span>
             )}
           </div>
           <div className="events-drink-row-factor">
@@ -277,7 +283,8 @@ function EventDrinkSelectionPage({
   buttonIcons,
   isDarkMode,
 }) {
-  const swipeDeleteIcon = getEffectiveIcon(buttonIcons || DEFAULT_BUTTON_ICONS, 'swipeDelete', isDarkMode) || '🗑';
+  const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
+  const swipeDeleteIcon = getEffectiveIcon(effectiveButtonIcons, 'swipeDelete', isDarkMode) || '🗑';
   const [customDrinkIds, setCustomDrinkIds] = useState(initialCustomDrinkIds ?? []);
   const [drinkDistributionFactors, setDrinkDistributionFactors] = useState(
     initialDrinkDistributionFactors ?? {},
@@ -287,6 +294,8 @@ function EventDrinkSelectionPage({
   );
   const [drinkToAdd, setDrinkToAdd] = useState('');
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
+  const [fabPressed, setFabPressed] = useState(false);
+  const [cancelPressed, setCancelPressed] = useState(false);
 
   const toggleCustomDrink = (id) => {
     setCustomDrinkIds((prev) => {
@@ -355,7 +364,7 @@ function EventDrinkSelectionPage({
   };
 
   return (
-    <div className="events-page-container">
+    <div className="events-page-container events-drink-selection-page">
       <div className="events-page-header">
         <h2>Getränke</h2>
         <button
@@ -387,7 +396,7 @@ function EventDrinkSelectionPage({
                 </select>
                 <button
                   type="button"
-                  className="events-secondary-btn"
+                  className="events-drink-add-btn"
                   onClick={() => {
                     if (drinkToAdd) {
                       toggleCustomDrink(drinkToAdd);
@@ -434,20 +443,61 @@ function EventDrinkSelectionPage({
             <p className="events-info-text">Noch keine eigenen Getränke angelegt.</p>
           )}
 
-          <p className="events-info-text">
+          <span className="events-selected-count-badge">
             {customDrinkIds.length} {customDrinkIds.length === 1 ? 'Getränk' : 'Getränke'} ausgewählt.
-          </p>
+          </span>
         </div>
 
         <div className="events-form-actions">
-          <button type="button" className="events-secondary-btn" onClick={onBack}>
+          <button type="button" className="events-secondary-btn events-save-desktop-only" onClick={onBack}>
             Abbrechen
           </button>
-          <button type="button" className="events-primary-btn" onClick={handleSave}>
+          <button type="button" className="events-primary-btn events-save-desktop-only" onClick={handleSave}>
             Speichern
           </button>
         </div>
       </div>
+
+      {/* FAB Save Button - mobile only, matches the "Rezept bearbeiten" FAB pattern */}
+      <button
+        type="button"
+        className={`events-save-fab-button${fabPressed ? ' pressed' : ''}`}
+        onClick={handleSave}
+        onMouseDown={() => setFabPressed(true)}
+        onMouseUp={() => setFabPressed(false)}
+        onMouseLeave={() => setFabPressed(false)}
+        onTouchStart={() => setFabPressed(true)}
+        onTouchEnd={() => setFabPressed(false)}
+        aria-label="Getränkeauswahl speichern"
+        title="Speichern"
+      >
+        {isBase64Image(getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)) ? (
+          <img src={getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)} alt="Speichern" className="button-icon-image" draggable="false" />
+        ) : (
+          getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)
+        )}
+      </button>
+
+      {/* Cancel FAB button - positioned at bottom-left, mobile only */}
+      <button
+        type="button"
+        className={`events-cancel-fab-button${cancelPressed ? ' pressed' : ''}`}
+        onClick={onBack}
+        onTouchStart={() => setCancelPressed(true)}
+        onTouchEnd={() => setCancelPressed(false)}
+        onTouchCancel={() => setCancelPressed(false)}
+        onMouseDown={() => setCancelPressed(true)}
+        onMouseUp={() => setCancelPressed(false)}
+        onMouseLeave={() => setCancelPressed(false)}
+        title="Abbrechen"
+        aria-label="Getränkeauswahl abbrechen"
+      >
+        {isBase64Image(getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)) ? (
+          <img src={getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)} alt="Abbrechen" className="button-icon-image" draggable="false" />
+        ) : (
+          getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)
+        )}
+      </button>
     </div>
   );
 }

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -438,6 +438,43 @@
   font-size: 14px;
 }
 
+/* Neutral outlined "Hinzufügen" button - lower visual weight than the
+   filled primary Speichern button/FAB. */
+.events-drink-add-btn {
+  background: transparent;
+  color: #555;
+  border: 1px solid #ccc;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.events-drink-add-btn:hover:not(:disabled) {
+  background: #f5f5f5;
+  border-color: #bbb;
+}
+
+.events-drink-add-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.events-selected-count-badge {
+  display: inline-flex;
+  align-self: flex-start;
+  align-items: center;
+  margin-top: 8px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: #eef3f1;
+  color: #4a6b60;
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .events-result-card {
   background: white;
   border-radius: 10px;
@@ -855,15 +892,16 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 16px;
 }
 
 .events-drink-row {
   position: relative;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: 10px;
   background: white;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e8e8e8;
+  box-shadow: none;
 }
 
 .events-drink-row-swipe-background {
@@ -902,41 +940,55 @@
 .events-drink-row-content {
   position: relative;
   z-index: 1;
-  padding: 10px 12px;
+  padding: 16px;
 }
 
 .events-drink-row-name {
   font-weight: 600;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
   color: #2F5D50;
 }
 
+/* Grid (not flex) so the Mengen-input column has a fixed width and stays in
+   the same horizontal position regardless of how many unit pills wrap onto
+   additional lines in the left column. */
 .events-drink-row-details {
-  display: flex;
-  gap: 12px;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 16px;
 }
 
 .events-drink-row-einheiten {
-  flex: 1;
+  min-width: 0;
+}
+
+.events-drink-row-empty-label,
+.events-drink-row-single-unit {
+  color: #888;
+  font-size: 0.9rem;
+  font-weight: 400;
 }
 
 .events-unit-chip-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .events-unit-chip {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  padding: 4px 12px;
-  font-size: 0.85rem;
+  padding: 3px 10px;
+  font-size: 0.78rem;
+  font-weight: 400;
   cursor: pointer;
-  border: 1.5px solid #aaa;
+  border: 1px solid #ccc;
   background: transparent;
-  color: #333;
+  color: #666;
   line-height: 1.4;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
@@ -948,15 +1000,88 @@
 }
 
 .events-unit-chip-check {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
+}
+
+/* Unit typeahead ("Einheit hinzufügen …") - constrained so it wraps inside
+   the chip row instead of pushing the card wider than its container. */
+.events-einheiten-typeahead {
+  position: relative;
+  flex: 1 1 140px;
+  min-width: 110px;
+  max-width: 100%;
+}
+
+.events-einheiten-typeahead-input {
+  width: 100%;
+  max-width: 200px;
+  box-sizing: border-box;
+  padding: 3px 10px;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-family: inherit;
+  color: #666;
+}
+
+.events-einheiten-typeahead-input::placeholder {
+  color: #999;
+}
+
+.events-einheiten-typeahead-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  min-width: 160px;
+  max-width: 240px;
+  max-height: 220px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.events-einheiten-typeahead-dropdown button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  font-size: 0.85rem;
+  color: #333;
+  cursor: pointer;
+}
+
+.events-einheiten-typeahead-dropdown button:hover {
+  background: #f0f7f4;
+  color: #2F5D50;
 }
 
 .events-drink-row-factor {
-  flex-shrink: 0;
+  justify-self: end;
 }
 
 .events-drink-row-factor input[type="number"] {
-  width: 80px;
+  width: 72px;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 15px;
+  font-family: inherit;
+  color: #333;
+  text-align: right;
+}
+
+.events-drink-row-factor input[type="number"]:focus {
+  outline: none;
+  border-color: #2F5D50;
 }
 
 /* ── Swipe-Delete für Getränke-Zeilen ───────────────────────────────────── */

--- a/src/components/UnitChip.js
+++ b/src/components/UnitChip.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-function UnitChip({ label, selected, onToggle }) {
+function UnitChip({ label, ariaLabel, selected, onToggle }) {
   return (
     <button
       type="button"
       className={`events-unit-chip${selected ? ' events-unit-chip--selected' : ''}`}
       onClick={onToggle}
       aria-pressed={selected}
-      aria-label={label}
+      aria-label={ariaLabel || label}
     >
       {selected && <span className="events-unit-chip-check" aria-hidden="true">✓ </span>}
       {label}

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3844,7 +3844,8 @@
 
 [data-theme="dark"] .events-drink-row {
   background: #1e1e1e;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  border-color: #3d3d3d;
+  box-shadow: none;
 }
 
 [data-theme="dark"] .events-drink-row-content {
@@ -3853,6 +3854,11 @@
 
 [data-theme="dark"] .events-drink-row-name {
   color: #7fb8a3;
+}
+
+[data-theme="dark"] .events-drink-row-empty-label,
+[data-theme="dark"] .events-drink-row-single-unit {
+  color: #999;
 }
 
 [data-theme="dark"] .events-unit-chip {
@@ -3867,8 +3873,53 @@
   color: #fff;
 }
 
+[data-theme="dark"] .events-einheiten-typeahead-input {
+  background: #2a2a2a;
+  color: #ccc;
+  border-color: #555;
+}
+
+[data-theme="dark"] .events-einheiten-typeahead-input::placeholder {
+  color: #777;
+}
+
+[data-theme="dark"] .events-einheiten-typeahead-dropdown {
+  background: #1e1e1e;
+  border-color: #3d3d3d;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] .events-einheiten-typeahead-dropdown button {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .events-einheiten-typeahead-dropdown button:hover {
+  background: #2a2a2a;
+  color: #7fb8a3;
+}
+
 [data-theme="dark"] .events-drink-row-factor input[type="number"] {
   background: #2a2a2a;
   color: #e8e8e8;
   border-color: #555;
+}
+
+[data-theme="dark"] .events-drink-row-factor input[type="number"]:focus {
+  border-color: #4f9a80;
+}
+
+[data-theme="dark"] .events-drink-add-btn {
+  background: transparent;
+  color: #ccc;
+  border-color: #555;
+}
+
+[data-theme="dark"] .events-drink-add-btn:hover:not(:disabled) {
+  background: #2a2a2a;
+  border-color: #666;
+}
+
+[data-theme="dark"] .events-selected-count-badge {
+  background: #1f2b27;
+  color: #9fc4b7;
 }


### PR DESCRIPTION
- Fix Mengen-input overflowing the screen edge and shifting position based
  on unit pill count: switch drink row layout from flex to a grid with a
  fixed-width right column so the factor input stays consistently aligned
  across all drink cards, and constrain the unit typeahead so it wraps
  instead of pushing the card wider than its container.
- Reuse the exact FAB save/cancel button pattern, icons and dark-mode
  values from the "Rezept bearbeiten" page family (events-save-fab-button /
  events-cancel-fab-button) for mobile, keeping regular buttons on
  desktop/tablet.
- Drop the "(Kasten)"-style Gebinde suffix from unit pills, showing only
  the quantity while keeping the full label available to screen readers.
- Give the "Hinzufügen" button a neutral outlined style with less visual
  weight than the primary Speichern action.
- Turn the "X Getränke ausgewählt" text into a compact badge, replace the
  "–" empty state with "Keine Einheit ausgewählt", unify card spacing to
  an 8/16/24 scale, and reduce card borders/shadows and unit-pill sizing.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DkQTR7oFFa6GsTFL84NXq4