### PR TITLE
feat: Rezept-Verlinkung im Getränk-Namensfeld erlauben

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2057,6 +2057,7 @@ function App() {
         <EventsPage
           onBack={() => handleViewChange('recipes')}
           currentUser={currentUser}
+          recipes={recipes}
           pendingEventReminderId={pendingEventReminderId}
           onPendingEventReminderHandled={() => {
             setPendingEventReminderId(null);

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -1,10 +1,24 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import './EventsPage.css';
 import { subscribeToCustomDrinks, saveCustomDrink, deleteCustomDrink } from '../utils/eventsFirestore';
 import OverviewAddFab from './OverviewAddFab';
+import RecipeTypeahead from './RecipeTypeahead';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel, PREDEFINED_DRINKS } from '../utils/drinkCategories';
 import { getCustomLists, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
+import { encodeRecipeLink, decodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
+
+const DRINK_RECIPE_CATEGORY = 'Drinks';
+
+const isDrinkRecipe = (recipe) =>
+  Array.isArray(recipe?.speisekategorie)
+    ? recipe.speisekategorie.includes(DRINK_RECIPE_CATEGORY)
+    : recipe?.speisekategorie === DRINK_RECIPE_CATEGORY;
+
+const getDrinkDisplayName = (drink) => {
+  const link = decodeRecipeLink(drink?.name);
+  return link ? link.recipeName : (drink?.name || '');
+};
 
 const SWIPE_DELETE_THRESHOLD = 56;
 const SWIPE_DELETE_MAX_OFFSET = 96;
@@ -118,7 +132,7 @@ function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
               type="button"
               className="drink-swipe-delete-action"
               onClick={() => { onDelete(drink); resetSwipe(); }}
-              aria-label={`${drink.name} löschen`}
+              aria-label={`${getDrinkDisplayName(drink)} löschen`}
             >
               {isBase64Image(swipeDeleteIcon) ? (
                 <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
@@ -138,7 +152,7 @@ function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <h3>{drink.name}</h3>
+        <h3>{getDrinkDisplayName(drink)}</h3>
         <p className="events-card-meta">
           {[
             drink.kategorie ? getDrinkCategoryLabel(drink.kategorie) : null,
@@ -154,7 +168,7 @@ function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
   );
 }
 
-function DrinkManagementPage({ onBack, currentUser }) {
+function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [drinks, setDrinks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -164,6 +178,7 @@ function DrinkManagementPage({ onBack, currentUser }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [packageUnits, setPackageUnits] = useState([]);
+  const [showNameTypeahead, setShowNameTypeahead] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [fabPressed, setFabPressed] = useState(false);
@@ -207,11 +222,19 @@ function DrinkManagementPage({ onBack, currentUser }) {
     };
   }, []);
 
+  const drinkRecipes = useMemo(
+    () => (Array.isArray(recipes) ? recipes.filter(isDrinkRecipe) : []),
+    [recipes]
+  );
+
+  const nameRecipeLink = decodeRecipeLink(form.name);
+
   const openNew = () => {
     setEditId(null);
     setIsPredefined(false);
     setForm(emptyForm());
     setError('');
+    setShowNameTypeahead(false);
     setShowForm(true);
   };
 
@@ -231,7 +254,27 @@ function DrinkManagementPage({ onBack, currentUser }) {
           : [emptyEinheit()],
     });
     setError('');
+    setShowNameTypeahead(false);
     setShowForm(true);
+  };
+
+  const handleNameChange = (value) => {
+    setForm((f) => ({ ...f, name: value }));
+    setShowNameTypeahead(containsHashForTypeahead(value));
+  };
+
+  const handleNameRecipeSelect = (selectedRecipe) => {
+    setForm((f) => ({ ...f, name: encodeRecipeLink(selectedRecipe.id, selectedRecipe.title) }));
+    setShowNameTypeahead(false);
+  };
+
+  const handleClearNameLink = () => {
+    setForm((f) => ({ ...f, name: '' }));
+  };
+
+  const closeForm = () => {
+    setShowNameTypeahead(false);
+    setShowForm(false);
   };
 
   const addEinheit = () => {
@@ -299,7 +342,7 @@ function DrinkManagementPage({ onBack, currentUser }) {
       await deleteCustomDrink(currentUser.id, drink.id);
       const id = deleteBannerCounterRef.current;
       deleteBannerCounterRef.current = (id + 1) % 100000;
-      setDeleteBanners((prev) => [...prev, { id, message: `"${drink.name}" gelöscht.` }]);
+      setDeleteBanners((prev) => [...prev, { id, message: `"${getDrinkDisplayName(drink)}" gelöscht.` }]);
       const timeoutId = setTimeout(() => {
         setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
         deleteBannerTimeoutsRef.current.delete(id);
@@ -317,7 +360,7 @@ function DrinkManagementPage({ onBack, currentUser }) {
           <h2>{editId ? 'Getränk bearbeiten' : 'Neues Getränk'}</h2>
           <button
             className="events-close-btn"
-            onClick={() => setShowForm(false)}
+            onClick={closeForm}
             aria-label="Abbrechen"
             title="Abbrechen"
           >
@@ -327,14 +370,30 @@ function DrinkManagementPage({ onBack, currentUser }) {
         <form className="events-form" onSubmit={handleSave} ref={formRef}>
           <label className="events-form-field">
             <span>Name</span>
-            <input
-              type="text"
-              value={form.name}
-              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
-              placeholder="z. B. Craft-Bier, Apfelsaft, ..."
-              required={!isPredefined}
-              disabled={isPredefined}
-            />
+            <div className="events-name-input-wrapper">
+              <input
+                type="text"
+                value={nameRecipeLink ? nameRecipeLink.recipeName : form.name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                placeholder="z. B. Craft-Bier, Apfelsaft, ... (# verlinkt ein Rezept)"
+                required={!isPredefined}
+                disabled={isPredefined}
+                readOnly={!!nameRecipeLink}
+                className={nameRecipeLink ? 'recipe-link-input' : ''}
+                title={nameRecipeLink ? `Verlinktes Rezept: ${nameRecipeLink.recipeName}` : undefined}
+              />
+              {nameRecipeLink && !isPredefined && (
+                <button
+                  type="button"
+                  className="events-name-link-clear-btn"
+                  onClick={handleClearNameLink}
+                  aria-label="Verknüpfung entfernen"
+                  title="Verknüpfung entfernen"
+                >
+                  ×
+                </button>
+              )}
+            </div>
           </label>
 
           <label className="events-form-field">
@@ -433,7 +492,7 @@ function DrinkManagementPage({ onBack, currentUser }) {
             <button
               type="button"
               className="events-secondary-btn events-save-desktop-only"
-              onClick={() => setShowForm(false)}
+              onClick={closeForm}
               disabled={saving}
             >
               Abbrechen
@@ -477,7 +536,7 @@ function DrinkManagementPage({ onBack, currentUser }) {
         <button
           type="button"
           className={`events-cancel-fab-button ${cancelPressed ? 'pressed' : ''}`}
-          onClick={() => setShowForm(false)}
+          onClick={closeForm}
           onTouchStart={() => setCancelPressed(true)}
           onTouchEnd={() => setCancelPressed(false)}
           onTouchCancel={() => setCancelPressed(false)}
@@ -494,6 +553,15 @@ function DrinkManagementPage({ onBack, currentUser }) {
             getEffectiveIcon(buttonIcons, 'cancelRecipe', isDarkMode)
           )}
         </button>
+
+        {showNameTypeahead && (
+          <RecipeTypeahead
+            recipes={drinkRecipes}
+            onSelect={handleNameRecipeSelect}
+            onCancel={() => setShowNameTypeahead(false)}
+            inputValue={form.name}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -378,6 +378,85 @@ describe('DrinkManagementPage', () => {
     });
   });
 
+  describe('recipe linking in the name field', () => {
+    const recipes = [
+      { id: 'r1', title: 'Mojito', speisekategorie: ['Drinks'] },
+      { id: 'r2', title: 'Aperol Spritz', speisekategorie: ['Drinks'] },
+      { id: 'r3', title: 'Tomatensoße', speisekategorie: ['Hauptspeisen'] },
+    ];
+
+    test('typing # in the name field opens the recipe typeahead with only Drinks-category recipes', () => {
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#' } });
+
+      expect(screen.getByPlaceholderText('Rezept suchen...')).toBeInTheDocument();
+      expect(screen.getByText('Mojito')).toBeInTheDocument();
+      expect(screen.getByText('Aperol Spritz')).toBeInTheDocument();
+      expect(screen.queryByText('Tomatensoße')).not.toBeInTheDocument();
+    });
+
+    test('selecting a recipe from the typeahead links it and shows the recipe name', () => {
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#Mojito' } });
+
+      fireEvent.click(screen.getByText('Mojito'));
+
+      const nameInput = screen.getByRole('textbox', { name: /Name/i });
+      expect(nameInput.value).toBe('Mojito');
+      expect(nameInput).toHaveAttribute('readonly');
+      expect(screen.queryByPlaceholderText('Rezept suchen...')).not.toBeInTheDocument();
+    });
+
+    test('saving a linked drink stores the encoded recipe link as the name', async () => {
+      mockSaveCustomDrink.mockResolvedValue('new-drink-id');
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#Mojito' } });
+      fireEvent.click(screen.getByText('Mojito'));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+      await waitFor(() => {
+        expect(mockSaveCustomDrink).toHaveBeenCalledWith(
+          currentUser.id,
+          expect.objectContaining({ name: '#recipe:r1:Mojito' }),
+          undefined,
+        );
+      });
+    });
+
+    test('clearing a linked recipe name makes the field editable again', () => {
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#Mojito' } });
+      fireEvent.click(screen.getByText('Mojito'));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Verknüpfung entfernen' }));
+
+      const nameInput = screen.getByRole('textbox', { name: /Name/i });
+      expect(nameInput.value).toBe('');
+      expect(nameInput).not.toHaveAttribute('readonly');
+    });
+
+    test('the drink list shows the linked recipe name instead of the raw link', () => {
+      mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+        cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
+        return jest.fn();
+      });
+
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      expect(screen.getByText('Mojito')).toBeInTheDocument();
+      expect(screen.queryByText('#recipe:r1:Mojito')).not.toBeInTheDocument();
+    });
+  });
+
   describe('swipe-delete', () => {
     const createTouchEvent = (type, clientX, clientY) => ({
       touches: [{ clientX, clientY }],

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -328,6 +328,42 @@
   box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.12);
 }
 
+.events-name-input-wrapper {
+  position: relative;
+  display: flex;
+}
+
+.events-name-input-wrapper input {
+  flex: 1;
+  width: 100%;
+}
+
+.events-name-input-wrapper input.recipe-link-input {
+  background-color: #f0f7ff;
+  border-color: #90c2f7;
+  color: #1a5fa8;
+  cursor: default;
+  padding-right: 36px;
+}
+
+.events-name-link-clear-btn {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: #1a5fa8;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.events-name-link-clear-btn:hover {
+  color: #402C1C;
+}
+
 .events-category-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -38,7 +38,7 @@ const formatDrinkSummary = (berechnung) => {
     .join(', ');
 };
 
-function EventsPage({ onBack, currentUser, pendingEventReminderId, onPendingEventReminderHandled }) {
+function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPendingEventReminderHandled }) {
   const [isMobileView, setIsMobileView] = useState(() => window.innerWidth <= 768);
   const [editFabPressed, setEditFabPressed] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
@@ -133,6 +133,7 @@ function EventsPage({ onBack, currentUser, pendingEventReminderId, onPendingEven
       <DrinkManagementPage
         onBack={() => setSubView('list')}
         currentUser={currentUser}
+        recipes={recipes}
       />
     );
   }


### PR DESCRIPTION
Im Namensfeld der "Getränk bearbeiten"-Seite kann jetzt wie bei Zutaten
per # ein Rezept verlinkt werden. Die Typeahead-Auswahl zeigt dabei nur
Rezepte der Kategorie "Drinks" an.