### PR TITLE
Eingekauft-Felder auf Verbrauch nachtragen aus Kalkulation vorbefüllen

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -3,6 +3,7 @@ import './EventsPage.css';
 import { submitConsumption } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import { calculateCascadingEinkauf } from '../utils/einkaufCascade';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -49,13 +50,56 @@ function groupKategorienByDrink(kategorien, recipes) {
   return groups;
 }
 
+// Baut die Kaskaden-Einheiten (eigene Groesse + optionale Gebindegroesse) fuer eine Getraenke-Gruppe.
+function getGroupCascadeUnits(group) {
+  return group.rows.map((row) => {
+    if (row.isCustomDrink && Array.isArray(row.einheiten) && row.einheitIdx !== undefined) {
+      const einheit = row.einheiten[row.einheitIdx] || {};
+      const einheitsgroesseLiter = Number(einheit.einheitsgroesse);
+      const stueckProGebinde = Number(einheit.einheitenProGebinde);
+      const gebindeGroesseLiter =
+        Number.isFinite(einheitsgroesseLiter) && Number.isFinite(stueckProGebinde) && stueckProGebinde > 0
+          ? einheitsgroesseLiter * stueckProGebinde
+          : null;
+      return { key: row.kategorie, einheitsgroesseLiter, gebindeGroesseLiter };
+    }
+    return { key: row.kategorie, einheitsgroesseLiter: Number(row.gebindeGroesseLiter), gebindeGroesseLiter: null };
+  });
+}
+
+// Ermittelt den kalkulierten Liter-Bedarf einer Getraenke-Gruppe (identisch fuer alle Zeilen der Gruppe).
+function getGroupBedarfLiter(group) {
+  const row = group.rows[0];
+  const liter = Number(row?.literMitPuffer ?? row?.literOhnePuffer);
+  return Number.isFinite(liter) ? liter : 0;
+}
+
+// Berechnet die kaskadierende Vorbefuellung fuer alle Getraenke-Gruppen.
+function getCascadePrefill(drinkGroups) {
+  const prefillMap = {};
+  const warnings = [];
+  drinkGroups.forEach((group) => {
+    const units = getGroupCascadeUnits(group);
+    const bedarfLiter = getGroupBedarfLiter(group);
+    const { values: cascadeValues, warnings: groupWarnings } = calculateCascadingEinkauf(units, bedarfLiter);
+    Object.assign(prefillMap, cascadeValues);
+    groupWarnings.forEach((warning) => warnings.push(`${group.drinkName}: ${warning}`));
+  });
+  return { prefillMap, warnings };
+}
+
 function ConsumptionForm({ event, recipes, onDone, onCancel }) {
   const kategorien = (event.berechnung?.ergebnis || []).filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter);
   const drinkGroups = groupKategorienByDrink(kategorien, recipes);
+  const { prefillMap, warnings: prefillWarnings } = getCascadePrefill(drinkGroups);
   const [values, setValues] = useState(() => {
     const initial = {};
     kategorien.forEach((row) => {
-      initial[row.kategorie] = { eingekauft: '', uebrig: '' };
+      const prefillValue = prefillMap[row.kategorie];
+      initial[row.kategorie] = {
+        eingekauft: prefillValue !== undefined && prefillValue !== null ? String(prefillValue) : '',
+        uebrig: '',
+      };
     });
     return initial;
   });
@@ -141,7 +185,15 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
       </div>
       <p className="events-info-text">
         Wie viele Gebinde wurden für „{event.eventName}" eingekauft, und wie viele sind übrig?
+        {' '}Die Eingekauft-Felder sind bereits aus der Kalkulation vorbefüllt und lassen sich anpassen.
       </p>
