### PR TITLE
Einkaufsliste aus Event: aktivierte Zutaten, andere Getränke, Icon & Grün-Theme

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -9,6 +9,7 @@ import { useLongPress } from '../utils/useLongPress';
 import { decodeRecipeLink } from '../utils/recipeLinks';
 import { scaleIngredient, combineIngredients, isWaterIngredient, convertIngredientUnits } from '../utils/ingredientUtils';
 import { getCustomLists, getButtonIcons, getEffectiveIcon, getDarkModePreference, addMissingConversionEntries } from '../utils/customLists';
+import { isBase64Image } from '../utils/imageUtils';
 import ShoppingListModal from './ShoppingListModal';
 
 function getEinheitSizeLabel(einheitsgroesse) {
@@ -22,6 +23,15 @@ function getEinheitSizeLabel(einheitsgroesse) {
 function getRowDrinkName(row, recipes) {
   if ((row.isCustomDrink || row.isPredefinedDrink) && row.drinkLabel) return resolveDrinkDisplay(row.drinkLabel, recipes).displayName;
   return CATEGORY_LABELS[row.kategorie] || row.kategorie;
+}
+
+// Gebindeeinheit wenn vorhanden, sonst die Einheit -- fuer die Einkaufsliste.
+function getRowPurchaseUnit(row) {
+  if (row.isCustomDrink && Array.isArray(row.einheiten) && row.einheitIdx !== undefined) {
+    const einheit = row.einheiten[row.einheitIdx];
+    if (einheit) return einheit.gebindeinheit || einheit.einheit || '';
+  }
+  return row.gebinde || '';
 }
 
 function getRowUnitSubtitle(row) {
@@ -114,6 +124,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
   const [changes, setChanges] = useState(null);
   const [conversionTable, setConversionTable] = useState([]);
   const [bringButtonIcon, setBringButtonIcon] = useState('Bring');
+  const [shoppingListIcon, setShoppingListIcon] = useState('Einkauf');
   const [showShoppingListModal, setShowShoppingListModal] = useState(false);
   const [showPortionSelector, setShowPortionSelector] = useState(false);
   const [linkedPortionCounts, setLinkedPortionCounts] = useState({});
@@ -130,22 +141,42 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
       const [icons, lists] = await Promise.all([getButtonIcons(), getCustomLists()]);
       setConversionTable(lists.conversionTable || []);
       setBringButtonIcon(getEffectiveIcon(icons, 'bringButton', getDarkModePreference()) || 'Bring');
+      setShoppingListIcon(getEffectiveIcon(icons, 'shoppingList', getDarkModePreference()) || 'Einkauf');
     };
     loadShoppingListSettings();
   }, []);
 
-  // Recipes linked directly from a drink's name (see resolveDrinkDisplay), deduplicated.
+  // Getraenke-Gruppen aufteilen: mit Rezeptlink (linkedRecipes) vs. ohne (nonRecipeGroups).
   const linkedRecipes = [];
