### PR TITLE
Auto Version Bump: Timeout-Absicherung gegen hängende Runs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.bump.outputs.new_version }}
       bump_type: ${{ steps.determine-bump.outputs.bump_type }}


### PR DESCRIPTION
## Zusammenhang

Nach dem Merge von PR #2817 sind mehrere „Auto Version Bump"-Runs in einen Zustand geraten, in dem sie 15 Minuten liefen bzw. dauerhaft `queued` blieben, statt wie sonst binnen Sekunden durchzulaufen (0 `in_progress`-Runs bei mehreren `queued`-Runs deutet auf eine GitHub-Actions-Runner-Verfügbarkeitsstörung hin, nicht auf einen Fehler im Workflow-Skript selbst).

## Änderung

- `timeout-minutes: 5` für den `bump-version`-Job in `.github/workflows/version-bump.yml` ergänzt.

Damit bricht ein künftiger Hänger nach 5 statt nach 15+ Minuten ab und muss nicht mehr manuell gecancelt werden – zusätzlich bleiben dann nutzbare Logs für die Fehlersuche erhalten (bei den ursprünglichen, manuell gecancelten Runs waren die Logs nicht mehr abrufbar).

## Hinweis

Dies behebt keine zugrunde liegende Infrastruktur-Störung bei GitHub Actions selbst (falls es eine gibt) – dafür bitte kurz https://github.com/settings/billing/summary und https://www.githubstatus.com/ prüfen.

## Test plan

- [ ] Nach dem Merge beobachten, ob der ausgelöste „Auto Version Bump"-Run normal durchläuft oder – falls er wieder hängt – jetzt nach 5 Minuten mit auswertbaren Logs abbricht.


---
_Generated by [Claude Code](https://claude.ai/code/session_019hWSi7Fxn3MCL6cyB1Zjkk)_