+      {prefillWarnings.length > 0 && (
+        <div className="events-warnings">
+          {prefillWarnings.map((warning, idx) => (
+            <p key={idx} className="events-warning-text">{warning}</p>
+          ))}
+        </div>
+      )}
       <form className="events-form" onSubmit={handleSubmit}>
         {drinkGroups.map((group) => (
           <div className="events-consumption-group" key={group.key}>
@@ -156,6 +208,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
                   <input
                     type="number"
                     min="0"
+                    step="0.01"
                     value={values[row.kategorie].eingekauft}
                     onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
                   />

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ConsumptionForm from './ConsumptionForm';
+
+const mockSubmitConsumption = jest.fn();
+
+jest.mock('../utils/eventsFirestore', () => ({
+  submitConsumption: (...args) => mockSubmitConsumption(...args),
+}));
+
+jest.mock('./EventForm', () => ({
+  CATEGORY_LABELS: { wasser: 'Wasser' },
+}));
+
+function makeEvent(ergebnis) {
+  return {
+    id: 'event1',
+    eventName: 'Testfest',
+    berechnung: { ergebnis },
+  };
+}
+
+describe('ConsumptionForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
+    const einheiten = [
+      { einheitsgroesse: 50, einheit: 'Fass', gebindeinheit: '', einheitenProGebinde: '' },
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink1:0',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 62.7,
+        gebinde: null,
+        gebindeGroesseLiter: 50,
+        einheiten,
+      },
+      {
+        kategorie: 'drink1:1',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 1,
+        literMitPuffer: 62.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
+    expect(eingekauftInputs).toHaveLength(2);
+    expect(eingekauftInputs[0]).toHaveValue(1);
+    expect(eingekauftInputs[1]).toHaveValue(1.75);
+  });
+
+  it('befüllt die einzige Einheit korrekt, wenn ein Getränk nur eine Einheit hat', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    const eingekauftInput = screen.getByLabelText('Eingekauft');
+    expect(eingekauftInput).toHaveValue(1.75);
+  });
+
+  it('lässt das Feld leer und zeigt eine Warnung, wenn eine Einheitsgröße fehlt', () => {
+    const einheiten = [
+      { einheitsgroesse: 0, einheit: 'Flasche', gebindeinheit: '', einheitenProGebinde: '' },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink3:0',
+        drinkId: 'drink3',
+        drinkLabel: 'Limo',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 10,
+        gebinde: null,
+        gebindeGroesseLiter: 0.5,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    const eingekauftInput = screen.getByLabelText('Eingekauft');
+    expect(eingekauftInput).toHaveValue(null);
+    expect(screen.getByText(/Limo:.*keine gültige/)).toBeInTheDocument();
+  });
+});

--- a/src/utils/einkaufCascade.js
+++ b/src/utils/einkaufCascade.js
@@ -1,0 +1,89 @@
+/**
+ * Kaskadierende Verteilung des kalkulierten Liter-Bedarfs eines Getraenks
+ * auf die "Eingekauft"-Felder seiner Einheiten (z.B. Fass + Flasche).
+ */
+
+// Rundungsstufen fuer die kleinste Einheit, aufsteigend sortiert.
+const ROUNDING_STAGES = [1 / 4, 1 / 3, 1 / 2, 3 / 4, 1];
+const EPSILON = 1e-9;
+
+/**
+ * Rundet einen Wert auf die naechsthoehere Stufe aus ROUNDING_STAGES.
+ * Beispiele: 1,604 -> 1,75 | 2,4 -> 2,5 | 2,8 -> 3,0
+ * @param {number} value Zu rundender Wert (z.B. Rest / Gebindegroesse).
+ * @return {number} Gerundeter Wert.
+ */
+function roundToNextStage(value) {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  const floorVal = Math.floor(value);
+  const frac = value - floorVal;
+  if (frac < EPSILON) return floorVal;
+  const stage = ROUNDING_STAGES.find((s) => frac <= s + EPSILON) ?? 1;
+  return Math.round((floorVal + stage) * 1000) / 1000;
+}
+
+/**
+ * Verteilt den Liter-Bedarf eines Getraenks kaskadierend auf seine Einheiten.
+ *
+ * Ablauf: Einheiten werden nach ihrer eigenen Groesse (Liter) absteigend
+ * sortiert. Fuer alle bis auf die kleinste Einheit wird ganzzahlig so viel
+ * wie moeglich vom Restbedarf abgezogen (floor). Die kleinste Einheit erhaelt
+ * den verbleibenden Rest, umgerechnet in ihre Gebindegroesse (falls vorhanden,
+ * sonst ihre eigene Groesse) und auf die naechste Rundungsstufe aufgerundet.
+ *
+ * @param {Array<{key: string, einheitsgroesseLiter: number, gebindeGroesseLiter?: number|null}>} units
+ *   Einheiten des Getraenks. `einheitsgroesseLiter` ist die Groesse der Einheit selbst
+ *   (z.B. Flasche = 0,33), `gebindeGroesseLiter` optional die Groesse ihrer Gebindeeinheit
+ *   (z.B. Kasten = 7,92).
+ * @param {number} bedarfLiter Kalkulierter Bedarf in Litern.
+ * @return {{values: Object<string, number|null>, warnings: string[]}}
+ *   `values` mappt den `key` jeder Einheit auf den vorbefuellten Wert (null bei fehlender Groesse).
+ */
+export function calculateCascadingEinkauf(units, bedarfLiter) {
+  const values = {};
+  const warnings = [];
+
+  if (!Array.isArray(units) || units.length === 0) {
+    return { values, warnings };
+  }
+
+  const validUnits = [];
+  units.forEach((unit) => {
+    const size = Number(unit.einheitsgroesseLiter);
+    if (!Number.isFinite(size) || size <= 0) {
+      values[unit.key] = null;
+      warnings.push(`Einheit "${unit.key}" hat keine gültige Größe (Liter) - Feld bleibt leer.`);
+      return;
+    }
+    validUnits.push({ ...unit, einheitsgroesseLiter: size });
+  });
+
+  if (validUnits.length === 0) {
+    return { values, warnings };
+  }
+
+  const sorted = [...validUnits].sort((a, b) => b.einheitsgroesseLiter - a.einheitsgroesseLiter);
+  const smallest = sorted[sorted.length - 1];
+  const grossUnits = sorted.slice(0, -1);
+
+  let rest = Number(bedarfLiter);
+  if (!Number.isFinite(rest) || rest < 0) rest = 0;
+
+  grossUnits.forEach((unit) => {
+    const anzahl = Math.floor(rest / unit.einheitsgroesseLiter);
+    rest -= anzahl * unit.einheitsgroesseLiter;
+    values[unit.key] = anzahl;
+  });
+
+  const gebindeSize = Number(smallest.gebindeGroesseLiter);
+  const basisLiter = Number.isFinite(gebindeSize) && gebindeSize > 0 ? gebindeSize : smallest.einheitsgroesseLiter;
+
+  if (!Number.isFinite(basisLiter) || basisLiter <= 0) {
+    values[smallest.key] = null;
+    warnings.push(`Einheit "${smallest.key}" hat keine gültige Gebinde-/Einheitsgröße - Feld bleibt leer.`);
+  } else {
+    values[smallest.key] = roundToNextStage(rest / basisLiter);
+  }
+
+  return { values, warnings };
+}

--- a/src/utils/einkaufCascade.test.js
+++ b/src/utils/einkaufCascade.test.js
@@ -1,0 +1,81 @@
+import { calculateCascadingEinkauf } from './einkaufCascade';
+
+describe('calculateCascadingEinkauf', () => {
+  it('kaskadiert Fass (groß, kein Gebinde) und Flasche (klein, mit Gebinde Kasten)', () => {
+    const units = [
+      { key: 'fass', einheitsgroesseLiter: 50, gebindeGroesseLiter: null },
+      { key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 24 * 0.33 },
+    ];
+    const { values, warnings } = calculateCascadingEinkauf(units, 62.7);
+    expect(values.fass).toBe(1);
+    expect(values.flasche).toBeCloseTo(1.75, 6);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('rundet 2,4 auf 2,5 und 2,8 auf 3,0', () => {
+    const units = [{ key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 1 }];
+    expect(calculateCascadingEinkauf(units, 2.4).values.flasche).toBeCloseTo(2.5, 6);
+    expect(calculateCascadingEinkauf(units, 2.8).values.flasche).toBeCloseTo(3.0, 6);
+  });
+
+  it('funktioniert mit nur einer Einheit (kein Fass, nur Flasche)', () => {
+    const units = [{ key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 7.92 }];
+    const { values, warnings } = calculateCascadingEinkauf(units, 12.7);
+    expect(values.flasche).toBeCloseTo(1.75, 6);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('lässt das Feld leer und warnt, wenn eine große Einheit keine Größe hat', () => {
+    const units = [
+      { key: 'fass', einheitsgroesseLiter: 0, gebindeGroesseLiter: null },
+      { key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 7.92 },
+    ];
+    const { values, warnings } = calculateCascadingEinkauf(units, 62.7);
+    expect(values.fass).toBeNull();
+    // Fass entfällt komplett, voller Bedarf (62.7) geht auf die Flasche: 62.7 / 7.92 = 7.9166... -> Stufe 1 -> 8.0
+    expect(values.flasche).toBeCloseTo(8.0, 6);
+    expect(warnings.length).toBe(1);
+  });
+
+  it('lässt eine mittlere Einheit ohne gültige Größe aus, ohne die übrigen Einheiten zu stören', () => {
+    const units = [
+      { key: 'fass', einheitsgroesseLiter: 50, gebindeGroesseLiter: null },
+      { key: 'mittelgebinde', einheitsgroesseLiter: 0, gebindeGroesseLiter: null },
+      { key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 24 * 0.33 },
+    ];
+    const { values, warnings } = calculateCascadingEinkauf(units, 62.7);
+    expect(values.fass).toBe(1);
+    expect(values.mittelgebinde).toBeNull();
+    expect(values.flasche).toBeCloseTo(1.75, 6);
+    expect(warnings.length).toBe(1);
+  });
+
+  it('lässt das Feld leer und warnt, wenn die einzige (kleinste) Einheit keine gültige Größe hat', () => {
+    const units = [{ key: 'flasche', einheitsgroesseLiter: 0, gebindeGroesseLiter: null }];
+    const { values, warnings } = calculateCascadingEinkauf(units, 62.7);
+    expect(values.flasche).toBeNull();
+    expect(warnings.length).toBe(1);
+  });
+
+  it('nutzt die eigene Größe als Basis, wenn keine Gebindeeinheit vorhanden ist', () => {
+    const units = [{ key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: null }];
+    const { values } = calculateCascadingEinkauf(units, 0.5);
+    // 0.5 / 0.33 = 1.515... -> nächste Stufe 3/4 -> 1.75
+    expect(values.flasche).toBeCloseTo(1.75, 6);
+  });
+
+  it('gibt leere values zurück, wenn keine Einheiten übergeben werden', () => {
+    expect(calculateCascadingEinkauf([], 10).values).toEqual({});
+    expect(calculateCascadingEinkauf(undefined, 10).values).toEqual({});
+  });
+
+  it('behandelt Bedarf 0 als 0 in allen Feldern', () => {
+    const units = [
+      { key: 'fass', einheitsgroesseLiter: 50, gebindeGroesseLiter: null },
+      { key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 7.92 },
+    ];
+    const { values } = calculateCascadingEinkauf(units, 0);
+    expect(values.fass).toBe(0);
+    expect(values.flasche).toBe(0);
+  });
+});


### PR DESCRIPTION
Neue reine Funktion calculateCascadingEinkauf() verteilt den kalkulierten
Liter-Bedarf eines Getränks kaskadierend auf seine Einheiten: Einheiten
werden absteigend nach Größe sortiert, alle außer der kleinsten werden
ganzzahlig (floor) befüllt, die kleinste Einheit erhält den Rest
umgerechnet in ihre Gebinde-/Einheitsgröße und auf 1/4-Stufen aufgerundet.

ConsumptionForm befüllt die Eingekauft-Felder damit automatisch beim
Öffnen der Seite (nur initial, bestehende Werte werden nie überschrieben)
und zeigt Warnungen an, wenn eine Einheit ohne gültige Größe konfiguriert
ist.