### PR TITLE
Sperren-Button fuer Eingekauft-Menge auf der Einkauf & Verbrauch-Seite

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './EventsPage.css';
-import { submitConsumption } from '../utils/eventsFirestore';
+import { submitConsumption, lockEinkaufMenge } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { calculateCascadingEinkauf } from '../utils/einkaufCascade';
@@ -11,6 +11,7 @@ import { scaleIngredient, combineIngredients, isWaterIngredient, convertIngredie
 import { getCustomLists, getButtonIcons, getEffectiveIcon, getDarkModePreference, addMissingConversionEntries } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import ShoppingListModal from './ShoppingListModal';
+import LockIcon from './icons/LockIcon';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -104,13 +105,18 @@ function getCascadePrefill(drinkGroups) {
   return { prefillMap, warnings };
 }
 
-function ConsumptionForm({ event, recipes, onDone, onCancel }) {
+function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const kategorien = (event.berechnung?.ergebnis || []).filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter);
   const drinkGroups = groupKategorienByDrink(kategorien, recipes);
   const { prefillMap, warnings: prefillWarnings } = getCascadePrefill(drinkGroups);
   const [values, setValues] = useState(() => {
     const initial = {};
     kategorien.forEach((row) => {
+      const lockedValue = event.einkaufGesperrt?.[row.kategorie];
+      if (lockedValue !== undefined) {
+        initial[row.kategorie] = { eingekauft: lockedValue, uebrig: '' };
+        return;
+      }
       const prefillValue = prefillMap[row.kategorie];
       initial[row.kategorie] = {
         eingekauft: prefillValue !== undefined && prefillValue !== null ? formatQuantityFraction(prefillValue) : '',
@@ -119,6 +125,9 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
     });
     return initial;
   });
+  const [lockedKategorien, setLockedKategorien] = useState(
+    () => new Set(Object.keys(event.einkaufGesperrt || {}))
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [changes, setChanges] = useState(null);
@@ -224,6 +233,15 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
     }));
   };
 
