### PR TITLE
Sperren/Entsperren der Eingekauft-Menge auf Getränkeebene

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './EventsPage.css';
-import { submitConsumption, lockEinkaufMenge } from '../utils/eventsFirestore';
+import { submitConsumption, lockEinkaufMengen, unlockEinkaufMengen } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { calculateCascadingEinkauf } from '../utils/einkaufCascade';
@@ -12,6 +12,7 @@ import { getCustomLists, getButtonIcons, getEffectiveIcon, getDarkModePreference
 import { isBase64Image } from '../utils/imageUtils';
 import ShoppingListModal from './ShoppingListModal';
 import LockIcon from './icons/LockIcon';
+import UnlockIcon from './icons/UnlockIcon';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -233,12 +234,37 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     }));
   };
 
-  const handleLockRow = (kategorie) => {
-    setLockedKategorien((prev) => new Set(prev).add(kategorie));
-    if (currentUser?.id) {
-      lockEinkaufMenge(currentUser.id, event.id, kategorie, values[kategorie]?.eingekauft || '').catch((err) => {
-        console.error('Error locking eingekauft value:', err);
+  const isGroupLocked = (group) =>
+    group.rows.length > 0 && group.rows.every((row) => lockedKategorien.has(row.kategorie));
+
+  const handleToggleLock = (group) => {
+    const kategorienKeys = group.rows.map((row) => row.kategorie);
+    if (isGroupLocked(group)) {
+      setLockedKategorien((prev) => {
+        const next = new Set(prev);
+        kategorienKeys.forEach((kategorie) => next.delete(kategorie));
+        return next;
       });
+      if (currentUser?.id) {
+        unlockEinkaufMengen(currentUser.id, event.id, kategorienKeys).catch((err) => {
+          console.error('Error unlocking eingekauft values:', err);
+        });
+      }
+    } else {
+      setLockedKategorien((prev) => {
+        const next = new Set(prev);
+        kategorienKeys.forEach((kategorie) => next.add(kategorie));
+        return next;
+      });
+      if (currentUser?.id) {
+        const werteByKategorie = {};
+        kategorienKeys.forEach((kategorie) => {
+          werteByKategorie[kategorie] = values[kategorie]?.eingekauft || '';
+        });
+        lockEinkaufMengen(currentUser.id, event.id, werteByKategorie).catch((err) => {
+          console.error('Error locking eingekauft values:', err);
+        });
+      }
     }
   };
 
@@ -319,12 +345,27 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
         </div>
       )}
       <form className="events-form" onSubmit={handleSubmit}>
-        {drinkGroups.map((group) => (
-          <div className="events-consumption-group" key={group.key}>
-            <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
-            {group.rows.map((row) => {
-              const isLocked = lockedKategorien.has(row.kategorie);
-              return (
+        {drinkGroups.map((group) => {
+          const groupLocked = isGroupLocked(group);
+          return (
+            <div className="events-consumption-group" key={group.key}>
+              <div className="events-consumption-group-header">
+                <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
+                <button
+                  type="button"
+                  className="events-lock-btn"
+                  onClick={() => handleToggleLock(group)}
+                  aria-label={groupLocked ? 'Eingekaufte Menge entsperren' : 'Eingekaufte Menge sperren'}
+                  title={
+                    groupLocked
+                      ? 'Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)'
+                      : 'Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)'
+                  }
+                >
+                  {groupLocked ? <UnlockIcon size={18} /> : <LockIcon size={18} />}
+                </button>
+              </div>
+              {group.rows.map((row) => (
                 <div className="events-form-row" key={row.kategorie}>
                   {getRowUnitSubtitle(row) && (
                     <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
@@ -338,7 +379,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
                       title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
                       value={values[row.kategorie].eingekauft}
                       onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
-                      disabled={isLocked}
+                      disabled={groupLocked}
                     />
                   </label>
                   <label className="events-form-field">
@@ -350,22 +391,11 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
                       onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
                     />
                   </label>
-                  {!isLocked && (
-                    <button
-                      type="button"
-                      className="events-lock-btn"
-                      onClick={() => handleLockRow(row.kategorie)}
-                      aria-label="Eingekaufte Menge sperren"
-                      title="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
-                    >
-                      <LockIcon size={18} />
-                    </button>
-                  )}
                 </div>
-              );
-            })}
-          </div>
-        ))}
+              ))}
+            </div>
+          );
+        })}
 
         {error && <p className="events-error-text">{error}</p>}
 

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -4,11 +4,13 @@ import ConsumptionForm from './ConsumptionForm';
 import { encodeRecipeLink } from '../utils/recipeLinks';
 
 const mockSubmitConsumption = jest.fn();
-const mockLockEinkaufMenge = jest.fn(() => Promise.resolve());
+const mockLockEinkaufMengen = jest.fn(() => Promise.resolve());
+const mockUnlockEinkaufMengen = jest.fn(() => Promise.resolve());
 
 jest.mock('../utils/eventsFirestore', () => ({
   submitConsumption: (...args) => mockSubmitConsumption(...args),
-  lockEinkaufMenge: (...args) => mockLockEinkaufMenge(...args),
+  lockEinkaufMengen: (...args) => mockLockEinkaufMengen(...args),
+  unlockEinkaufMengen: (...args) => mockUnlockEinkaufMengen(...args),
 }));
 
 jest.mock('./EventForm', () => ({
@@ -26,7 +28,8 @@ function makeEvent(ergebnis) {
 describe('ConsumptionForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLockEinkaufMenge.mockResolvedValue(undefined);
+    mockLockEinkaufMengen.mockResolvedValue(undefined);
+    mockUnlockEinkaufMengen.mockResolvedValue(undefined);
   });
 
   it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
@@ -183,18 +186,30 @@ describe('ConsumptionForm', () => {
     expect(screen.getByRole('dialog', { name: 'Einkaufsliste' })).toHaveClass('shopping-list-modal--event');
   });
 
-  it('zeigt einen Sperren-Button, sperrt beim Klick das Feld und blendet den Button aus', async () => {
+  it('sperrt beim Klick alle Einheiten des Getraenks gemeinsam und zeigt danach den Entsperren-Button', async () => {
     const einheiten = [
+      { einheitsgroesse: 50, einheit: 'Fass', gebindeinheit: '', einheitenProGebinde: '' },
       { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
     ];
     const ergebnis = [
       {
-        kategorie: 'drink2:0',
-        drinkId: 'drink2',
-        drinkLabel: 'Cola',
+        kategorie: 'drink1:0',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
         isCustomDrink: true,
         einheitIdx: 0,
-        literMitPuffer: 12.7,
+        literMitPuffer: 62.7,
+        gebinde: null,
+        gebindeGroesseLiter: 50,
+        einheiten,
+      },
+      {
+        kategorie: 'drink1:1',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 1,
+        literMitPuffer: 62.7,
         gebinde: 'Kasten',
         gebindeGroesseLiter: 0.33,
         einheiten,
@@ -214,12 +229,77 @@ describe('ConsumptionForm', () => {
     const lockButton = screen.getByRole('button', { name: 'Eingekaufte Menge sperren' });
     fireEvent.click(lockButton);
 
-    expect(mockLockEinkaufMenge).toHaveBeenCalledWith('user1', 'event1', 'drink2:0', '1 3/4');
-    expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
+    expect(mockLockEinkaufMengen).toHaveBeenCalledWith('user1', 'event1', {
+      'drink1:0': '1',
+      'drink1:1': '1 3/4',
+    });
+    const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
+    expect(eingekauftInputs[0]).toBeDisabled();
+    expect(eingekauftInputs[1]).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' })).toBeInTheDocument();
   });
 
-  it('laedt eine bereits gesperrte Menge ohne Neukalkulation und ohne Sperren-Button', () => {
+  it('entsperrt beim Klick auf den Entsperren-Button wieder alle Einheiten des Getraenks', async () => {
+    const einheiten = [
+      { einheitsgroesse: 50, einheit: 'Fass', gebindeinheit: '', einheitenProGebinde: '' },
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink1:0',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 62.7,
+        gebinde: null,
+        gebindeGroesseLiter: 50,
+        einheiten,
+      },
+      {
+        kategorie: 'drink1:1',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 1,
+        literMitPuffer: 62.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = {
+      ...makeEvent(ergebnis),
+      einkaufGesperrt: { 'drink1:0': '1', 'drink1:1': '1 3/4' },
+    };
+
+    render(
+      <ConsumptionForm
+        event={event}
+        recipes={[]}
+        onDone={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={{ id: 'user1' }}
+      />
+    );
+
+    const eingekauftInputsLocked = screen.getAllByLabelText('Eingekauft');
+    expect(eingekauftInputsLocked[0]).toBeDisabled();
+    expect(eingekauftInputsLocked[1]).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
+
+    const unlockButton = screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' });
+    fireEvent.click(unlockButton);
+
+    expect(mockUnlockEinkaufMengen).toHaveBeenCalledWith('user1', 'event1', ['drink1:0', 'drink1:1']);
+    const eingekauftInputsUnlocked = screen.getAllByLabelText('Eingekauft');
+    expect(eingekauftInputsUnlocked[0]).not.toBeDisabled();
+    expect(eingekauftInputsUnlocked[1]).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' })).toBeInTheDocument();
+  });
+
+  it('laedt eine bereits gesperrte Menge ohne Neukalkulation und zeigt den Entsperren-Button', () => {
     const einheiten = [
       { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
     ];
@@ -243,5 +323,6 @@ describe('ConsumptionForm', () => {
     expect(screen.getByLabelText('Eingekauft')).toHaveValue('3');
     expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' })).toBeInTheDocument();
   });
 });

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -299,6 +299,13 @@
   border-top: 1px solid #eee;
 }
 
+.events-consumption-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .events-consumption-drink-name {
   margin: 0;
   font-weight: 600;
@@ -348,7 +355,6 @@
 
 .events-lock-btn {
   flex: 0 0 auto;
-  align-self: flex-end;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/icons/UnlockIcon.js
+++ b/src/components/icons/UnlockIcon.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const UnlockIcon = ({ color = 'currentColor', size = 24 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="5"
+        y="11"
+        width="14"
+        height="10"
+        rx="2"
+        stroke={color}
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M8 11V7a4 4 0 0 1 7.5-2"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  );
+};
+
+export default UnlockIcon;

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -11,6 +11,7 @@ import {
   addDoc,
   setDoc,
   deleteDoc,
+  deleteField,
   onSnapshot,
   query,
   orderBy,
@@ -112,18 +113,35 @@ export const calculateEventDrinks = async (event, eventId) => {
 };
 
 /**
- * Sperrt die "Eingekauft"-Menge einer Getraenke-Kategorie auf einem Event, damit
- * sie beim naechsten Oeffnen der Einkauf & Verbrauch-Seite nicht mehr aus dem
- * kalkulierten Bedarf neu vorbefuellt wird.
+ * Sperrt die "Eingekauft"-Mengen aller Kategorien eines Getraenks auf einem Event,
+ * damit sie beim naechsten Oeffnen der Einkauf & Verbrauch-Seite nicht mehr aus dem
+ * kalkulierten Bedarf neu vorbefuellt werden.
  * @param {string} uid - Current user ID
  * @param {string} eventId - ID of the event
- * @param {string} kategorie - Kategorie-Schluessel der Getraenke-Zeile
- * @param {string} eingekauft - Die einzufrierende "Eingekauft"-Menge
+ * @param {Object} werteByKategorie - { kategorie: eingekauft } der einzufrierenden Mengen
  * @returns {Promise<void>}
  */
-export const lockEinkaufMenge = async (uid, eventId, kategorie, eingekauft) => {
+export const lockEinkaufMengen = async (uid, eventId, werteByKategorie) => {
   const eventRef = doc(db, 'users', uid, 'events', eventId);
-  await setDoc(eventRef, { einkaufGesperrt: { [kategorie]: eingekauft } }, { merge: true });
+  await setDoc(eventRef, { einkaufGesperrt: werteByKategorie }, { merge: true });
+};
+
+/**
+ * Entsperrt die "Eingekauft"-Mengen aller Kategorien eines Getraenks auf einem Event,
+ * damit sie beim naechsten Oeffnen der Einkauf & Verbrauch-Seite wieder aus dem
+ * kalkulierten Bedarf neu vorbefuellt werden.
+ * @param {string} uid - Current user ID
+ * @param {string} eventId - ID of the event
+ * @param {string[]} kategorien - Kategorie-Schluessel der zu entsperrenden Getraenke-Zeilen
+ * @returns {Promise<void>}
+ */
+export const unlockEinkaufMengen = async (uid, eventId, kategorien) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  const updates = {};
+  kategorien.forEach((kategorie) => {
+    updates[kategorie] = deleteField();
+  });
+  await setDoc(eventRef, { einkaufGesperrt: updates }, { merge: true });
 };
 
 /**


### PR DESCRIPTION
## Summary
- Jedes Getränk auf der Einkauf & Verbrauch-Seite hat einen Button, der die "Eingekauft"-Mengen aller zugehörigen Einheiten (z.B. Fass + Flasche desselben Biers) gemeinsam sperrt.
- Gesperrte Getränke werden beim erneuten Öffnen der Seite **nicht** mehr aus dem kalkulierten Bedarf neu vorbefüllt, sondern laden ihre zuletzt eingegebene Menge unverändert. Ungesperrte Getränke werden wie bisher neu kalkuliert.
- Nach dem Sperren erscheint an gleicher Stelle ein Entsperren-Button, der die Felder wieder freigibt und die gespeicherten Werte aus dem Event entfernt.
- Lock-Status wird direkt in Firestore auf dem Event persistiert (`einkaufGesperrt`), keine Cloud-Function nötig.

## Test plan
- [x] `npm test` für `ConsumptionForm.test.js` und `EventsPage.test.js` (17 Tests, grün)
- [x] ESLint auf geänderten Dateien ohne neue Warnungen/Fehler
- [x] Verifiziert, dass unabhängig fehlschlagende Test-Suiten (z.B. `App.test.js`) bereits vor dieser Änderung fehlschlugen (per `git stash`)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GG4bWq5RreN78YzDZzm2N)_