### PR TITLE
Redesign Gäste screen for minimal/clean consistency with Getränke screen

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -214,6 +214,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         currentUser={currentUser}
         selectedGuestIds={selectedGuestIds}
         driverGuestIds={driverGuestIds}
+        buttonIcons={buttonIcons}
+        isDarkMode={isDarkMode}
         onSave={(newSelectedIds, newDriverIds) => {
           setSelectedGuestIds(newSelectedIds);
           setDriverGuestIds(newDriverIds);

--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import './EventsPage.css';
 import { subscribeToGuestProfiles } from '../utils/eventsFirestore';
 import { getGuestDisplayName } from '../utils/guestPreferences';
+import { DEFAULT_BUTTON_ICONS, getEffectiveIcon } from '../utils/customLists';
+import { isBase64Image } from '../utils/imageUtils';
 
 function EventGuestSelectionPage({
   currentUser,
@@ -9,14 +11,19 @@ function EventGuestSelectionPage({
   driverGuestIds: initialDriverGuestIds,
   onSave,
   onBack,
+  buttonIcons,
+  isDarkMode,
 }) {
   const [guests, setGuests] = useState([]);
   const [selectedGuestIds, setSelectedGuestIds] = useState(initialSelectedGuestIds ?? []);
   const [driverGuestIds, setDriverGuestIds] = useState(initialDriverGuestIds ?? []);
   const [searchQuery, setSearchQuery] = useState('');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [fabPressed, setFabPressed] = useState(false);
+  const [cancelPressed, setCancelPressed] = useState(false);
   const searchRef = useRef(null);
   const dropdownRef = useRef(null);
+  const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
 
   useEffect(() => {
     if (!currentUser?.id) return undefined;
@@ -171,6 +178,7 @@ function EventGuestSelectionPage({
                         <td>
                           <input
                             type="checkbox"
+                            className="events-driver-checkbox"
                             checked={driverGuestIds.includes(guest.id)}
                             onChange={() => toggleDriverGuest(guest.id)}
                             aria-label={`${fullName} als Fahrer markieren`}
@@ -184,22 +192,73 @@ function EventGuestSelectionPage({
             </div>
           )}
 
-          <p className="events-info-text">
-            {selectedGuestIds.length} {selectedGuestIds.length === 1 ? 'Gast' : 'Gäste'} ausgewählt.
-          </p>
-          <p className="events-info-text">
-            {driverGuestIds.length} Fahrer markiert.
-          </p>
+          <div className="events-guest-summary-badges">
+            <span className="events-summary-badge">
+              {selectedGuestIds.length} {selectedGuestIds.length === 1 ? 'Gast' : 'Gäste'} ausgewählt.
+            </span>
+            <span className="events-summary-badge">
+              {driverGuestIds.length} Fahrer markiert.
+            </span>
+          </div>
         </div>
         <div className="events-form-actions">
-          <button type="button" className="events-secondary-btn" onClick={onBack}>
+          <button
+            type="button"
+            className="events-secondary-btn events-save-desktop-only"
+            onClick={onBack}
+          >
             Abbrechen
           </button>
-          <button type="button" className="events-primary-btn" onClick={handleSave}>
+          <button
+            type="button"
+            className="events-primary-btn events-form-actions-save"
+            onClick={handleSave}
+          >
             Speichern
           </button>
         </div>
       </div>
+
+      {/* FAB Save button - mobile only */}
+      <button
+        type="button"
+        className={`events-save-fab-button${fabPressed ? ' pressed' : ''}`}
+        onClick={handleSave}
+        onMouseDown={() => setFabPressed(true)}
+        onMouseUp={() => setFabPressed(false)}
+        onMouseLeave={() => setFabPressed(false)}
+        onTouchStart={() => setFabPressed(true)}
+        onTouchEnd={() => setFabPressed(false)}
+        aria-label="Gästeliste speichern"
+        title="Speichern"
+      >
+        {isBase64Image(getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)) ? (
+          <img src={getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)} alt="Speichern" className="button-icon-image" draggable="false" />
+        ) : (
+          getEffectiveIcon(effectiveButtonIcons, 'saveRecipe', isDarkMode)
+        )}
+      </button>
+
+      {/* Cancel FAB button - positioned at bottom-left, mobile only */}
+      <button
+        type="button"
+        className={`events-cancel-fab-button ${cancelPressed ? 'pressed' : ''}`}
+        onClick={onBack}
+        onTouchStart={() => setCancelPressed(true)}
+        onTouchEnd={() => setCancelPressed(false)}
+        onTouchCancel={() => setCancelPressed(false)}
+        onMouseDown={() => setCancelPressed(true)}
+        onMouseUp={() => setCancelPressed(false)}
+        onMouseLeave={() => setCancelPressed(false)}
+        title="Abbrechen"
+        aria-label="Gästeauswahl abbrechen"
+      >
+        {isBase64Image(getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)) ? (
+          <img src={getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)} alt="Abbrechen" className="button-icon-image" draggable="false" />
+        ) : (
+          getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)
+        )}
+      </button>
     </div>
   );
 }

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -14,8 +14,9 @@
 
 .events-page-header h2 {
   margin: 0;
-  color: #2F5D50;
+  color: #333;
   font-size: 28px;
+  font-weight: 600;
   text-align: left;
 }
 
@@ -62,16 +63,17 @@
   justify-content: space-between;
   align-items: center;
   background: white;
+  border: 1px solid #ececec;
   border-radius: 10px;
   padding: 16px 20px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s;
 }
 
 .events-card:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
 }
 
 .events-card-main h3 {
@@ -253,9 +255,10 @@
 
 .events-form {
   background: white;
+  border: 1px solid #ececec;
   border-radius: 10px;
   padding: 24px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -304,17 +307,25 @@
 }
 
 .events-form-field > span:first-child {
-  font-weight: 600;
+  font-weight: 500;
   color: #333;
 }
 
 .events-form-field input,
 .events-form-field select {
-  padding: 10px 12px;
-  border: 1px solid #ddd;
+  padding: 8px 16px;
+  border: 1px solid #e2e2e2;
   border-radius: 8px;
   font-size: 16px;
   font-family: inherit;
+}
+
+.events-form-field input:focus,
+.events-form-field select:focus,
+.events-guest-search-input:focus {
+  outline: none;
+  border-color: #2F5D50;
+  box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.12);
 }
 
 .events-category-grid {
@@ -334,7 +345,8 @@
 }
 
 .events-category-checkbox input[type="checkbox"],
