### PR TITLE
fix: predefined_mineralwasser wird von calculateEventDrinks aufgeloest

### DIFF
--- a/functions/calculateEventDrinks.categoryDistribution.test.js
+++ b/functions/calculateEventDrinks.categoryDistribution.test.js
@@ -626,3 +626,49 @@ test('calculate leitet Kategorien mit eigenem Budget aus custom drinks ab, wenn 
   assert.equal(bitburger.literOhnePuffer, bierAlkoholfrei.literOhnePuffer);
   assert.equal(bitburger.literMitPuffer, bierAlkoholfrei.literMitPuffer);
 });
+
+test('loadCustomDrinks loest "predefined_mineralwasser" auf, ohne Firestore abzufragen', async () => {
+  const db = {
+    collection() {
+      throw new Error('Firestore sollte fuer vordefinierte Getraenke nicht angefragt werden.');
+    },
+  };
+
+  const result = await _internal.loadCustomDrinks(db, 'user-1', ['predefined_mineralwasser']);
+
+  assert.ok(result.predefined_mineralwasser, 'predefined_mineralwasser wurde aufgeloest');
+  assert.equal(result.predefined_mineralwasser.kategorie, 'wasser');
+  assert.equal(result.predefined_mineralwasser.predefined, true);
+});
+
+test('calculate erzeugt fuer "predefined_mineralwasser" weder Warnung noch eigene Zeile', () => {
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 6,
+        guests: {adults: 10, children: 0},
+        season: 'sommer',
+        eventType: 'familienfeier',
+        categories: ['wasser'],
+        customDrinkIds: ['predefined_mineralwasser'],
+        pufferProzent: 0,
+      },
+      DEFAULT_RATES,
+      {
+        predefined_mineralwasser: {
+          name: 'Mineralwasser',
+          kategorie: 'wasser',
+          einheiten: [],
+          predefined: true,
+        },
+      },
+  );
+
+  const wasser = result.ergebnis.find((item) => item.kategorie === 'wasser');
+  const predefinedRow = result.ergebnis.find((item) => item.kategorie === 'predefined_mineralwasser');
+
+  assert.equal(result.warnungen.length, 0, 'keine Warnung fuer bekanntes vordefiniertes Getraenk');
+  assert.ok(wasser, 'wasser-Kategorie wird normal berechnet');
+  assert.ok(wasser.literOhnePuffer > 0);
+  assert.equal(predefinedRow, undefined, 'keine eigene Zeile fuer das vordefinierte Getraenk ohne Gebinde');
+});

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -20,7 +20,22 @@ async function loadRatesDb(db, uid) {
 }
 
 /**
+ * Vordefinierte Getraenke, die allen Nutzern ohne Firestore-Dokument zur
+ * Verfuegung stehen. Spiegelt PREDEFINED_DRINKS aus drinkCategories.js (src).
+ */
+const PREDEFINED_DRINKS = {
+  predefined_mineralwasser: {
+    name: 'Mineralwasser',
+    kategorie: 'wasser',
+    einheiten: [],
+    predefined: true,
+  },
+};
+
+/**
  * Laedt die benutzerdefinierten Getraenke eines Nutzers aus Firestore.
+ * Vordefinierte Getraenke-IDs (siehe PREDEFINED_DRINKS) werden direkt
+ * aufgeloest, ohne Firestore abzufragen.
  * @param {object} db Firestore-Instanz.
  * @param {string} uid Firebase-Nutzer-ID.
  * @param {string[]} drinkIds IDs der gewuenschten Getraenke.
@@ -31,6 +46,10 @@ async function loadCustomDrinks(db, uid, drinkIds) {
   const result = {};
   await Promise.all(
       drinkIds.map(async (id) => {
+        if (PREDEFINED_DRINKS[id]) {
+          result[id] = PREDEFINED_DRINKS[id];
+          return;
+        }
         const snap = await db.collection('users').doc(uid).collection('customDrinks').doc(id).get();
         if (snap.exists) {
           result[id] = snap.data();
@@ -443,6 +462,13 @@ function calculate(event, ratesDb, customDrinksMap) {
       warnungen.push(
           `Benutzerdefiniertes Getraenk '${drinkId}' nicht gefunden -- wird uebersprungen.`,
       );
+      continue;
+    }
+
+    // Vordefinierte Getraenke ohne eigene Gebinde (z.B. Mineralwasser) liefern
+    // keine Gebinde-/Ratendaten -- ihr Bedarf steckt bereits in der normalen
+    // Kategorie-Zeile (siehe categoryLitersMap oben), daher keine eigene Zeile.
+    if (entry.predefined && (!Array.isArray(entry.einheiten) || entry.einheiten.length === 0)) {
       continue;
     }
 


### PR DESCRIPTION
PREDEFINED_DRINKS ('Mineralwasser') werden nur im Frontend definiert
(src/utils/drinkCategories.js), waehrend die Cloud Function
calculateEventDrinks benutzerdefinierte Getraenke ausschliesslich aus
Firestore laedt. Dadurch wurde predefined_mineralwasser -- das bei
neuen Events automatisch vorausgewaehlt wird -- serverseitig nicht
gefunden und mit der Warnung "Benutzerdefiniertes Getraenk
'predefined_mineralwasser' nicht gefunden -- wird uebersprungen"
uebersprungen.

loadCustomDrinks kennt nun eine gespiegelte PREDEFINED_DRINKS-Map und
loest solche IDs direkt auf, ohne Firestore abzufragen. Da Mineralwasser
keine eigenen Gebinde-/Ratendaten hat, wird dafuer keine zusaetzliche
Zeile erzeugt -- der Bedarf steckt bereits in der normalen
"wasser"-Kategoriezeile.