### PR TITLE
Resolve #recipe: links centrally, add ingredient toggle to drink edit page

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './EventsPage.css';
 import { submitConsumption } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -11,8 +12,8 @@ function getEinheitSizeLabel(einheitsgroesse) {
   return `${liters.toFixed(1).replace('.', ',')} l`;
 }
 
-function getRowDrinkName(row) {
-  if (row.isCustomDrink && row.drinkLabel) return row.drinkLabel;
+function getRowDrinkName(row, recipes) {
+  if (row.isCustomDrink && row.drinkLabel) return resolveDrinkDisplay(row.drinkLabel, recipes).displayName;
   return CATEGORY_LABELS[row.kategorie] || row.kategorie;
 }
 
@@ -31,14 +32,14 @@ function getRowUnitSubtitle(row) {
   return null;
 }
 
-function groupKategorienByDrink(kategorien) {
+function groupKategorienByDrink(kategorien, recipes) {
   const groups = [];
   const groupsByKey = new Map();
   kategorien.forEach((row) => {
     const key = row.drinkId || row.kategorie;
     let group = groupsByKey.get(key);
     if (!group) {
-      group = { key, drinkName: getRowDrinkName(row), rows: [] };
+      group = { key, drinkName: getRowDrinkName(row, recipes), rows: [] };
       groupsByKey.set(key, group);
       groups.push(group);
     }
@@ -47,9 +48,9 @@ function groupKategorienByDrink(kategorien) {
   return groups;
 }
 
-function ConsumptionForm({ event, onDone, onCancel }) {
+function ConsumptionForm({ event, recipes, onDone, onCancel }) {
   const kategorien = (event.berechnung?.ergebnis || []).filter((row) => row.isCustomDrink && row.gebindeGroesseLiter);
-  const drinkGroups = groupKategorienByDrink(kategorien);
+  const drinkGroups = groupKategorienByDrink(kategorien, recipes);
   const [values, setValues] = useState(() => {
     const initial = {};
     kategorien.forEach((row) => {

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -6,7 +6,10 @@ import RecipeTypeahead from './RecipeTypeahead';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel, PREDEFINED_DRINKS } from '../utils/drinkCategories';
 import { getCustomLists, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
-import { encodeRecipeLink, decodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
+import { encodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import { parseIngredientPartsSync } from '../utils/ingredientUtils';
+import { updateRecipe } from '../utils/recipeFirestore';
 
 const DRINK_RECIPE_CATEGORY = 'Drinks';
 
@@ -14,11 +17,6 @@ const isDrinkRecipe = (recipe) =>
   Array.isArray(recipe?.speisekategorie)
     ? recipe.speisekategorie.includes(DRINK_RECIPE_CATEGORY)
     : recipe?.speisekategorie === DRINK_RECIPE_CATEGORY;
-
-const getDrinkDisplayName = (drink) => {
-  const link = decodeRecipeLink(drink?.name);
-  return link ? link.recipeName : (drink?.name || '');
-};
 
 const SWIPE_DELETE_THRESHOLD = 56;
 const SWIPE_DELETE_MAX_OFFSET = 96;
@@ -58,7 +56,7 @@ const emptyForm = () => ({
   einheiten: [emptyEinheit()],
 });
 
-function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
+function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
   const touchStartXRef = React.useRef(null);
   const touchStartYRef = React.useRef(null);
   const swipeDirectionLockedRef = React.useRef(null);
@@ -132,7 +130,7 @@ function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
               type="button"
               className="drink-swipe-delete-action"
               onClick={() => { onDelete(drink); resetSwipe(); }}
-              aria-label={`${getDrinkDisplayName(drink)} löschen`}
+              aria-label={`${displayName} löschen`}
             >
               {isBase64Image(swipeDeleteIcon) ? (
                 <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
@@ -152,7 +150,7 @@ function DrinkRow({ drink, onEdit, onDelete, swipeDeleteIcon }) {
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <h3>{getDrinkDisplayName(drink)}</h3>
+        <h3>{displayName}</h3>
         <p className="events-card-meta">
           {[
             drink.kategorie ? getDrinkCategoryLabel(drink.kategorie) : null,
@@ -227,7 +225,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     [recipes]
   );
 
-  const nameRecipeLink = decodeRecipeLink(form.name);
+  const nameDrinkDisplay = resolveDrinkDisplay(form.name, recipes);
 
   const openNew = () => {
     setEditId(null);
@@ -292,6 +290,23 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     }));
   };
 
+  const handleToggleIngredientIncluded = async (ingredientIndex) => {
+    const recipe = nameDrinkDisplay.recipe;
+    if (!recipe) return;
+    const currentIngredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : [];
+    const updatedIngredients = currentIngredients.map((item, idx) => {
+      if (idx !== ingredientIndex) return item;
+      const normalized = typeof item === 'string' ? { type: 'ingredient', text: item } : item;
+      const currentlyIncluded = normalized.includedInCalculation !== false;
+      return { ...normalized, includedInCalculation: !currentlyIncluded };
+    });
+    try {
+      await updateRecipe(recipe.id, { ingredients: updatedIngredients });
+    } catch (err) {
+      console.error('Error updating ingredient calculation flag:', err);
+    }
+  };
+
   const handleSave = async (e) => {
     e.preventDefault();
     if (!isPredefined && !form.name.trim()) {
@@ -342,7 +357,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
       await deleteCustomDrink(currentUser.id, drink.id);
       const id = deleteBannerCounterRef.current;
       deleteBannerCounterRef.current = (id + 1) % 100000;
-      setDeleteBanners((prev) => [...prev, { id, message: `"${getDrinkDisplayName(drink)}" gelöscht.` }]);
+      const deletedDisplayName = resolveDrinkDisplay(drink, recipes).displayName;
+      setDeleteBanners((prev) => [...prev, { id, message: `"${deletedDisplayName}" gelöscht.` }]);
       const timeoutId = setTimeout(() => {
         setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
         deleteBannerTimeoutsRef.current.delete(id);
@@ -373,16 +389,16 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             <div className="events-name-input-wrapper">
               <input
                 type="text"
-                value={nameRecipeLink ? nameRecipeLink.recipeName : form.name}
+                value={nameDrinkDisplay.isRecipe ? nameDrinkDisplay.displayName : form.name}
                 onChange={(e) => handleNameChange(e.target.value)}
                 placeholder="z. B. Craft-Bier, Apfelsaft, ... (# verlinkt ein Rezept)"
                 required={!isPredefined}
                 disabled={isPredefined}
-                readOnly={!!nameRecipeLink}
-                className={nameRecipeLink ? 'recipe-link-input' : ''}
-                title={nameRecipeLink ? `Verlinktes Rezept: ${nameRecipeLink.recipeName}` : undefined}
+                readOnly={nameDrinkDisplay.isRecipe}
+                className={nameDrinkDisplay.isRecipe ? 'recipe-link-input' : ''}
+                title={nameDrinkDisplay.isRecipe ? `Verlinktes Rezept: ${nameDrinkDisplay.displayName}` : undefined}
               />
-              {nameRecipeLink && !isPredefined && (
+              {nameDrinkDisplay.isRecipe && !isPredefined && (
                 <button
                   type="button"
                   className="events-name-link-clear-btn"
@@ -485,6 +501,38 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
               Einheit hinzufügen
             </button>
           </div>
+
+          {nameDrinkDisplay.isRecipe && nameDrinkDisplay.recipe && (
+            <div className="events-form-field">
+              <span>Zutaten von „{nameDrinkDisplay.displayName}"</span>
+              <ul className="drink-recipe-ingredient-list">
+                {nameDrinkDisplay.ingredients.map((rawItem, idx) => {
+                  const item = typeof rawItem === 'string' ? { type: 'ingredient', text: rawItem } : rawItem;
+                  if (item.type === 'heading') return null;
+                  const { amount, amountMax, unit, name } = parseIngredientPartsSync(item.text);
+                  const amountLabel = amount != null
+                    ? `${amount}${amountMax != null ? `–${amountMax}` : ''}${unit ? ` ${unit}` : ''}`
+                    : null;
+                  const included = item.includedInCalculation !== false;
+                  return (
+                    <li key={idx} className="drink-recipe-ingredient-row">
+                      <span className="drink-recipe-ingredient-name">{name}</span>
+                      {amountLabel && <span className="drink-recipe-ingredient-amount">{amountLabel}</span>}
+                      <label className="drink-recipe-ingredient-toggle">
+                        <input
+                          type="checkbox"
+                          checked={included}
+                          onChange={() => handleToggleIngredientIncluded(idx)}
+                          aria-label={`${name} in Kalkulation berücksichtigen`}
+                        />
+                        <span className="drink-recipe-ingredient-toggle-slider" aria-hidden="true" />
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
 
           {error && <p className="events-error-text">{error}</p>}
 
@@ -592,6 +640,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             <DrinkRow
               key={drink.id}
               drink={drink}
+              displayName={resolveDrinkDisplay(drink, recipes).displayName}
               onEdit={openEdit}
               onDelete={handleDelete}
               swipeDeleteIcon={swipeDeleteIcon}

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -6,11 +6,16 @@ const mockSubscribeToCustomDrinks = jest.fn();
 const mockSaveCustomDrink = jest.fn();
 const mockDeleteCustomDrink = jest.fn();
 const mockGetCustomLists = jest.fn();
+const mockUpdateRecipe = jest.fn();
 
 jest.mock('../utils/eventsFirestore', () => ({
   subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
   saveCustomDrink: (...args) => mockSaveCustomDrink(...args),
   deleteCustomDrink: (...args) => mockDeleteCustomDrink(...args),
+}));
+
+jest.mock('../utils/recipeFirestore', () => ({
+  updateRecipe: (...args) => mockUpdateRecipe(...args),
 }));
 
 jest.mock('../utils/customLists', () => ({
@@ -35,6 +40,7 @@ describe('DrinkManagementPage', () => {
       return jest.fn();
     });
     mockGetCustomLists.mockResolvedValue({ packageUnits: [] });
+    mockUpdateRecipe.mockResolvedValue(undefined);
   });
 
   test('renders the mobile add FAB even in the empty state and opens the create form', () => {
@@ -454,6 +460,91 @@ describe('DrinkManagementPage', () => {
 
       expect(screen.getByText('Mojito')).toBeInTheDocument();
       expect(screen.queryByText('#recipe:r1:Mojito')).not.toBeInTheDocument();
+    });
+
+    describe('ingredient list on the edit page', () => {
+      const recipesWithIngredients = [
+        {
+          id: 'r1',
+          title: 'Mojito',
+          speisekategorie: ['Drinks'],
+          ingredients: [
+            { type: 'ingredient', text: '50 ml Rum' },
+            { type: 'ingredient', text: '2 EL Zucker', includedInCalculation: false },
+            { type: 'heading', text: 'Deko' },
+          ],
+        },
+      ];
+
+      test('shows the ingredients of the linked recipe with amount and unit', () => {
+        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+          cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
+          return jest.fn();
+        });
+
+        render(<DrinkManagementPage currentUser={currentUser} recipes={recipesWithIngredients} />);
+
+        fireEvent.click(screen.getByText('Mojito'));
+
+        expect(screen.getByText('Rum')).toBeInTheDocument();
+        expect(screen.getByText('50 ml')).toBeInTheDocument();
+        expect(screen.getByText('Zucker')).toBeInTheDocument();
+        expect(screen.getByText('2 EL')).toBeInTheDocument();
+        // Headings are not rendered as ingredient rows
+        expect(screen.queryByText('Deko')).not.toBeInTheDocument();
+      });
+
+      test('does not show an ingredient list for a normal (non-recipe) drink', () => {
+        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+          cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
+          return jest.fn();
+        });
+
+        render(<DrinkManagementPage currentUser={currentUser} recipes={recipesWithIngredients} />);
+
+        fireEvent.click(screen.getByText('Craft-Bier'));
+
+        expect(screen.queryByText('Rum')).not.toBeInTheDocument();
+      });
+
+      test('toggling an ingredient persists includedInCalculation on the recipe document', async () => {
+        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+          cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
+          return jest.fn();
+        });
+
+        render(<DrinkManagementPage currentUser={currentUser} recipes={recipesWithIngredients} />);
+
+        fireEvent.click(screen.getByText('Mojito'));
+
+        const rumToggle = screen.getByRole('checkbox', { name: 'Rum in Kalkulation berücksichtigen' });
+        expect(rumToggle).toBeChecked();
+        fireEvent.click(rumToggle);
+
+        await waitFor(() => {
+          expect(mockUpdateRecipe).toHaveBeenCalledWith('r1', {
+            ingredients: [
+              { type: 'ingredient', text: '50 ml Rum', includedInCalculation: false },
+              { type: 'ingredient', text: '2 EL Zucker', includedInCalculation: false },
+              { type: 'heading', text: 'Deko' },
+            ],
+          });
+        });
+
+        const zuckerToggle = screen.getByRole('checkbox', { name: 'Zucker in Kalkulation berücksichtigen' });
+        expect(zuckerToggle).not.toBeChecked();
+        fireEvent.click(zuckerToggle);
+
+        await waitFor(() => {
+          expect(mockUpdateRecipe).toHaveBeenLastCalledWith('r1', {
+            ingredients: [
+              { type: 'ingredient', text: '50 ml Rum' },
+              { type: 'ingredient', text: '2 EL Zucker', includedInCalculation: true },
+              { type: 'heading', text: 'Deko' },
+            ],
+          });
+        });
+      });
     });
   });
 

--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -3,6 +3,7 @@ import './EventsPage.css';
 import UnitChip from './UnitChip';
 import { getEffectiveIcon, DEFAULT_BUTTON_ICONS } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 
 const MIN_DISTRIBUTION_FACTOR = 0.1;
 const MAX_DISTRIBUTION_FACTOR = 2.0;
@@ -117,6 +118,7 @@ const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
 
 function DrinkRow({
   drink,
+  displayName,
   factor,
   einheiten,
   selectedIndices,
@@ -208,7 +210,7 @@ function DrinkRow({
             type="button"
             className="events-drink-row-swipe-action"
             onClick={handleSwipeDeleteClick}
-            aria-label={`${drink.name} entfernen`}
+            aria-label={`${displayName} entfernen`}
           >
             {isBase64Image(swipeDeleteIcon) ? (
               <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
@@ -226,7 +228,7 @@ function DrinkRow({
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <div className="events-drink-row-name">{drink.name}</div>
+        <div className="events-drink-row-name">{displayName}</div>
         <div className="events-drink-row-details">
           <div className="events-drink-row-einheiten">
             {einheiten.length > 1 ? (
@@ -247,7 +249,7 @@ function DrinkRow({
                   einheiten={einheiten}
                   selectedIndices={selectedIndices}
                   onToggle={onToggleEinheit}
-                  drinkName={drink.name}
+                  drinkName={displayName}
                 />
               </div>
             ) : einheiten.length === 1 ? (
@@ -264,7 +266,7 @@ function DrinkRow({
               step="0.01"
               value={factor.toFixed(2)}
               onChange={(e) => onUpdateFactor(e.target.value)}
-              aria-label={`${drink.name} Faktor`}
+              aria-label={`${displayName} Faktor`}
             />
           </div>
         </div>
@@ -278,6 +280,7 @@ function EventDrinkSelectionPage({
   customDrinkIds: initialCustomDrinkIds,
   drinkDistributionFactors: initialDrinkDistributionFactors,
   drinkSelectedEinheiten: initialDrinkSelectedEinheiten,
+  recipes,
   onSave,
   onBack,
   buttonIcons,
@@ -391,7 +394,7 @@ function EventDrinkSelectionPage({
                   {customDrinks
                     .filter((d) => !customDrinkIds.includes(d.id))
                     .map((drink) => (
-                      <option key={drink.id} value={drink.id}>{drink.name}</option>
+                      <option key={drink.id} value={drink.id}>{resolveDrinkDisplay(drink, recipes).displayName}</option>
                     ))}
                 </select>
                 <button
@@ -421,6 +424,7 @@ function EventDrinkSelectionPage({
                       <DrinkRow
                         key={drink.id}
                         drink={drink}
+                        displayName={resolveDrinkDisplay(drink, recipes).displayName}
                         factor={factor}
                         einheiten={einheiten}
                         selectedIndices={selectedIndices}

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -58,7 +58,7 @@ const normalizeDistributionFactor = (value) => {
 
 const todayIsoDate = () => new Date().toISOString().slice(0, 10);
 
-function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, initialEvent }) {
+function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, initialEvent, recipes }) {
   const isEditing = Boolean(initialEvent?.id);
 
   const [eventName, setEventName] = useState(initialEvent?.eventName ?? '');
@@ -238,6 +238,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         customDrinkIds={customDrinkIds}
         drinkDistributionFactors={drinkDistributionFactors}
         drinkSelectedEinheiten={drinkSelectedEinheiten}
+        recipes={recipes}
         buttonIcons={buttonIcons}
         isDarkMode={isDarkMode}
         onSave={(newDrinkIds, newDrinkDistributionFactors, newDrinkSelectedEinheiten) => {

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -422,6 +422,82 @@
   color: #a12626;
 }
 
+.drink-recipe-ingredient-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.drink-recipe-ingredient-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border: 1px solid #e2e2e2;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.drink-recipe-ingredient-name {
+  flex: 1;
+  color: #333;
+}
+
+.drink-recipe-ingredient-amount {
+  color: #777;
+  white-space: nowrap;
+}
+
+.drink-recipe-ingredient-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.drink-recipe-ingredient-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.drink-recipe-ingredient-toggle-slider {
+  position: absolute;
+  inset: 0;
+  background-color: #ccc;
+  border-radius: 22px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.drink-recipe-ingredient-toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.15s ease;
+}
+
+.drink-recipe-ingredient-toggle input:checked + .drink-recipe-ingredient-toggle-slider {
+  background-color: #2F5D50;
+}
+
+.drink-recipe-ingredient-toggle input:checked + .drink-recipe-ingredient-toggle-slider::before {
+  transform: translateX(18px);
+}
+
+.drink-recipe-ingredient-toggle input:focus-visible + .drink-recipe-ingredient-toggle-slider {
+  box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.3);
+}
+
 .events-drink-selector {
   display: flex;
   gap: 8px;

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -10,6 +10,7 @@ import OverviewAddFab from './OverviewAddFab';
 import { canEditRecipes } from '../utils/userManagement';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 
 const STATUS_LABELS = {
   geplant: 'Geplant',
@@ -143,6 +144,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       <GuestManagementPage
         onBack={() => setSubView('list')}
         currentUser={currentUser}
+        recipes={recipes}
       />
     );
   }
@@ -154,6 +156,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         onCancel={() => setSubView('list')}
         currentUser={currentUser}
         onManageDrinks={() => setSubView('drinks')}
+        recipes={recipes}
       />
     );
   }
@@ -167,6 +170,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         currentUser={currentUser}
         onManageDrinks={() => setSubView('drinks')}
         initialEvent={selectedEvent}
+        recipes={recipes}
       />
     );
   }
@@ -175,6 +179,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     return (
       <ConsumptionForm
         event={selectedEvent}
+        recipes={recipes}
         onDone={(eventId) => {
           setSelectedEventId(eventId);
           setFallbackEvent(null);
@@ -243,7 +248,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
                   .filter((row) => row.isCustomDrink || !row.hasCustomDrinkCoverage)
                   .map((row) => (
                     <tr key={row.kategorie}>
-                      <td>{row.isCustomDrink && row.drinkLabel ? row.drinkLabel : (CATEGORY_LABELS[row.kategorie] || row.kategorie)}</td>
+                      <td>{row.isCustomDrink && row.drinkLabel ? resolveDrinkDisplay(row.drinkLabel, recipes).displayName : (CATEGORY_LABELS[row.kategorie] || row.kategorie)}</td>
                       <td>{row.literMitPuffer} l</td>
                     </tr>
                   ))}

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -12,6 +12,7 @@ import { getGuestDisplayName, normalizePreferenceFactor } from '../utils/guestPr
 import { DRINK_CATEGORIES, getDrinkCategoryLabel } from '../utils/drinkCategories';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 
 const emptyForm = () => ({
   vorname: '',
@@ -32,7 +33,7 @@ const getPreferenceLabel = (factor) => {
   return 'wird nicht berücksichtigt';
 };
 
-function GuestManagementPage({ onBack, currentUser }) {
+function GuestManagementPage({ onBack, currentUser, recipes }) {
   const [profiles, setProfiles] = useState([]);
   const [customDrinks, setCustomDrinks] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -79,8 +80,8 @@ function GuestManagementPage({ onBack, currentUser }) {
   }, [currentUser?.id]);
 
   const availableDrinks = useMemo(() => {
-    return customDrinks.map((drink) => ({ id: drink.id, label: drink.name || drink.id }));
-  }, [customDrinks]);
+    return customDrinks.map((drink) => ({ id: drink.id, label: resolveDrinkDisplay(drink, recipes).displayName || drink.id }));
+  }, [customDrinks, recipes]);
 
   const openNew = () => {
     setEditId(null);

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3821,6 +3821,22 @@
   color: #e8e8e8;
 }
 
+[data-theme="dark"] .drink-recipe-ingredient-row {
+  border-color: #555;
+}
+
+[data-theme="dark"] .drink-recipe-ingredient-name {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .drink-recipe-ingredient-amount {
+  color: #999;
+}
+
+[data-theme="dark"] .drink-recipe-ingredient-toggle-slider {
+  background-color: #555;
+}
+
 [data-theme="dark"] .events-delete-btn {
   background: #4a2323;
   color: #f0a0a0;

--- a/src/utils/drinkDisplay.js
+++ b/src/utils/drinkDisplay.js
@@ -1,0 +1,47 @@
+/**
+ * Drink Display Resolution
+ * Central place to turn a drink reference (a custom drink object, or a raw
+ * name/label string such as those coming out of the calculation results)
+ * into something displayable, resolving `#recipe:id:name` links against
+ * the already-loaded recipes list instead of leaving the raw link string
+ * on screen.
+ */
+
+import { decodeRecipeLink } from './recipeLinks';
+
+/**
+ * Resolves a drink reference for display.
+ * @param {Object|string} drinkRef - custom drink object (with a `name` field) or a raw name/label string
+ * @param {Array} [recipes] - currently loaded recipes (each with at least `id`, `title`, `ingredients`)
+ * @returns {{
+ *   isRecipe: boolean,
+ *   displayName: string,
+ *   recipeId: string|null,
+ *   recipe: Object|null,
+ *   ingredients: Array,
+ * }}
+ */
+export const resolveDrinkDisplay = (drinkRef, recipes = []) => {
+  const rawName = typeof drinkRef === 'string' ? drinkRef : drinkRef?.name;
+  const link = decodeRecipeLink(rawName);
+
+  if (!link) {
+    return {
+      isRecipe: false,
+      displayName: rawName || '',
+      recipeId: null,
+      recipe: null,
+      ingredients: [],
+    };
+  }
+
+  const recipe = Array.isArray(recipes) ? recipes.find((r) => r.id === link.recipeId) || null : null;
+
+  return {
+    isRecipe: true,
+    displayName: recipe?.title || link.recipeName,
+    recipeId: link.recipeId,
+    recipe,
+    ingredients: Array.isArray(recipe?.ingredients) ? recipe.ingredients : [],
+  };
+};

--- a/src/utils/ingredientUtils.js
+++ b/src/utils/ingredientUtils.js
@@ -238,7 +238,7 @@ const QUANTITY_PATTERN = '(?:\\d+\\s+\\d+\\/\\d+|\\d+\\/\\d+|\\d+(?:[.,]\\d+)?)'
  * @param {string} ingredient - The ingredient string to parse
  * @returns {{ amount: number|null, unit: string|null, name: string }}
  */
-function parseIngredientPartsSync(ingredient) {
+export function parseIngredientPartsSync(ingredient) {
   if (!ingredient || typeof ingredient !== 'string') {
     return { amount: null, unit: null, name: ingredient || '' };
   }


### PR DESCRIPTION
Adds resolveDrinkDisplay() (src/utils/drinkDisplay.js) as the single place
that turns a drink reference into a display name, resolving #recipe:id:name
links against the already-loaded recipes list instead of leaving the raw
link string on screen. Wired it into every place a drink name was rendered:
the event detail "Getränke" table, "Getränke verwalten", the drink
selection dropdown/rows, the consumption form, and the guest preferred-
drinks list. recipes is threaded through EventsPage -> EventForm ->
EventDrinkSelectionPage and EventsPage -> ConsumptionForm/GuestManagementPage
so each of these can resolve names without extra Firestore reads.

On the drink edit page, recipe-linked drinks now list their ingredients
(name/amount/unit, parsed via the newly exported parseIngredientPartsSync)
with a per-ingredient toggle. Toggling flips a new includedInCalculation
field (default true) on the ingredient and persists it directly on the
recipe document via updateRecipe. The toggle has no calculation effect yet;
that's future work.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dvfk3BeKXVH5rjf4pnZNAQ