### PR TITLE
Getränkematrix um Longdrinks erweitern + explizites Subkategorie-Modell

### DIFF
--- a/functions/calculateEventDrinks.categoryDistribution.test.js
+++ b/functions/calculateEventDrinks.categoryDistribution.test.js
@@ -2,7 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {_internal} = require('./calculateEventDrinks');
-const {DEFAULT_RATES} = require('./drinkRates');
+const {DEFAULT_RATES, DRINK_WEIGHTS} = require('./drinkRates');
 
 test('resolveTopLevelCategory gibt fuer Oberkategorie die ID selbst zurueck', () => {
   assert.equal(_internal.resolveTopLevelCategory('softdrinks'), 'softdrinks');
@@ -23,6 +23,112 @@ test('resolveTopLevelCategory loest Weinvarianten auf "wein" auf', () => {
   assert.equal(_internal.resolveTopLevelCategory('wein_weisswein'), 'wein');
   assert.equal(_internal.resolveTopLevelCategory('wein_rose'), 'wein');
   assert.equal(_internal.resolveTopLevelCategory('wein_rotwein'), 'wein');
+});
+
+test('resolveTopLevelCategory loest longdrinks auf "spirituosen" auf', () => {
+  assert.equal(_internal.resolveTopLevelCategory('longdrinks'), 'spirituosen');
+});
+
+// --- longdrinks/spirituosen Subkategorie-Redistribution (analog zu bier/bier_alkoholfrei) ---
+
+test('calculate vererbt longdrinks-Gewicht auf spirituosen, wenn longdrinks nicht angeboten wird', () => {
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 4,
+        guests: {adults: 10, children: 0},
+        season: 'uebergang',
+        eventType: 'familienfeier',
+        categories: ['spirituosen', 'wasser'],
+        customDrinkIds: [],
+        pufferProzent: 0,
+      },
+      DEFAULT_RATES,
+      {},
+  );
+
+  const spirituosen = result.ergebnis.find((item) => item.kategorie === 'spirituosen');
+  const wasser = result.ergebnis.find((item) => item.kategorie === 'wasser');
+  const totalBeverage = 10 * 0.5 * 4;
+  const sumWeights = DRINK_WEIGHTS.spirituosen.basis + DRINK_WEIGHTS.longdrinks.basis + DRINK_WEIGHTS.wasser.basis;
+
+  assert.ok(spirituosen);
+  assert.ok(wasser);
+  assert.equal(
+      spirituosen.literOhnePuffer,
+      Math.round((totalBeverage * (DRINK_WEIGHTS.spirituosen.basis + DRINK_WEIGHTS.longdrinks.basis) / sumWeights) * 100) / 100,
+      'spirituosen erhaelt das komplette longdrinks-Gewicht (Geschwister-Fallback)',
+  );
+  assert.equal(
+      wasser.literOhnePuffer,
+      Math.round((totalBeverage * DRINK_WEIGHTS.wasser.basis / sumWeights) * 100) / 100,
+  );
+});
+
+test('calculate behandelt longdrinks als eigene Kategorie mit eigenem Budget, wenn angeboten', () => {
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 4,
+        guests: {adults: 10, children: 0},
+        season: 'uebergang',
+        eventType: 'familienfeier',
+        categories: ['spirituosen', 'longdrinks', 'wasser'],
+        customDrinkIds: [],
+        pufferProzent: 0,
+      },
+      DEFAULT_RATES,
+      {},
+  );
+
+  const spirituosen = result.ergebnis.find((item) => item.kategorie === 'spirituosen');
+  const longdrinks = result.ergebnis.find((item) => item.kategorie === 'longdrinks');
+  const totalBeverage = 10 * 0.5 * 4;
+  const sumWeights = DRINK_WEIGHTS.spirituosen.basis + DRINK_WEIGHTS.longdrinks.basis + DRINK_WEIGHTS.wasser.basis;
+
+  assert.ok(spirituosen);
+  assert.ok(longdrinks);
+  assert.equal(
+      spirituosen.literOhnePuffer,
+      Math.round((totalBeverage * DRINK_WEIGHTS.spirituosen.basis / sumWeights) * 100) / 100,
+      'spirituosen bekommt NICHT das longdrinks-Gewicht, da longdrinks explizit angeboten wird',
+  );
+  assert.equal(
+      longdrinks.literOhnePuffer,
+      Math.round((totalBeverage * DRINK_WEIGHTS.longdrinks.basis / sumWeights) * 100) / 100,
+  );
+});
+
+test('calculate leitet Kategorie "longdrinks" (eigenes Budget) aus custom drinks ab, wenn event.categories leer ist', () => {
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 4,
+        guests: {adults: 10, children: 0},
+        season: 'uebergang',
+        eventType: 'familienfeier',
+        categories: [],
+        customDrinkIds: ['ginTonic'],
+        pufferProzent: 0,
+      },
+      DEFAULT_RATES,
+      {
+        ginTonic: {
+          name: 'Gin Tonic',
+          kategorie: 'longdrinks',
+          einheiten: [{einheitsgroesse: 0.2, gebindeinheit: 'Glas'}],
+        },
+      },
+  );
+
+  const standardCategories = result.ergebnis.filter((item) => !item.isCustomDrink);
+  const longdrinks = result.ergebnis.find((item) => item.kategorie === 'longdrinks');
+  const ginTonic = result.ergebnis.find((item) => item.kategorie === 'ginTonic');
+
+  assert.equal(standardCategories.length, 1, 'nur eine Standardkategorie ("longdrinks") wird berechnet');
+  assert.ok(longdrinks, 'longdrinks ist als Kategorie mit eigenem Budget vorhanden, nicht kollabiert zu spirituosen');
+  assert.ok(ginTonic);
+  assert.equal(ginTonic.literOhnePuffer, longdrinks.literOhnePuffer);
 });
 
 test('calculate verteilt Softdrink-Kategoriebedarf gleichmaessig auf zwei Getraenke', () => {

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -1,6 +1,6 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DEFAULT_RATES, SEASON_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight} = require('./drinkRates');
+const {DEFAULT_RATES, SEASON_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, getWeightSubcategoryParents, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight} = require('./drinkRates');
 
 /**
  * Laedt die kalibrierten Erfahrungswerte eines Nutzers und mischt sie mit
@@ -107,27 +107,42 @@ function normalizeDistributionFactor(value) {
 }
 
 /**
- * Map von Unterkategorie-ID auf uebergeordnete Kategorie-ID.
- * Spiegelt die Hierarchie aus drinkCategories.js (src) wider.
- * bier_alkoholfrei ist eine direkte Unterkategorie von bier.
+ * Rein kosmetische Unterkategorien (Geschmacksvarianten), die kein eigenes
+ * Gewicht in DRINK_WEIGHTS haben und daher immer vollstaendig ins Budget der
+ * Elternkategorie aufgeloest werden. Spiegelt die Hierarchie aus
+ * drinkCategories.js (src) wider.
  */
-const DRINK_CATEGORY_PARENTS = {
+const COSMETIC_SUBCATEGORY_PARENTS = {
   bier_koelsch: 'bier',
   bier_pils: 'bier',
   bier_weizen: 'bier',
-  bier_alkoholfrei: 'bier',
   wein_weisswein: 'wein',
   wein_rose: 'wein',
   wein_rotwein: 'wein',
 };
 
-const CATEGORY_HAS_OWN_BUDGET = new Set(['bier_alkoholfrei']);
+/**
+ * Map von Unterkategorie-ID auf uebergeordnete Kategorie-ID. Kombiniert die
+ * kosmetischen Geschmacksvarianten mit den Subkategorien, die ein eigenes
+ * Budget/Gewicht in DRINK_WEIGHTS besitzen (z.B. bier_alkoholfrei, longdrinks)
+ * -- DRINK_WEIGHTS.parent ist dafuer die einzige Quelle der Wahrheit.
+ */
+const DRINK_CATEGORY_PARENTS = {...COSMETIC_SUBCATEGORY_PARENTS, ...getWeightSubcategoryParents()};
+
+/**
+ * Subkategorien mit eigenem Budget/Gewicht (siehe DRINK_WEIGHTS.parent), die
+ * bei der Kategorie-Ableitung aus custom drinks NICHT in ihre Elternkategorie
+ * kollabiert werden duerfen.
+ */
+const CATEGORY_HAS_OWN_BUDGET = new Set(Object.keys(getWeightSubcategoryParents()));
 
 /**
  * Set of category IDs that are considered alcoholic (for alkohol-restriction logic).
- * Mirrors ALCOHOLIC_CATEGORY_IDS in guestPreferences.js (src).
+ * Mirrors ALCOHOLIC_CATEGORY_IDS in guestPreferences.js (src). Anders als
+ * bier_alkoholfrei ist longdrinks (Subkategorie von spirituosen) alkoholisch
+ * und muss daher explizit gelistet werden.
  */
-const ALCOHOLIC_CATEGORY_IDS_FUNCTIONS = new Set(['bier', 'wein', 'sekt', 'spirituosen']);
+const ALCOHOLIC_CATEGORY_IDS_FUNCTIONS = new Set(['bier', 'wein', 'sekt', 'spirituosen', 'longdrinks']);
 
 /**
  * Liefert die uebergeordnete Kategorie-ID, falls vorhanden; sonst die ID selbst.

--- a/functions/drinkRates.drinkWeights.test.js
+++ b/functions/drinkRates.drinkWeights.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const {DRINK_WEIGHTS, getDrinkWeight, BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR} = require('./drinkRates');
+const {DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR} = require('./drinkRates');
 const {_internal} = require('./calculateEventDrinks');
 
 // --- getDrinkWeight ---
@@ -47,10 +47,40 @@ test('DRINK_WEIGHTS Basis-Gewichte ergeben in Summe 1.0', () => {
 });
 
 test('DRINK_WEIGHTS enthaelt alle erwarteten Kategorien', () => {
-  const expected = ['bier', 'bier_alkoholfrei', 'wein', 'softdrinks', 'spirituosen', 'kaffee', 'tee', 'wasser'];
+  const expected = ['bier', 'bier_alkoholfrei', 'wein', 'softdrinks', 'spirituosen', 'longdrinks', 'kaffee', 'tee', 'wasser'];
   for (const cat of expected) {
     assert.ok(Object.prototype.hasOwnProperty.call(DRINK_WEIGHTS, cat), `${cat} fehlt in DRINK_WEIGHTS`);
   }
+});
+
+// --- parent / getWeightSubcategoryParents / getParentTotal ---
+
+test('DRINK_WEIGHTS.parent bildet die Eltern/Kind-Beziehungen ab', () => {
+  assert.equal(DRINK_WEIGHTS.bier.parent, null);
+  assert.equal(DRINK_WEIGHTS.bier_alkoholfrei.parent, 'bier');
+  assert.equal(DRINK_WEIGHTS.wein.parent, null);
+  assert.equal(DRINK_WEIGHTS.spirituosen.parent, null);
+  assert.equal(DRINK_WEIGHTS.longdrinks.parent, 'spirituosen');
+  assert.equal(DRINK_WEIGHTS.wasser.parent, null);
+});
+
+test('getWeightSubcategoryParents gibt nur Subkategorien mit eigenem Budget zurueck', () => {
+  assert.deepEqual(getWeightSubcategoryParents(), {
+    bier_alkoholfrei: 'bier',
+    longdrinks: 'spirituosen',
+  });
+});
+
+test('getParentTotal summiert Elternkategorie und alle Subkategorien', () => {
+  assert.equal(getParentTotal({bier: 2.0, bier_alkoholfrei: 0.5}, 'bier'), 2.5);
+  assert.equal(getParentTotal({spirituosen: 1.2, longdrinks: 0.8}, 'spirituosen'), 2.0);
+});
+
+test('getParentTotal ignoriert fehlende Subkategorien und liefert 0 fuer unbekannte Elternkategorie', () => {
+  assert.equal(getParentTotal({bier: 2.0}, 'bier'), 2.0);
+  assert.equal(getParentTotal({}, 'bier'), 0);
+  assert.equal(getParentTotal({bier: 2.0}, 'unbekannt'), 0);
+  assert.equal(getParentTotal(null, 'bier'), 0);
 });
 
 // --- Proportionale Verteilung mit DRINK_WEIGHTS ---

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -48,6 +48,10 @@ const DEFAULT_RATES = {
     erwachsene: 0.02, kinder: 0.0,
     gebindeLiter: 0.7, gebindeName: '0,7L-Flasche', modus: 'stunde', anteilTrinker: 0.25,
   },
+  longdrinks: {
+    erwachsene: 0.03, kinder: 0.0,
+    gebindeLiter: 1.0, gebindeName: '1L-Flasche (Mixer)', modus: 'stunde', anteilTrinker: 0.35,
+  },
   kaffee: {
     erwachsene: 0.30, kinder: 0.0,
     gebindeLiter: 0.0625, gebindeName: 'Tasse (125ml)', modus: 'pauschal',
@@ -65,57 +69,116 @@ const SEASON_FACTORS = {sommer: 1.2, uebergang: 1.0, winter: 0.85};
  * Basis-Gewicht bestimmt den proportionalen Anteil einer Kategorie am
  * Gesamtgetraenkebedarf. Saisonale und Tageszeit-Anpassungen folgen in
  * separaten Tickets.
+ *
+ * `parent` verweist auf den Key der uebergeordneten Kategorie (oder null bei
+ * Top-Level-Kategorien) und ist die Referenz-Quelle fuer alle Eltern/Kind-
+ * Beziehungen im Getraenke-Modell (siehe getWeightSubcategoryParents(),
+ * getParentTotal() sowie DRINK_CATEGORY_PARENTS in calculateEventDrinks.js).
+ *
+ * bier_alkoholfrei (85/15-Split von "bier") und longdrinks (40/60-Split von
+ * "spirituosen") sind beides ungeprueft geschaetzte Aufteilungen ohne
+ * Kalibrierungsgrundlage und sollten nachgeschaerft werden, sobald genug
+ * Erfahrungswerte aus echten Events vorliegen.
  */
 const DRINK_WEIGHTS = {
   bier: {
+    parent: null,
     basis: 0.221,
     winter: -0.016,
     sommer: 0.010,
     nachmittag: -0.040,
   },
   bier_alkoholfrei: {
+    parent: 'bier',
     basis: 0.039,
     winter: -0.002,
     sommer: 0.004,
     nachmittag: 0.005,
   },
   wein: {
+    parent: null,
     basis: 0.150,
     winter: 0.042,
     sommer: -0.053,
     nachmittag: -0.020,
   },
   softdrinks: {
+    parent: null,
     basis: 0.260,
     winter: -0.048,
     sommer: 0.056,
     nachmittag: 0.020,
   },
   spirituosen: {
-    basis: 0.030,
-    winter: 0.005,
-    sommer: -0.008,
-    nachmittag: -0.015,
+    parent: null,
+    basis: 0.012,
+    winter: 0.007,
+    sommer: -0.010,
+    nachmittag: -0.010,
+  },
+  longdrinks: {
+    parent: 'spirituosen',
+    basis: 0.018,
+    winter: -0.002,
+    sommer: 0.002,
+    nachmittag: -0.005,
   },
   kaffee: {
+    parent: null,
     basis: 0.090,
     winter: 0.046,
     sommer: -0.039,
     nachmittag: 0.035,
   },
   tee: {
+    parent: null,
     basis: 0.040,
     winter: 0.025,
     sommer: -0.021,
     nachmittag: 0.015,
   },
   wasser: {
+    parent: null,
     basis: 0.170,
     winter: -0.051,
     sommer: 0.050,
     nachmittag: 0.000,
   },
 };
+
+/**
+ * Leitet aus DRINK_WEIGHTS eine Map von Subkategorie-Key auf Elternkategorie-Key ab.
+ * Einzige Quelle der Wahrheit fuer Eltern/Kind-Beziehungen mit eigenem Budget
+ * (Kategorien mit parent: null werden nicht aufgenommen).
+ * @return {object} Subkategorie-Key -> Elternkategorie-Key.
+ */
+function getWeightSubcategoryParents() {
+  const result = {};
+  for (const [key, entry] of Object.entries(DRINK_WEIGHTS)) {
+    if (entry.parent) result[key] = entry.parent;
+  }
+  return result;
+}
+
+/**
+ * Summiert fuer eine Elternkategorie deren eigenen Betrag plus die Betraege
+ * aller Subkategorien (basierend auf DRINK_WEIGHTS.parent). Fuer Ansichten,
+ * die keine Subkategorie-Granularitaet benoetigen (z.B. Einkaufslisten:
+ * "wie viel Bier insgesamt", alkoholisch + alkoholfrei).
+ * @param {object} categoryAmounts Map von Kategorie-Key -> Betrag (z.B. Liter).
+ * @param {string} parentKey Key der Elternkategorie.
+ * @return {number} Summe aus Elternkategorie-Betrag und allen Subkategorie-Betraegen.
+ */
+function getParentTotal(categoryAmounts, parentKey) {
+  if (!categoryAmounts || !parentKey) return 0;
+  let total = Number(categoryAmounts[parentKey]) || 0;
+  for (const [key, entry] of Object.entries(DRINK_WEIGHTS)) {
+    if (entry.parent === parentKey && categoryAmounts[key] !== undefined) {
+      total += Number(categoryAmounts[key]) || 0;
+    }
+  }
+  return total;
+}
 
 /**
  * Gibt das Gewicht einer Getraenkekategorie zurueck.
@@ -138,15 +201,16 @@ function getDrinkWeight(category, season, timeOfDay) { // eslint-disable-line no
  * Die Basis-Gewichte ergeben in Summe 1.0.
  */
 const CHILDREN_DRINK_WEIGHTS = {
-  bier: {basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
-  bier_alkoholfrei: {basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
-  wein: {basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
-  spirituosen: {basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
-  softdrinks: {basis: 0.280, winter: -0.040, sommer: 0.050, nachmittag: 0.010},
-  saft: {basis: 0.320, winter: 0.010, sommer: 0.030, nachmittag: 0.015},
-  kaffee: {basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
-  tee: {basis: 0.030, winter: 0.030, sommer: -0.010, nachmittag: 0.010},
-  wasser: {basis: 0.370, winter: -0.020, sommer: 0.060, nachmittag: -0.005},
+  bier: {parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  bier_alkoholfrei: {parent: 'bier', basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  wein: {parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  spirituosen: {parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  longdrinks: {parent: 'spirituosen', basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  softdrinks: {parent: null, basis: 0.280, winter: -0.040, sommer: 0.050, nachmittag: 0.010},
+  saft: {parent: null, basis: 0.320, winter: 0.010, sommer: 0.030, nachmittag: 0.015},
+  kaffee: {parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0},
+  tee: {parent: null, basis: 0.030, winter: 0.030, sommer: -0.010, nachmittag: 0.010},
+  wasser: {parent: null, basis: 0.370, winter: -0.020, sommer: 0.060, nachmittag: -0.005},
 };
 
 /**
@@ -184,4 +248,4 @@ function durationFactor(hours) {
   return Math.max(0.75, 1.0 - 0.03 * extra);
 }
 
-module.exports = {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight};
+module.exports = {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight};

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -33,6 +33,7 @@ const CATEGORY_LABELS = {
   wein_rotwein: 'Rotwein',
   sekt: 'Sekt',
   spirituosen: 'Spirituosen',
+  longdrinks: 'Longdrinks',
   kaffee: 'Kaffee',
   tee: 'Tee',
 };

--- a/src/utils/drinkCategories.js
+++ b/src/utils/drinkCategories.js
@@ -22,7 +22,13 @@ export const DRINK_CATEGORIES = [
     ],
   },
   { id: 'sekt', label: 'Sekt' },
-  { id: 'spirituosen', label: 'Spirituosen' },
+  {
+    id: 'spirituosen',
+    label: 'Spirituosen',
+    subcategories: [
+      { id: 'longdrinks', label: 'Longdrinks', hasOwnBudget: true },
+    ],
+  },
   { id: 'kaffee', label: 'Kaffee' },
   { id: 'tee', label: 'Tee' },
 ];


### PR DESCRIPTION
DRINK_WEIGHTS/CHILDREN_DRINK_WEIGHTS bekommen ein parent-Feld als einzige
Quelle der Wahrheit für Eltern/Kind-Beziehungen (bisher nur implizit über
DRINK_CATEGORY_PARENTS in calculateEventDrinks.js). "spirituosen" (0,030)
wird per 40/60-Split in "spirituosen" (0,012) und "longdrinks" (0,018)
aufgeteilt, analog zum bereits bestehenden 85/15-Split von bier/bier_alkoholfrei.

- DRINK_CATEGORY_PARENTS und CATEGORY_HAS_OWN_BUDGET leiten die
  Subkategorien mit eigenem Budget jetzt aus DRINK_WEIGHTS.parent ab, statt
  sie manuell doppelt zu pflegen. Der bestehende Geschwister-Fallback
  (Subkategorie nicht angeboten, Elternkategorie schon -> Gewicht geht an
  die Elternkategorie) greift dadurch automatisch auch für
  longdrinks -> spirituosen.
- Neue Hilfsfunktion getParentTotal() aggregiert Eltern- + Subkategorie-
  Beträge für Ansichten ohne Subkategorie-Granularität.
- longdrinks als alkoholische Kategorie in ALCOHOLIC_CATEGORY_IDS_FUNCTIONS
  ergänzt (im Gegensatz zu bier_alkoholfrei).
- DEFAULT_RATES, DRINK_CATEGORIES (src) und CATEGORY_LABELS um longdrinks
  ergänzt, damit Gebinde-Zeile, Getränkeverwaltung-Dropdown und Anzeige
  funktionieren.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K1ArEpZLyNNNLcjLSnqcR8