### PR TITLE
Eingekauft-Mengen als Bruch darstellen

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -4,6 +4,7 @@ import { submitConsumption } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { calculateCascadingEinkauf } from '../utils/einkaufCascade';
+import { formatQuantityFraction, parseFractionQuantity } from '../utils/fractionFormat';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -97,7 +98,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
     kategorien.forEach((row) => {
       const prefillValue = prefillMap[row.kategorie];
       initial[row.kategorie] = {
-        eingekauft: prefillValue !== undefined && prefillValue !== null ? String(prefillValue) : '',
+        eingekauft: prefillValue !== undefined && prefillValue !== null ? formatQuantityFraction(prefillValue) : '',
         uebrig: '',
       };
     });
@@ -122,7 +123,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
       const gebinde = {};
       Object.entries(values).forEach(([kategorie, { eingekauft, uebrig }]) => {
         gebinde[kategorie] = {
-          eingekauft: Number(eingekauft) || 0,
+          eingekauft: parseFractionQuantity(eingekauft) || 0,
           uebrig: Number(uebrig) || 0,
         };
       });
@@ -206,9 +207,10 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
                 <label className="events-form-field">
                   <span>Eingekauft</span>
                   <input
-                    type="number"
-                    min="0"
-                    step="0.01"
+                    type="text"
+                    inputMode="text"
+                    placeholder="z.B. 1 3/4"
+                    title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
                     value={values[row.kategorie].eingekauft}
                     onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
                   />

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -59,8 +59,8 @@ describe('ConsumptionForm', () => {
 
     const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
     expect(eingekauftInputs).toHaveLength(2);
-    expect(eingekauftInputs[0]).toHaveValue(1);
-    expect(eingekauftInputs[1]).toHaveValue(1.75);
+    expect(eingekauftInputs[0]).toHaveValue('1');
+    expect(eingekauftInputs[1]).toHaveValue('1 3/4');
   });
 
   it('befüllt die einzige Einheit korrekt, wenn ein Getränk nur eine Einheit hat', () => {
@@ -84,7 +84,7 @@ describe('ConsumptionForm', () => {
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
     const eingekauftInput = screen.getByLabelText('Eingekauft');
-    expect(eingekauftInput).toHaveValue(1.75);
+    expect(eingekauftInput).toHaveValue('1 3/4');
   });
 
   it('lässt das Feld leer und zeigt eine Warnung, wenn eine Einheitsgröße fehlt', () => {
@@ -108,7 +108,7 @@ describe('ConsumptionForm', () => {
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
     const eingekauftInput = screen.getByLabelText('Eingekauft');
-    expect(eingekauftInput).toHaveValue(null);
+    expect(eingekauftInput).toHaveValue('');
     expect(screen.getByText(/Limo:.*keine gültige/)).toBeInTheDocument();
   });
 });

--- a/src/utils/einkaufCascade.js
+++ b/src/utils/einkaufCascade.js
@@ -23,6 +23,20 @@ function roundToNextStage(value) {
 }
 
 /**
+ * Rundet einen Wert auf die naechste ganze Zahl auf (fuer Einheiten ohne
+ * eigene Gebindeeinheit, die nicht in Bruchteilen gekauft werden koennen).
+ * @param {number} value Zu rundender Wert.
+ * @return {number} Aufgerundeter, ganzzahliger Wert.
+ */
+function roundToWholeNumber(value) {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  const floorVal = Math.floor(value);
+  const frac = value - floorVal;
+  if (frac < EPSILON) return floorVal;
+  return floorVal + 1;
+}
+
+/**
  * Verteilt den Liter-Bedarf eines Getraenks kaskadierend auf seine Einheiten.
  *
  * Ablauf: Einheiten werden nach ihrer eigenen Groesse (Liter) absteigend
@@ -76,13 +90,18 @@ export function calculateCascadingEinkauf(units, bedarfLiter) {
   });
 
   const gebindeSize = Number(smallest.gebindeGroesseLiter);
-  const basisLiter = Number.isFinite(gebindeSize) && gebindeSize > 0 ? gebindeSize : smallest.einheitsgroesseLiter;
+  const hatGebindeeinheit = Number.isFinite(gebindeSize) && gebindeSize > 0;
+  const basisLiter = hatGebindeeinheit ? gebindeSize : smallest.einheitsgroesseLiter;
 
   if (!Number.isFinite(basisLiter) || basisLiter <= 0) {
     values[smallest.key] = null;
     warnings.push(`Einheit "${smallest.key}" hat keine gültige Gebinde-/Einheitsgröße - Feld bleibt leer.`);
   } else {
-    values[smallest.key] = roundToNextStage(rest / basisLiter);
+    const verhaeltnis = rest / basisLiter;
+    // Ohne Gebindeeinheit (z.B. lose Flaschen ohne Kasten) wird immer auf
+    // ganze Zahlen aufgerundet, da Bruchteile einer Einheit nicht gekauft
+    // werden koennen.
+    values[smallest.key] = hatGebindeeinheit ? roundToNextStage(verhaeltnis) : roundToWholeNumber(verhaeltnis);
   }
 
   return { values, warnings };

--- a/src/utils/einkaufCascade.test.js
+++ b/src/utils/einkaufCascade.test.js
@@ -57,11 +57,11 @@ describe('calculateCascadingEinkauf', () => {
     expect(warnings.length).toBe(1);
   });
 
-  it('nutzt die eigene Größe als Basis, wenn keine Gebindeeinheit vorhanden ist', () => {
+  it('nutzt die eigene Größe als Basis und rundet ganzzahlig, wenn keine Gebindeeinheit vorhanden ist', () => {
     const units = [{ key: 'flasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: null }];
     const { values } = calculateCascadingEinkauf(units, 0.5);
-    // 0.5 / 0.33 = 1.515... -> nächste Stufe 3/4 -> 1.75
-    expect(values.flasche).toBeCloseTo(1.75, 6);
+    // 0.5 / 0.33 = 1.515... -> ohne Gebindeeinheit ganzzahlig aufgerundet -> 2
+    expect(values.flasche).toBe(2);
   });
 
   it('gibt leere values zurück, wenn keine Einheiten übergeben werden', () => {

--- a/src/utils/fractionFormat.js
+++ b/src/utils/fractionFormat.js
@@ -1,0 +1,75 @@
+/**
+ * Formatierung und Parsing von Mengenangaben als Bruch (z.B. "1/2", "1 3/4")
+ * fuer die Anzeige der "Eingekauft"-Felder.
+ */
+
+const EPSILON = 1e-6;
+const DENOMINATORS = [2, 3, 4];
+
+function gcd(a, b) {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+/**
+ * Formatiert eine Dezimalzahl als Bruch-String fuer die Anzeige.
+ * Beispiele: 1.75 -> "1 3/4" | 0.5 -> "1/2" | 1.333... -> "1 1/3" | 2 -> "2"
+ * Werte ohne passenden Bruch (Halbe/Drittel/Viertel) werden als deutsche
+ * Dezimalzahl mit Komma dargestellt.
+ * @param {number|string} value Zu formatierender Wert.
+ * @return {string} Formatierter Anzeigewert.
+ */
+export function formatQuantityFraction(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '';
+  if (num < 0) return String(value);
+
+  const whole = Math.floor(num + EPSILON);
+  const frac = num - whole;
+
+  if (frac < EPSILON) return String(whole);
+
+  for (const den of DENOMINATORS) {
+    const numerator = Math.round(frac * den);
+    if (numerator > 0 && Math.abs(frac - numerator / den) < EPSILON) {
+      const divisor = gcd(numerator, den);
+      const fracStr = `${numerator / divisor}/${den / divisor}`;
+      return whole > 0 ? `${whole} ${fracStr}` : fracStr;
+    }
+  }
+
+  return num.toLocaleString('de-DE', { maximumFractionDigits: 2 });
+}
+
+/**
+ * Parst eine per Hand eingegebene Mengenangabe (Bruch, gemischte Zahl,
+ * Dezimalzahl mit Punkt oder Komma) in eine Dezimalzahl.
+ * Beispiele: "1 3/4" -> 1.75 | "1/2" -> 0.5 | "2" -> 2 | "1,5" -> 1.5
+ * @param {string} input Roher Eingabetext.
+ * @return {number} Geparster Wert, NaN falls nicht interpretierbar.
+ */
+export function parseFractionQuantity(input) {
+  if (input === null || input === undefined) return NaN;
+  const str = String(input).trim().replace(',', '.');
+  if (str === '') return NaN;
+
+  const mixedMatch = str.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  if (mixedMatch) {
+    const whole = Number(mixedMatch[1]);
+    const numerator = Number(mixedMatch[2]);
+    const denominator = Number(mixedMatch[3]);
+    if (denominator === 0) return NaN;
+    return whole + numerator / denominator;
+  }
+
+  const fracMatch = str.match(/^(\d+)\/(\d+)$/);
+  if (fracMatch) {
+    const numerator = Number(fracMatch[1]);
+    const denominator = Number(fracMatch[2]);
+    if (denominator === 0) return NaN;
+    return numerator / denominator;
+  }
+
+  const num = Number(str);
+  return Number.isFinite(num) ? num : NaN;
+}

--- a/src/utils/fractionFormat.test.js
+++ b/src/utils/fractionFormat.test.js
@@ -1,0 +1,54 @@
+import { formatQuantityFraction, parseFractionQuantity } from './fractionFormat';
+
+describe('formatQuantityFraction', () => {
+  it('formatiert ganze Zahlen ohne Bruch', () => {
+    expect(formatQuantityFraction(2)).toBe('2');
+    expect(formatQuantityFraction(0)).toBe('0');
+  });
+
+  it('formatiert reine Brüche ohne führende Ganzzahl', () => {
+    expect(formatQuantityFraction(0.5)).toBe('1/2');
+    expect(formatQuantityFraction(0.25)).toBe('1/4');
+    expect(formatQuantityFraction(0.75)).toBe('3/4');
+    expect(formatQuantityFraction(1 / 3)).toBe('1/3');
+  });
+
+  it('formatiert gemischte Zahlen (ganze Zahl + Bruch)', () => {
+    expect(formatQuantityFraction(1.75)).toBe('1 3/4');
+    expect(formatQuantityFraction(1 + 1 / 3)).toBe('1 1/3');
+    expect(formatQuantityFraction(2.5)).toBe('2 1/2');
+  });
+
+  it('faellt bei ungewoehnlichen Werten auf Dezimalzahl mit Komma zurueck', () => {
+    expect(formatQuantityFraction(1.6)).toBe('1,6');
+  });
+
+  it('gibt einen leeren String fuer ungueltige Werte zurueck', () => {
+    expect(formatQuantityFraction(null)).toBe('');
+    expect(formatQuantityFraction(undefined)).toBe('');
+    expect(formatQuantityFraction('')).toBe('');
+  });
+});
+
+describe('parseFractionQuantity', () => {
+  it('parst gemischte Brüche', () => {
+    expect(parseFractionQuantity('1 3/4')).toBeCloseTo(1.75, 6);
+    expect(parseFractionQuantity('1 1/3')).toBeCloseTo(1 + 1 / 3, 6);
+  });
+
+  it('parst reine Brüche', () => {
+    expect(parseFractionQuantity('1/2')).toBeCloseTo(0.5, 6);
+  });
+
+  it('parst ganze Zahlen und Dezimalzahlen', () => {
+    expect(parseFractionQuantity('2')).toBe(2);
+    expect(parseFractionQuantity('1,5')).toBeCloseTo(1.5, 6);
+    expect(parseFractionQuantity('1.5')).toBeCloseTo(1.5, 6);
+  });
+
+  it('gibt NaN fuer nicht interpretierbare Eingaben zurueck', () => {
+    expect(Number.isNaN(parseFractionQuantity('abc'))).toBe(true);
+    expect(Number.isNaN(parseFractionQuantity(''))).toBe(true);
+    expect(Number.isNaN(parseFractionQuantity(null))).toBe(true);
+  });
+});


### PR DESCRIPTION
Das "Eingekauft"-Feld auf der Verbrauch-Seite zeigt Mengen jetzt als
Bruch bzw. gemischte Zahl (z.B. "1/2" oder "1 3/4") statt als
Dezimalzahl an. Einheiten ohne eigene Gebindeeinheit werden bei der
Vorbefüllung immer auf ganze Zahlen aufgerundet, da Bruchteile davon
nicht gekauft werden können.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013PqWA4jtsnGLhm3Tz1g6Ah