### PR TITLE
Freie Einheitsgröße (ml) für rezeptverlinkte Getränke

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -440,15 +440,33 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             {form.einheiten.map((einheit, idx) => (
               <div key={idx} className="events-form-row events-einheit-row">
                 <label className="events-form-field">
-                  <span>Einheitsgröße</span>
-                  <select
-                    value={einheit.einheitsgroesse}
-                    onChange={(e) => updateEinheit(idx, 'einheitsgroesse', e.target.value)}
-                  >
-                    {UNIT_SIZES.map((u) => (
-                      <option key={u.value} value={u.value}>{u.label}</option>
-                    ))}
-                  </select>
+                  <span>{nameDrinkDisplay.isRecipe ? 'Einheitsgröße (ml)' : 'Einheitsgröße'}</span>
+                  {nameDrinkDisplay.isRecipe ? (
+                    <input
+                      type="number"
+                      min="1"
+                      step="1"
+                      value={
+                        einheit.einheitsgroesse !== '' && einheit.einheitsgroesse !== null && einheit.einheitsgroesse !== undefined
+                          ? Math.round(Number(einheit.einheitsgroesse) * 1000)
+                          : ''
+                      }
+                      onChange={(e) => {
+                        const ml = e.target.value;
+                        updateEinheit(idx, 'einheitsgroesse', ml === '' ? '' : Number(ml) / 1000);
+                      }}
+                      placeholder="z. B. 250"
+                    />
+                  ) : (
+                    <select
+                      value={einheit.einheitsgroesse}
+                      onChange={(e) => updateEinheit(idx, 'einheitsgroesse', e.target.value)}
+                    >
+                      {UNIT_SIZES.map((u) => (
+                        <option key={u.value} value={u.value}>{u.label}</option>
+                      ))}
+                    </select>
+                  )}
                 </label>
                 <label className="events-form-field">
                   <span>Gebindeinheit</span>

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -450,6 +450,49 @@ describe('DrinkManagementPage', () => {
       expect(nameInput).not.toHaveAttribute('readonly');
     });
 
+    test('shows a free-form ml input for Einheitsgröße instead of the dropdown when the drink is linked to a recipe', () => {
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#Mojito' } });
+      fireEvent.click(screen.getByText('Mojito'));
+
+      expect(screen.getByText('Einheitsgröße (ml)')).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton', { name: 'Einheitsgröße (ml)' })).toBeInTheDocument();
+      expect(screen.queryByText('Einheitsgröße')).not.toBeInTheDocument();
+    });
+
+    test('saving a recipe-linked drink converts the entered ml value to liters', async () => {
+      mockSaveCustomDrink.mockResolvedValue('new-drink-id');
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+      fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: '#Mojito' } });
+      fireEvent.click(screen.getByText('Mojito'));
+
+      fireEvent.change(screen.getByRole('spinbutton', { name: 'Einheitsgröße (ml)' }), { target: { value: '250' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+      await waitFor(() => {
+        expect(mockSaveCustomDrink).toHaveBeenCalledWith(
+          currentUser.id,
+          expect.objectContaining({
+            einheiten: [expect.objectContaining({ einheitsgroesse: 0.25 })],
+          }),
+          undefined,
+        );
+      });
+    });
+
+    test('keeps the Einheitsgröße dropdown for drinks that are not linked to a recipe', () => {
+      render(<DrinkManagementPage currentUser={currentUser} recipes={recipes} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+
+      expect(screen.getByText('Einheitsgröße')).toBeInTheDocument();
+      expect(screen.queryByText('Einheitsgröße (ml)')).not.toBeInTheDocument();
+    });
+
     test('the drink list shows the linked recipe name instead of the raw link', () => {
       mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
         cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);


### PR DESCRIPTION
Getränke, deren Name mit einem Drinkrezept verlinkt ist, erhalten
statt des Einheitsgröße-Dropdowns ein freies Zahlenfeld in ml.
Alle anderen Getränke behalten das bestehende Dropdown. Intern wird
der Wert weiterhin in Litern gespeichert, damit bestehende
Berechnungen unverändert funktionieren.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018GBsPCxTc5Ro5zTjWYDNmD