+  const nonRecipeGroups = [];
   {
     const seenIds = new Set();
     drinkGroups.forEach((group) => {
       const display = resolveDrinkDisplay(group.rows[0]?.drinkLabel, recipes);
-      if (display.isRecipe && display.recipe && !seenIds.has(display.recipe.id)) {
-        seenIds.add(display.recipe.id);
-        linkedRecipes.push(display.recipe);
+      if (display.isRecipe && display.recipe) {
+        if (!seenIds.has(display.recipe.id)) {
+          seenIds.add(display.recipe.id);
+          linkedRecipes.push(display.recipe);
+        }
+      } else {
+        nonRecipeGroups.push(group);
       }
     });
   }
+
+  // Getraenke ohne Rezeptlink: in Gebindeeinheit (falls vorhanden, sonst Einheit) uebernehmen.
+  const getOtherDrinkItems = () => {
+    const items = [];
+    nonRecipeGroups.forEach((group) => {
+      group.rows.forEach((row) => {
+        const quantityText = (values[row.kategorie]?.eingekauft || '').trim();
+        if (!quantityText || !parseFractionQuantity(quantityText)) return;
+        const unit = getRowPurchaseUnit(row);
+        items.push(unit ? `${quantityText} ${unit} ${group.drinkName}` : `${quantityText} ${group.drinkName}`);
+      });
+    });
+    return items;
+  };
 
   const getShoppingListIngredients = () => {
     const ingredients = [];
@@ -156,6 +187,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
       (linkedRecipe.ingredients || []).forEach((ing) => {
         const item = typeof ing === 'string' ? { type: 'ingredient', text: ing } : ing;
         if (item.type === 'heading') return;
+        if (item.includedInCalculation === false) return; // nur auf der Getränk-bearbeiten-Karte aktivierte Zutaten
         const text = typeof ing === 'string' ? ing : ing.text;
         if (decodeRecipeLink(text)) return; // skip nested links
         if (isWaterIngredient(text)) return; // skip water
@@ -167,7 +199,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
       missingSavedRef.current = true;
       addMissingConversionEntries(missing, conversionTable).catch(console.error);
     }
-    return combineIngredients(converted);
+    return [...combineIngredients(converted), ...getOtherDrinkItems()];
   };
 
   const handleShoppingListClick = () => {
@@ -300,7 +332,12 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
         {error && <p className="events-error-text">{error}</p>}
 
         <div className="events-form-actions">
-          <button type="button" className="events-secondary-btn" onClick={handleShoppingListClick}>
+          <button type="button" className="events-secondary-btn events-shopping-list-btn" onClick={handleShoppingListClick}>
+            {isBase64Image(shoppingListIcon) ? (
+              <img src={shoppingListIcon} alt="" className="button-icon-image" draggable="false" />
+            ) : (
+              <span className="events-shopping-list-btn-icon">{shoppingListIcon}</span>
+            )}
             Einkaufsliste erstellen
           </button>
         </div>
@@ -321,10 +358,11 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
           onClose={() => setShowShoppingListModal(false)}
           shareId={event.id}
           bringButtonIcon={bringButtonIcon}
+          accentTheme="event"
         />
       )}
       {showPortionSelector && linkedRecipes.length > 0 && (
-        <div className="portion-selector-overlay" onClick={() => setShowPortionSelector(false)}>
+        <div className="portion-selector-overlay events-portion-selector-overlay" onClick={() => setShowPortionSelector(false)}>
           <div
             className="portion-selector-modal"
             role="dialog"

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ConsumptionForm from './ConsumptionForm';
+import { encodeRecipeLink } from '../utils/recipeLinks';
 
 const mockSubmitConsumption = jest.fn();
 
@@ -110,5 +111,68 @@ describe('ConsumptionForm', () => {
     const eingekauftInput = screen.getByLabelText('Eingekauft');
     expect(eingekauftInput).toHaveValue('');
     expect(screen.getByText(/Limo:.*keine gültige/)).toBeInTheDocument();
+  });
+
+  it('übernimmt Getränke ohne Rezeptlink in der Gebindeeinheit (sonst Einheit) in die Einkaufsliste', async () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Einkaufsliste erstellen/ }));
+
+    expect(await screen.findByText('1 3/4 Kasten Cola')).toBeInTheDocument();
+  });
+
+  it('übernimmt bei Getränken mit Rezeptlink nur die auf der Getränk-bearbeiten-Karte aktivierten Zutaten', async () => {
+    const recipe = {
+      id: 'rezept1',
+      title: 'Aperol Spritz',
+      portionen: 4,
+      ingredients: [
+        { type: 'ingredient', text: '100 ml Aperol' },
+        { type: 'ingredient', text: '50 ml Sirup', includedInCalculation: false },
+      ],
+    };
+    const einheiten = [
+      { einheitsgroesse: 0.2, einheit: 'Glas', gebindeinheit: '', einheitenProGebinde: '' },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink4:0',
+        drinkId: 'drink4',
+        drinkLabel: encodeRecipeLink('rezept1', 'Aperol Spritz'),
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 4,
+        gebinde: null,
+        gebindeGroesseLiter: 0.2,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[recipe]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Einkaufsliste erstellen/ }));
+    const generateBtn = await screen.findByText('Einkaufsliste erstellen', { selector: '.portion-selector-generate-btn' });
+    fireEvent.click(generateBtn);
+
+    expect(await screen.findByText('100 ml Aperol')).toBeInTheDocument();
+    expect(screen.queryByText(/Sirup/)).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Einkaufsliste' })).toHaveClass('shopping-list-modal--event');
   });
 });

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -563,6 +563,32 @@
   color: #a12626;
 }
 