+  const handleLockRow = (kategorie) => {
+    setLockedKategorien((prev) => new Set(prev).add(kategorie));
+    if (currentUser?.id) {
+      lockEinkaufMenge(currentUser.id, event.id, kategorie, values[kategorie]?.eingekauft || '').catch((err) => {
+        console.error('Error locking eingekauft value:', err);
+      });
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
@@ -304,33 +322,48 @@ function ConsumptionForm({ event, recipes, onDone, onCancel }) {
         {drinkGroups.map((group) => (
           <div className="events-consumption-group" key={group.key}>
             <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
-            {group.rows.map((row) => (
-              <div className="events-form-row" key={row.kategorie}>
-                {getRowUnitSubtitle(row) && (
-                  <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
-                )}
-                <label className="events-form-field">
-                  <span>Eingekauft</span>
-                  <input
-                    type="text"
-                    inputMode="text"
-                    placeholder="z.B. 1 3/4"
-                    title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
-                    value={values[row.kategorie].eingekauft}
-                    onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
-                  />
-                </label>
-                <label className="events-form-field">
-                  <span>Übrig</span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={values[row.kategorie].uebrig}
-                    onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
-                  />
-                </label>
-              </div>
-            ))}
+            {group.rows.map((row) => {
+              const isLocked = lockedKategorien.has(row.kategorie);
+              return (
+                <div className="events-form-row" key={row.kategorie}>
+                  {getRowUnitSubtitle(row) && (
+                    <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
+                  )}
+                  <label className="events-form-field">
+                    <span>Eingekauft</span>
+                    <input
+                      type="text"
+                      inputMode="text"
+                      placeholder="z.B. 1 3/4"
+                      title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
+                      value={values[row.kategorie].eingekauft}
+                      onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
+                      disabled={isLocked}
+                    />
+                  </label>
+                  <label className="events-form-field">
+                    <span>Übrig</span>
+                    <input
+                      type="number"
+                      min="0"
+                      value={values[row.kategorie].uebrig}
+                      onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
+                    />
+                  </label>
+                  {!isLocked && (
+                    <button
+                      type="button"
+                      className="events-lock-btn"
+                      onClick={() => handleLockRow(row.kategorie)}
+                      aria-label="Eingekaufte Menge sperren"
+                      title="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
+                    >
+                      <LockIcon size={18} />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
           </div>
         ))}
 

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -4,9 +4,11 @@ import ConsumptionForm from './ConsumptionForm';
 import { encodeRecipeLink } from '../utils/recipeLinks';
 
 const mockSubmitConsumption = jest.fn();
+const mockLockEinkaufMenge = jest.fn(() => Promise.resolve());
 
 jest.mock('../utils/eventsFirestore', () => ({
   submitConsumption: (...args) => mockSubmitConsumption(...args),
+  lockEinkaufMenge: (...args) => mockLockEinkaufMenge(...args),
 }));
 
 jest.mock('./EventForm', () => ({
@@ -24,6 +26,7 @@ function makeEvent(ergebnis) {
 describe('ConsumptionForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockLockEinkaufMenge.mockResolvedValue(undefined);
   });
 
   it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
@@ -178,5 +181,67 @@ describe('ConsumptionForm', () => {
     expect(await screen.findByText('500 ml Aperol')).toBeInTheDocument();
     expect(screen.queryByText(/Sirup/)).not.toBeInTheDocument();
     expect(screen.getByRole('dialog', { name: 'Einkaufsliste' })).toHaveClass('shopping-list-modal--event');
+  });
+
+  it('zeigt einen Sperren-Button, sperrt beim Klick das Feld und blendet den Button aus', async () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(
+      <ConsumptionForm
+        event={makeEvent(ergebnis)}
+        recipes={[]}
+        onDone={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={{ id: 'user1' }}
+      />
+    );
+
+    const lockButton = screen.getByRole('button', { name: 'Eingekaufte Menge sperren' });
+    fireEvent.click(lockButton);
+
+    expect(mockLockEinkaufMenge).toHaveBeenCalledWith('user1', 'event1', 'drink2:0', '1 3/4');
+    expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
+  });
+
+  it('laedt eine bereits gesperrte Menge ohne Neukalkulation und ohne Sperren-Button', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), einkaufGesperrt: { 'drink2:0': '3' } };
+
+    render(<ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    expect(screen.getByLabelText('Eingekauft')).toHaveValue('3');
+    expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
   });
 });

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -340,6 +340,34 @@
   box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.12);
 }
 
+.events-form-field input:disabled {
+  background: #f2f2f2;
+  color: #888;
+  cursor: not-allowed;
+}
+
+.events-lock-btn {
+  flex: 0 0 auto;
+  align-self: flex-end;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid #e2e2e2;
+  border-radius: 8px;
+  background: #fff;
+  color: #666;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.events-lock-btn:hover {
+  background: #f2f2f2;
+  color: #2F5D50;
+  border-color: #2F5D50;
+}
+
 .events-name-input-wrapper {
   position: relative;
   display: flex;

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -186,6 +186,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       <ConsumptionForm
         event={selectedEvent}
         recipes={recipes}
+        currentUser={currentUser}
         onDone={(eventId) => {
           setSelectedEventId(eventId);
           setFallbackEvent(null);

--- a/src/components/icons/LockIcon.js
+++ b/src/components/icons/LockIcon.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const LockIcon = ({ color = 'currentColor', size = 24 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="5"
+        y="11"
+        width="14"
+        height="10"
+        rx="2"
+        stroke={color}
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M8 11V7a4 4 0 0 1 8 0v4"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+};
+
+export default LockIcon;

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -112,6 +112,21 @@ export const calculateEventDrinks = async (event, eventId) => {
 };
 
 /**
+ * Sperrt die "Eingekauft"-Menge einer Getraenke-Kategorie auf einem Event, damit
+ * sie beim naechsten Oeffnen der Einkauf & Verbrauch-Seite nicht mehr aus dem
+ * kalkulierten Bedarf neu vorbefuellt wird.
+ * @param {string} uid - Current user ID
+ * @param {string} eventId - ID of the event
+ * @param {string} kategorie - Kategorie-Schluessel der Getraenke-Zeile
+ * @param {string} eingekauft - Die einzufrierende "Eingekauft"-Menge
+ * @returns {Promise<void>}
+ */
+export const lockEinkaufMenge = async (uid, eventId, kategorie, eingekauft) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  await setDoc(eventRef, { einkaufGesperrt: { [kategorie]: eingekauft } }, { merge: true });
+};
+
+/**
  * Call the submitConsumption Cloud Function: records the actual consumption
  * of a finished event and updates the user's calibrated rates.
  * @param {string} eventId - ID of the event


### PR DESCRIPTION
Jede Getraenke-Zeile bekommt einen Button, der die aktuelle "Eingekauft"-
Menge sperrt: die Menge wird auf dem Event persistiert, das Feld wird
deaktiviert und der Button verschwindet. Beim erneuten Oeffnen der Seite
wird eine gesperrte Menge unveraendert geladen statt aus dem kalkulierten
Bedarf neu vorbefuellt zu werden; ungesperrte Zeilen werden wie bisher
neu kalkuliert.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019GG4bWq5RreN78YzDZzm2N