### PR TITLE
Bedarf auf Eventkarte je Getraenk statt je Einheit anzeigen

### DIFF
--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -33,6 +33,21 @@ const formatLiter = (value) => {
   return num.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
 };
 
+// Fasst die Ergebniszeilen pro Getraenk zusammen (ein Getraenk kann mehrere
+// Zeilen haben, wenn mehrere Gebinde-Einheiten ausgewaehlt sind -- der Bedarf
+// ist dabei fuer alle Zeilen einer Gruppe identisch, daher reicht eine Zeile).
+const groupErgebnisRowsByDrink = (rows) => {
+  const seen = new Set();
+  const grouped = [];
+  rows.forEach((row) => {
+    const key = row.drinkId || row.kategorie;
+    if (seen.has(key)) return;
+    seen.add(key);
+    grouped.push(row);
+  });
+  return grouped;
+};
+
 const formatDrinkSummary = (berechnung) => {
   const ergebnis = berechnung?.ergebnis;
   if (!ergebnis || ergebnis.length === 0) return null;
@@ -251,10 +266,10 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
                 </tr>
               </thead>
               <tbody>
-                {(berechnung?.ergebnis || [])
-                  .filter((row) => row.isCustomDrink || !row.hasCustomDrinkCoverage)
+                {groupErgebnisRowsByDrink((berechnung?.ergebnis || [])
+                  .filter((row) => row.isCustomDrink || !row.hasCustomDrinkCoverage))
                   .map((row) => (
-                    <tr key={row.kategorie}>
+                    <tr key={row.drinkId || row.kategorie}>
                       <td>{row.isCustomDrink && row.drinkLabel ? resolveDrinkDisplay(row.drinkLabel, recipes).displayName : (CATEGORY_LABELS[row.kategorie] || row.kategorie)}</td>
                       <td className="events-table-amount">{formatLiter(row.literMitPuffer)} l</td>
                     </tr>

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -278,4 +278,47 @@ describe('EventsPage', () => {
 
     expect(screen.queryByText(/~15L Craft Bier/)).not.toBeInTheDocument();
   });
+
+  test('shows Bedarf only once per drink in detail view, even when multiple Einheiten are selected', () => {
+    const event = {
+      id: 'e7',
+      eventName: 'Bierfest',
+      date: '2026-01-10',
+      durationHours: 3,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 20, children: 0 },
+      berechnung: {
+        ergebnis: [
+          {
+            kategorie: 'custom_1:0',
+            drinkId: 'custom_1',
+            drinkLabel: 'Craft Bier',
+            literMitPuffer: 24,
+            isCustomDrink: true,
+            einheitIdx: 0,
+          },
+          {
+            kategorie: 'custom_1:1',
+            drinkId: 'custom_1',
+            drinkLabel: 'Craft Bier',
+            literMitPuffer: 24,
+            isCustomDrink: true,
+            einheitIdx: 1,
+          },
+        ],
+      },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([event]);
+      return jest.fn();
+    });
+
+    render(<EventsPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByText('Bierfest'));
+
+    expect(screen.getAllByText('Craft Bier')).toHaveLength(1);
+    expect(screen.getAllByText(/24,0 l/)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Getraenke mit mehreren gewaehlten Gebinde-Einheiten erzeugten je
Einheit eine eigene Ergebniszeile mit demselben Gesamtbedarf, wodurch
die Menge in der Getraenke-Tabelle der Eventdetailansicht mehrfach
angezeigt wurde. Die Zeilen werden nun pro Getraenk zusammengefasst.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FJHTLJ8g9EfcC7zessTXVp