### PR TITLE
Neues Feld "Einheit" für Getränke hinzufügen

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -46,6 +46,7 @@ const getUnitSizeLabel = (liters) => {
 
 const emptyEinheit = () => ({
   einheitsgroesse: 0.5,
+  einheit: '',
   gebindeinheit: '',
   einheitenProGebinde: '',
 });
@@ -176,6 +177,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [packageUnits, setPackageUnits] = useState([]);
+  const [drinkUnits, setDrinkUnits] = useState([]);
   const [showNameTypeahead, setShowNameTypeahead] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
@@ -189,8 +191,10 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   useEffect(() => {
     getCustomLists().then((lists) => {
       setPackageUnits(lists.packageUnits || []);
+      setDrinkUnits(lists.drinkUnits || []);
     }).catch(() => {
       setPackageUnits([]);
+      setDrinkUnits([]);
     });
     import('../utils/customLists').then(({ getButtonIcons }) => {
       getButtonIcons().then((icons) => setButtonIcons(icons)).catch(() => {});
@@ -246,6 +250,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
         Array.isArray(drink.einheiten) && drink.einheiten.length > 0
           ? drink.einheiten.map((e) => ({
               einheitsgroesse: e.einheitsgroesse ?? 0.5,
+              einheit: e.einheit || '',
               gebindeinheit: e.gebindeinheit || '',
               einheitenProGebinde: e.einheitenProGebinde ?? '',
             }))
@@ -330,6 +335,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
         ...(isPredefined ? {} : { name: form.name.trim(), kategorie: form.kategorie || null }),
         einheiten: form.einheiten.map((e) => {
           const einheit = { einheitsgroesse: Number(e.einheitsgroesse) };
+          const einheitTrimmed = String(e.einheit || '').trim();
+          if (einheitTrimmed) einheit.einheit = einheitTrimmed;
           const gebindeinheitTrimmed = String(e.gebindeinheit || '').trim();
           if (gebindeinheitTrimmed) einheit.gebindeinheit = gebindeinheitTrimmed;
           if (e.einheitenProGebinde !== '' && e.einheitenProGebinde !== null && e.einheitenProGebinde !== undefined) {
@@ -438,77 +445,102 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
           <div className="events-form-field">
             <span>Einheiten</span>
             {form.einheiten.map((einheit, idx) => (
-              <div key={idx} className="events-form-row events-einheit-row">
-                <label className="events-form-field">
-                  <span>{nameDrinkDisplay.isRecipe ? 'Einheitsgröße (ml)' : 'Einheitsgröße'}</span>
-                  {nameDrinkDisplay.isRecipe ? (
+              <div key={idx} className="events-einheit-group">
+                <div className="events-form-row events-einheit-row">
+                  <label className="events-form-field">
+                    <span>{nameDrinkDisplay.isRecipe ? 'Einheitsgröße (ml)' : 'Einheitsgröße'}</span>
+                    {nameDrinkDisplay.isRecipe ? (
+                      <input
+                        type="number"
+                        min="1"
+                        step="1"
+                        value={
+                          einheit.einheitsgroesse !== '' && einheit.einheitsgroesse !== null && einheit.einheitsgroesse !== undefined
+                            ? Math.round(Number(einheit.einheitsgroesse) * 1000)
+                            : ''
+                        }
+                        onChange={(e) => {
+                          const ml = e.target.value;
+                          updateEinheit(idx, 'einheitsgroesse', ml === '' ? '' : Number(ml) / 1000);
+                        }}
+                        placeholder="z. B. 250"
+                      />
+                    ) : (
+                      <select
+                        value={einheit.einheitsgroesse}
+                        onChange={(e) => updateEinheit(idx, 'einheitsgroesse', e.target.value)}
+                      >
+                        {UNIT_SIZES.map((u) => (
+                          <option key={u.value} value={u.value}>{u.label}</option>
+                        ))}
+                      </select>
+                    )}
+                  </label>
+                  <label className="events-form-field">
+                    <span>Einheit</span>
+                    {drinkUnits.length > 0 ? (
+                      <select
+                        value={einheit.einheit}
+                        onChange={(e) => updateEinheit(idx, 'einheit', e.target.value)}
+                      >
+                        <option value="">Keine Angabe</option>
+                        {drinkUnits.map((unit) => (
+                          <option key={unit.id} value={unit.singular}>{unit.singular}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        type="text"
+                        value={einheit.einheit}
+                        onChange={(e) => updateEinheit(idx, 'einheit', e.target.value)}
+                        placeholder="z. B. Glas, Flasche, Dose"
+                      />
+                    )}
+                  </label>
+                </div>
+                <div className="events-form-row events-einheit-row">
+                  <label className="events-form-field">
+                    <span>Einheiten pro Gebinde</span>
                     <input
                       type="number"
                       min="1"
                       step="1"
-                      value={
-                        einheit.einheitsgroesse !== '' && einheit.einheitsgroesse !== null && einheit.einheitsgroesse !== undefined
-                          ? Math.round(Number(einheit.einheitsgroesse) * 1000)
-                          : ''
-                      }
-                      onChange={(e) => {
-                        const ml = e.target.value;
-                        updateEinheit(idx, 'einheitsgroesse', ml === '' ? '' : Number(ml) / 1000);
-                      }}
-                      placeholder="z. B. 250"
+                      value={einheit.einheitenProGebinde}
+                      onChange={(e) => updateEinheit(idx, 'einheitenProGebinde', e.target.value)}
                     />
-                  ) : (
-                    <select
-                      value={einheit.einheitsgroesse}
-                      onChange={(e) => updateEinheit(idx, 'einheitsgroesse', e.target.value)}
+                  </label>
+                  <label className="events-form-field">
+                    <span>Gebindeinheit</span>
+                    {packageUnits.length > 0 ? (
+                      <select
+                        value={einheit.gebindeinheit}
+                        onChange={(e) => updateEinheit(idx, 'gebindeinheit', e.target.value)}
+                      >
+                        <option value="">Keine Angabe</option>
+                        {packageUnits.map((unit) => (
+                          <option key={unit.id} value={unit.singular}>{unit.singular}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        type="text"
+                        value={einheit.gebindeinheit}
+                        onChange={(e) => updateEinheit(idx, 'gebindeinheit', e.target.value)}
+                        placeholder="z. B. Flasche, Dose, Kasten"
+                      />
+                    )}
+                  </label>
+                  {form.einheiten.length > 1 && (
+                    <button
+                      type="button"
+                      className="events-secondary-btn"
+                      onClick={() => removeEinheit(idx)}
+                      aria-label="Einheit entfernen"
                     >
-                      {UNIT_SIZES.map((u) => (
-                        <option key={u.value} value={u.value}>{u.label}</option>
-                      ))}
-                    </select>
+                      –
+                    </button>
                   )}
-                </label>
-                <label className="events-form-field">
-                  <span>Gebindeinheit</span>
-                  {packageUnits.length > 0 ? (
-                    <select
-                      value={einheit.gebindeinheit}
-                      onChange={(e) => updateEinheit(idx, 'gebindeinheit', e.target.value)}
-                    >
-                      <option value="">Keine Angabe</option>
-                      {packageUnits.map((unit) => (
-                        <option key={unit.id} value={unit.singular}>{unit.singular}</option>
-                      ))}
-                    </select>
-                  ) : (
-                    <input
-                      type="text"
-                      value={einheit.gebindeinheit}
-                      onChange={(e) => updateEinheit(idx, 'gebindeinheit', e.target.value)}
-                      placeholder="z. B. Flasche, Dose, Kasten"
-                    />
-                  )}
-                </label>
-                <label className="events-form-field">
-                  <span>Einheiten pro Gebinde</span>
-                  <input
-                    type="number"
-                    min="1"
-                    step="1"
-                    value={einheit.einheitenProGebinde}
-                    onChange={(e) => updateEinheit(idx, 'einheitenProGebinde', e.target.value)}
-                  />
-                </label>
-                {form.einheiten.length > 1 && (
-                  <button
-                    type="button"
-                    className="events-secondary-btn"
-                    onClick={() => removeEinheit(idx)}
-                    aria-label="Einheit entfernen"
-                  >
-                    –
-                  </button>
-                )}
+                </div>
               </div>
             ))}
             <button

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -152,12 +152,13 @@ describe('DrinkManagementPage', () => {
     expect(screen.queryByLabelText(/Distributionsfaktor/i)).not.toBeInTheDocument();
   });
 
-  test('form contains new unit fields (Einheitsgröße, Gebindeinheit, Einheiten pro Gebinde)', () => {
+  test('form contains new unit fields (Einheitsgröße, Einheit, Gebindeinheit, Einheiten pro Gebinde)', () => {
     render(<DrinkManagementPage currentUser={currentUser} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
 
     expect(screen.getByText('Einheitsgröße')).toBeInTheDocument();
+    expect(screen.getByText('Einheit')).toBeInTheDocument();
     expect(screen.getByText('Gebindeinheit')).toBeInTheDocument();
     expect(screen.getByText('Einheiten pro Gebinde')).toBeInTheDocument();
   });
@@ -169,6 +170,10 @@ describe('DrinkManagementPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
 
     fireEvent.change(screen.getByRole('textbox', { name: /Name/i }), { target: { value: 'Craft-Bier' } });
+
+    // Fill the Einheit field
+    const einheitInput = screen.getByPlaceholderText('z. B. Glas, Flasche, Dose');
+    fireEvent.change(einheitInput, { target: { value: 'Glas' } });
 
     // Fill the Gebindeinheit field
     const gebindeinheitInput = screen.getByPlaceholderText('z. B. Flasche, Dose, Kasten');
@@ -188,6 +193,7 @@ describe('DrinkManagementPage', () => {
           einheiten: [
             expect.objectContaining({
               einheitsgroesse: 0.5,
+              einheit: 'Glas',
               gebindeinheit: 'Flasche',
               einheitenProGebinde: 24,
             }),
@@ -322,6 +328,44 @@ describe('DrinkManagementPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
 
     expect(screen.getByPlaceholderText('z. B. Flasche, Dose, Kasten')).toBeInTheDocument();
+  });
+
+  test('shows einheit as select when drinkUnits are configured', async () => {
+    mockGetCustomLists.mockResolvedValue({
+      packageUnits: [],
+      drinkUnits: [
+        { id: 'glas', singular: 'Glas', plural: 'Gläser' },
+        { id: 'flasche', singular: 'Flasche', plural: 'Flaschen' },
+        { id: 'dose', singular: 'Dose', plural: 'Dosen' },
+      ],
+    });
+
+    render(<DrinkManagementPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+
+    await waitFor(() => {
+      const selects = screen.getAllByRole('combobox');
+      const einheitSelect = selects.find((s) =>
+        s.querySelector('option[value="Glas"]')
+      );
+      expect(einheitSelect).toBeTruthy();
+      const options = within(einheitSelect).getAllByRole('option').map((o) => o.textContent);
+      expect(options).toContain('Glas');
+      expect(options).toContain('Flasche');
+      expect(options).toContain('Dose');
+    });
+
+    // Text input should not be visible when select is shown
+    expect(screen.queryByPlaceholderText('z. B. Glas, Flasche, Dose')).not.toBeInTheDocument();
+  });
+
+  test('shows einheit as text input when no drinkUnits are configured', () => {
+    render(<DrinkManagementPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Getränk anlegen' }));
+
+    expect(screen.getByPlaceholderText('z. B. Glas, Flasche, Dose')).toBeInTheDocument();
   });
 
   test('renders the FAB save button in the edit form', () => {

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -275,6 +275,18 @@
   min-width: 140px;
 }
 
+.events-einheit-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.events-einheit-group + .events-einheit-group {
+  margin-top: 8px;
+  padding-top: 16px;
+  border-top: 1px solid #eee;
+}
+
 .events-consumption-group {
   display: flex;
   flex-direction: column;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -234,6 +234,7 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
     units: [],
     portionUnits: [],
     packageUnits: [],
+    drinkUnits: [],
     conversionTable: [],
     customUnits: []
   });
@@ -245,6 +246,8 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
   const [newPortionPlural, setNewPortionPlural] = useState('');
   const [newPackageSingular, setNewPackageSingular] = useState('');
   const [newPackagePlural, setNewPackagePlural] = useState('');
+  const [newDrinkUnitSingular, setNewDrinkUnitSingular] = useState('');
+  const [newDrinkUnitPlural, setNewDrinkUnitPlural] = useState('');
   const [newConversionIngredient, setNewConversionIngredient] = useState('');
   const [newConversionUnit, setNewConversionUnit] = useState('');
   const [newConversionGrams, setNewConversionGrams] = useState('');
@@ -951,6 +954,32 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
     });
   };
 
+  const addDrinkUnit = () => {
+    if (newDrinkUnitSingular.trim() && newDrinkUnitPlural.trim()) {
+      const newId = newDrinkUnitSingular.toLowerCase().replace(/\s+/g, '-');
+      const exists = lists.drinkUnits.some(u => u.id === newId);
+      if (!exists) {
+        setLists({
+          ...lists,
+          drinkUnits: [...lists.drinkUnits, {
+            id: newId,
+            singular: newDrinkUnitSingular.trim(),
+            plural: newDrinkUnitPlural.trim()
+          }]
+        });
+        setNewDrinkUnitSingular('');
+        setNewDrinkUnitPlural('');
+      }
+    }
+  };
+
+  const removeDrinkUnit = (unitId) => {
+    setLists({
+      ...lists,
+      drinkUnits: lists.drinkUnits.filter(u => u.id !== unitId)
+    });
+  };
+
   const addConversionEntry = () => {
     if (newConversionIngredient.trim() && newConversionUnit.trim()) {
       const slugify = (str) => str.toLowerCase()
@@ -1091,6 +1120,20 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
         return {
           ...prevLists,
           packageUnits: arrayMove(prevLists.packageUnits, oldIndex, newIndex)
+        };
+      });
+    }
+  };
+
+  const handleDragEndDrinkUnits = (event) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setLists((prevLists) => {
+        const oldIndex = prevLists.drinkUnits.findIndex(u => u.id === active.id);
+        const newIndex = prevLists.drinkUnits.findIndex(u => u.id === over.id);
+        return {
+          ...prevLists,
+          drinkUnits: arrayMove(prevLists.drinkUnits, oldIndex, newIndex)
         };
       });
     }
@@ -2737,6 +2780,38 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
               <div className="list-items">
                 {lists.packageUnits.map((unit) => (
                   <SortablePortionUnitItem key={unit.id} id={unit.id} unit={unit} onRemove={() => removePackageUnit(unit.id)} />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        <div className="settings-section">
+          <h3>Getränkeeinheiten</h3>
+          <p className="section-description">
+            Definieren Sie die verfügbaren Einheiten für Getränke mit Singular- und Pluralformen (z.B. Glas/Gläser, Flasche/Flaschen).
+          </p>
+          <div className="list-input portion-unit-input">
+            <input
+              type="text"
+              value={newDrinkUnitSingular}
+              onChange={(e) => setNewDrinkUnitSingular(e.target.value)}
+              placeholder="Singular (z.B. Glas)"
+            />
+            <input
+              type="text"
+              value={newDrinkUnitPlural}
+              onChange={(e) => setNewDrinkUnitPlural(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && addDrinkUnit()}
+              placeholder="Plural (z.B. Gläser)"
+            />
+            <button onClick={addDrinkUnit}>Hinzufügen</button>
+          </div>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEndDrinkUnits}>
+            <SortableContext items={lists.drinkUnits.map(u => u.id)} strategy={verticalListSortingStrategy}>
+              <div className="list-items">
+                {lists.drinkUnits.map((unit) => (
+                  <SortablePortionUnitItem key={unit.id} id={unit.id} unit={unit} onRemove={() => removeDrinkUnit(unit.id)} />
                 ))}
               </div>
             </SortableContext>

--- a/src/utils/customLists.js
+++ b/src/utils/customLists.js
@@ -143,6 +143,13 @@ export const DEFAULT_PACKAGE_UNITS = [
   { id: 'fass', singular: 'Fass', plural: 'Fässer' },
 ];
 
+export const DEFAULT_DRINK_UNITS = [
+  { id: 'glas', singular: 'Glas', plural: 'Gläser' },
+  { id: 'flasche', singular: 'Flasche', plural: 'Flaschen' },
+  { id: 'dose', singular: 'Dose', plural: 'Dosen' },
+  { id: 'becher', singular: 'Becher', plural: 'Becher' },
+];
+
 /**
  * Normalizes packageUnits array – converts legacy plain strings to the
  * new `{ id, singular, plural }` object shape for backward compatibility.
@@ -1109,6 +1116,7 @@ export async function getSettings() {
         units: settings.units || DEFAULT_UNITS,
         portionUnits: settings.portionUnits || DEFAULT_PORTION_UNITS,
         packageUnits: normalizePackageUnits(settings.packageUnits ?? DEFAULT_PACKAGE_UNITS),
+        drinkUnits: settings.drinkUnits || DEFAULT_DRINK_UNITS,
         conversionTable: settings.conversionTable || DEFAULT_CONVERSION_TABLE,
         customUnits: settings.customUnits || [],
         customIngredientAdjectives: settings.customIngredientAdjectives || [],
@@ -1160,6 +1168,7 @@ export async function getSettings() {
       units: DEFAULT_UNITS,
       portionUnits: DEFAULT_PORTION_UNITS,
       packageUnits: DEFAULT_PACKAGE_UNITS,
+      drinkUnits: DEFAULT_DRINK_UNITS,
       conversionTable: DEFAULT_CONVERSION_TABLE,
       customIngredientAdjectives: [],
       headerSlogan: DEFAULT_SLOGAN,
@@ -1217,6 +1226,7 @@ export async function getSettings() {
       units: DEFAULT_UNITS,
       portionUnits: DEFAULT_PORTION_UNITS,
       packageUnits: DEFAULT_PACKAGE_UNITS,
+      drinkUnits: DEFAULT_DRINK_UNITS,
       conversionTable: DEFAULT_CONVERSION_TABLE,
       customIngredientAdjectives: [],
       headerSlogan: DEFAULT_SLOGAN,
@@ -1270,6 +1280,7 @@ export async function getCustomLists() {
     units: settings.units ?? DEFAULT_UNITS,
     portionUnits: settings.portionUnits ?? DEFAULT_PORTION_UNITS,
     packageUnits: normalizePackageUnits(settings.packageUnits ?? DEFAULT_PACKAGE_UNITS),
+    drinkUnits: settings.drinkUnits ?? DEFAULT_DRINK_UNITS,
     conversionTable: settings.conversionTable ?? DEFAULT_CONVERSION_TABLE,
     customUnits: [],
     customIngredientAdjectives: [],
@@ -1529,6 +1540,7 @@ export async function resetCustomLists() {
     units: DEFAULT_UNITS,
     portionUnits: DEFAULT_PORTION_UNITS,
     packageUnits: DEFAULT_PACKAGE_UNITS,
+    drinkUnits: DEFAULT_DRINK_UNITS,
     conversionTable: DEFAULT_CONVERSION_TABLE
   };
   

--- a/src/utils/customLists.test.js
+++ b/src/utils/customLists.test.js
@@ -38,6 +38,7 @@ import {
   DEFAULT_COMMON_ADJECTIVES,
   DEFAULT_PORTION_UNITS,
   DEFAULT_PACKAGE_UNITS,
+  DEFAULT_DRINK_UNITS,
   DEFAULT_CONVERSION_TABLE,
   expandCuisineSelection,
   getParentCuisineNames,
@@ -228,6 +229,7 @@ describe('getCustomLists – default fallbacks', () => {
     expect(lists.units).toEqual(DEFAULT_UNITS);
     expect(lists.portionUnits).toEqual(DEFAULT_PORTION_UNITS);
     expect(lists.packageUnits).toEqual(DEFAULT_PACKAGE_UNITS);
+    expect(lists.drinkUnits).toEqual(DEFAULT_DRINK_UNITS);
     expect(lists.conversionTable).toEqual(DEFAULT_CONVERSION_TABLE);
   });
 
@@ -283,6 +285,26 @@ describe('getCustomLists – default fallbacks', () => {
     expect(lists.packageUnits[0]).toEqual({ id: 'flasche', singular: 'Flasche', plural: 'Flasche' });
     expect(lists.packageUnits[1]).toEqual({ id: 'dose', singular: 'Dose', plural: 'Dose' });
     expect(lists.packageUnits[2]).toEqual({ id: 'sondergebinde', singular: 'Sondergebinde', plural: 'Sondergebinde' });
+  });
+
+  test('returns saved drinkUnits from Firestore instead of defaults', async () => {
+    const savedDrinkUnits = [
+      { id: 'glas', singular: 'Glas', plural: 'Gläser' },
+      { id: 'shot', singular: 'Shot', plural: 'Shots' },
+    ];
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({
+        drinkUnits: savedDrinkUnits,
+        aiRecipePrompt: DEFAULT_AI_RECIPE_PROMPT,
+      }),
+    });
+
+    const lists = await getCustomLists();
+
+    expect(lists.drinkUnits).toEqual(savedDrinkUnits);
+    expect(lists.drinkUnits).toHaveLength(2);
+    expect(lists.drinkUnits[1].id).toBe('shot');
   });
 
   test('keeps legacy customUnits empty even when Firestore still contains old values', async () => {


### PR DESCRIPTION
Analog zu den Gebindeeinheiten kann in den Einstellungen jetzt eine
Liste konfigurierbarer Einheiten (Singular/Plural) gepflegt werden.
Auf der Getränke-bearbeiten-Seite erscheint das neue Feld "Einheit"
rechts neben "Einheitsgröße"; "Einheiten pro Gebinde" und
"Gebindeeinheit" rücken in die Zeile darunter.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018wf6F7o8TMTWaeA5p5j8Vn