### PR TITLE
Verbrauch erfassen: Einheit als Fallback für fehlende Gebindeeinheit

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -22,7 +22,8 @@ function getRowUnitSubtitle(row) {
     const einheit = row.einheiten[row.einheitIdx];
     if (einheit) {
       const sizeLabel = getEinheitSizeLabel(einheit.einheitsgroesse);
-      return einheit.gebindeinheit ? `${sizeLabel} · ${einheit.gebindeinheit}` : sizeLabel;
+      const unitLabel = einheit.gebindeinheit || einheit.einheit;
+      return unitLabel ? `${sizeLabel} · ${unitLabel}` : sizeLabel;
     }
   }
   if (row.gebindeGroesseLiter) {


### PR DESCRIPTION
Wenn ein Getränk keine Gebindeeinheit gepflegt hat, zeigt die
Untertitel-Zeile jetzt die Einheit (z.B. Flasche) statt nur die Größe an.