### PR TITLE
Getränke-Portionen aus Eingekauft-Menge übernehmen, Einkaufsliste-Button nur Icon

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -148,6 +148,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
 
   // Getraenke-Gruppen aufteilen: mit Rezeptlink (linkedRecipes) vs. ohne (nonRecipeGroups).
   const linkedRecipes = [];
+  const linkedRecipeEingekauft = {};
   const nonRecipeGroups = [];
   {
     const seenIds = new Set();
@@ -157,6 +158,10 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
         if (!seenIds.has(display.recipe.id)) {
           seenIds.add(display.recipe.id);
           linkedRecipes.push(display.recipe);
+          const eingekauft = parseFractionQuantity(values[group.rows[0]?.kategorie]?.eingekauft);
+          if (Number.isFinite(eingekauft) && eingekauft > 0) {
+            linkedRecipeEingekauft[display.recipe.id] = Math.round(eingekauft);
+          }
         }
       } else {
         nonRecipeGroups.push(group);
@@ -204,7 +209,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
 
   const handleShoppingListClick = () => {
     if (linkedRecipes.length > 0) {
-      setLinkedPortionCounts({});
+      setLinkedPortionCounts({ ...linkedRecipeEingekauft });
       setShowPortionSelector(true);
     } else {
       missingSavedRef.current = false;
@@ -332,13 +337,18 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
         {error && <p className="events-error-text">{error}</p>}
 
         <div className="events-form-actions">
-          <button type="button" className="events-secondary-btn events-shopping-list-btn" onClick={handleShoppingListClick}>
+          <button
+            type="button"
+            className="events-secondary-btn events-shopping-list-btn"
+            onClick={handleShoppingListClick}
+            aria-label="Einkaufsliste erstellen"
+            title="Einkaufsliste erstellen"
+          >
             {isBase64Image(shoppingListIcon) ? (
               <img src={shoppingListIcon} alt="" className="button-icon-image" draggable="false" />
             ) : (
               <span className="events-shopping-list-btn-icon">{shoppingListIcon}</span>
             )}
-            Einkaufsliste erstellen
           </button>
         </div>
 

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -168,10 +168,14 @@ describe('ConsumptionForm', () => {
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[recipe]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Einkaufsliste erstellen/ }));
+
+    // Die vorbefuellte "Eingekauft"-Menge (20 Glaeser) wird als Portionenzahl uebernommen.
+    expect(await screen.findByText('20')).toBeInTheDocument();
+
     const generateBtn = await screen.findByText('Einkaufsliste erstellen', { selector: '.portion-selector-generate-btn' });
     fireEvent.click(generateBtn);
 
-    expect(await screen.findByText('100 ml Aperol')).toBeInTheDocument();
+    expect(await screen.findByText('500 ml Aperol')).toBeInTheDocument();
     expect(screen.queryByText(/Sirup/)).not.toBeInTheDocument();
     expect(screen.getByRole('dialog', { name: 'Einkaufsliste' })).toHaveClass('shopping-list-modal--event');
   });


### PR DESCRIPTION
Bei Getränken mit verlinktem Rezept wird die im Feld "Eingekauft"
erfasste Menge als Startwert im Dialog "Portionen für Einkaufsliste"
übernommen, statt der generischen Rezept-Portionenzahl. Der Button
"Einkaufsliste erstellen" im Verbrauchs-Formular zeigt nun nur noch
das Icon (Text bleibt als aria-label/title für Barrierefreiheit erhalten).