-.events-form-field input[type="range"] {
+.events-form-field input[type="range"],
+.events-driver-checkbox {
   accent-color: #2F5D50;
 }
 
@@ -440,9 +452,10 @@
 
 .events-result-card {
   background: white;
+  border: 1px solid #ececec;
   border-radius: 10px;
   padding: 24px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .events-result-card h3 {
@@ -491,15 +504,17 @@
 
 .events-table th,
 .events-table td {
-  padding: 10px 14px;
+  padding: 8px 16px;
   text-align: left;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #f2f2f2;
 }
 
 .events-table th {
-  background: #f8f9fa;
-  color: #555;
-  font-weight: 600;
+  background: transparent;
+  color: #8a8a8a;
+  font-weight: 500;
+  font-size: 13px;
+  border-bottom: 1px solid #eee;
 }
 
 .events-table tbody tr:last-child td {
@@ -512,12 +527,32 @@
 
 .events-guest-search-input {
   width: 100%;
-  padding: 10px 12px;
-  border: 1px solid #ddd;
+  padding: 8px 16px;
+  border: 1px solid #e2e2e2;
   border-radius: 8px;
   font-size: 16px;
   font-family: inherit;
   box-sizing: border-box;
+}
+
+.events-guest-summary-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.events-summary-badge {
+  display: inline-flex;
+  align-items: center;
+  background: #f2f4f3;
+  color: #6b6b6b;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .events-guest-typeahead-list {
@@ -526,9 +561,9 @@
   left: 0;
   right: 0;
   background: white;
-  border: 1px solid #ddd;
+  border: 1px solid #e2e2e2;
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
   list-style: none;
   margin: 0;
   padding: 4px 0;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3734,7 +3734,10 @@
 }
 
 /* ---- Events (Getränke-Kalkulation) ---- */
-[data-theme="dark"] .events-page-header h2,
+[data-theme="dark"] .events-page-header h2 {
+  color: #e8e8e8;
+}
+
 [data-theme="dark"] .events-card-main h3,
 [data-theme="dark"] .events-result-card h3 {
   color: #7fb8a3;
@@ -3765,11 +3768,36 @@
 [data-theme="dark"] .events-form,
 [data-theme="dark"] .events-result-card {
   background: #1e1e1e;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+  border-color: #333;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 [data-theme="dark"] .events-card:hover {
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="dark"] .events-guest-typeahead-list {
+  background: #262626;
+  border-color: #555;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .events-guest-typeahead-option {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .events-guest-typeahead-option:hover {
+  background: #333;
+  color: #7fb8a3;
+}
+
+[data-theme="dark"] .events-guest-typeahead-empty {
+  color: #999;
+}
+
+[data-theme="dark"] .events-summary-badge {
+  background: #2a2a2a;
+  color: #bbb;
 }
 
 [data-theme="dark"] .events-form-field > span:first-child {


### PR DESCRIPTION
- Fix Fahrer checkbox showing iOS system-blue instead of brand green by
  giving it the same accent-color treatment as the Gast checkbox
- Add mobile FAB save/cancel buttons (matching the Getränke/Rezept
  bearbeiten pattern and dark mode values), keep regular buttons on
  desktop/tablet
- Tone down table header weight/background, lighten row dividers and
  card borders/shadows, unify input spacing to the 8/16/24px scale
- Replace the two separate summary paragraphs with compact side-by-side
  badges
- Degreen the page title to match the RecipeForm heading treatment,
  keeping green as a checkbox/primary-button accent only
- Add missing dark-mode styling for the guest search dropdown