+.events-shopping-list-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.events-shopping-list-btn .button-icon-image {
+  width: 20px;
+  height: 20px;
+}
+
+/* Portionsauswahl-Dialog auf "Einkauf & Verbrauch": Signalfarben in Event-Grün
+   statt der sonst üblichen Rezept-Farben (portion-selector-* wird auch von
+   RecipeDetail/MenuDetail/GroupDetail genutzt, daher hier gescopet). */
+.events-portion-selector-overlay .portion-selector-generate-btn {
+  background: #2F5D50;
+}
+
+.events-portion-selector-overlay .portion-selector-generate-btn:hover {
+  background: #24493f;
+}
+
+.events-portion-selector-overlay .portion-selector-btn.longpress-active {
+  background: #cfe3da;
+}
+
 .events-error-text {
   color: #c0392b;
   font-size: 14px;

--- a/src/components/ShoppingListModal.css
+++ b/src/components/ShoppingListModal.css
@@ -235,6 +235,28 @@
   border-radius: 6px;
 }
 
+/* Signalfarben in Event-Grün, wenn von "Einkauf & Verbrauch" aufgerufen */
+.shopping-list-modal--event .shopping-list-checkbox {
+  accent-color: #2F5D50;
+}
+
+.shopping-list-modal--event .shopping-list-item:hover {
+  background: #eef3f1;
+}
+
+.shopping-list-modal--event .shopping-list-edit-input {
+  border-color: #2F5D50;
+}
+
+.shopping-list-modal--event .shopping-list-edit-btn:hover:not(:disabled) {
+  color: #2F5D50;
+}
+
+.shopping-list-modal--event .shopping-list-reset-btn:hover {
+  border-color: #2F5D50;
+  color: #2F5D50;
+}
+
 @media (max-width: 480px) {
   .shopping-list-footer {
     flex-wrap: wrap;

--- a/src/components/ShoppingListModal.js
+++ b/src/components/ShoppingListModal.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { isBase64Image } from '../utils/imageUtils';
 import './ShoppingListModal.css';
 
-function ShoppingListModal({ items, title, onClose, shareId, onEnableSharing, hideBringButton, bringButtonIcon }) {
+function ShoppingListModal({ items, title, onClose, shareId, onEnableSharing, hideBringButton, bringButtonIcon, accentTheme }) {
   const [listItems, setListItems] = useState(() =>
     items.map((text, index) => ({ id: index, text, checked: false }))
   );
@@ -108,7 +108,7 @@ function ShoppingListModal({ items, title, onClose, shareId, onEnableSharing, hi
   return (
     <div className="shopping-list-overlay" onClick={onClose}>
       <div
-        className="shopping-list-modal"
+        className={`shopping-list-modal${accentTheme === 'event' ? ' shopping-list-modal--event' : ''}`}
         role="dialog"
         aria-modal="true"
         aria-label="Einkaufsliste"


### PR DESCRIPTION
- Bei Getränken mit Rezeptlink werden nur die auf der Getränk-bearbeiten-Karte
  aktivierten Zutaten (includedInCalculation !== false) in die Einkaufsliste
  übernommen.
- Getränke ohne Rezeptlink werden jetzt ebenfalls in die Einkaufsliste
  aufgenommen, mit der eingegebenen Eingekauft-Menge in der Gebindeeinheit
  (fällt auf die Einheit zurück, falls keine Gebindeeinheit hinterlegt ist).
- Der Button "Einkaufsliste erstellen" zeigt jetzt das konfigurierbare
  Einkaufslisten-Icon aus der Rezeptdetailansicht (Icon-Key "shoppingList").
- Einkaufslisten- und Portionsauswahl-Dialog verwenden auf "Einkauf &
  Verbrauch" das Event-Grün (#2F5D50) statt der sonst üblichen Rezeptfarben.