### PR TITLE
Status-Konzept "Einkauf & Verbrauch": eingekauft-Status + Verbrauch-Sperre + Unterdeckungs-Check

### DIFF
--- a/functions/reminderConsumption.js
+++ b/functions/reminderConsumption.js
@@ -31,7 +31,7 @@ exports.reminderConsumption = onSchedule(
 
       const pendingEvents = await db
           .collectionGroup('events')
-          .where('status', '==', 'berechnet')
+          .where('status', 'in', ['berechnet', 'eingekauft'])
           .where('date', '<=', cutoffStr)
           .get();
 

--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -1,16 +1,25 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './EventsPage.css';
-import { submitConsumption, lockEinkaufMengen, unlockEinkaufMengen } from '../utils/eventsFirestore';
+import {
+  submitConsumption,
+  lockEinkaufMengen,
+  unlockEinkaufMengen,
+  lockVerbrauchMengen,
+  unlockVerbrauchMengen,
+  setEventStatus,
+} from '../utils/eventsFirestore';
 import { CATEGORY_LABELS } from './EventForm';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { calculateCascadingEinkauf } from '../utils/einkaufCascade';
 import { formatQuantityFraction, parseFractionQuantity } from '../utils/fractionFormat';
 import { useLongPress } from '../utils/useLongPress';
+import { useGroupLock } from '../hooks/useGroupLock';
 import { decodeRecipeLink } from '../utils/recipeLinks';
 import { scaleIngredient, combineIngredients, isWaterIngredient, convertIngredientUnits } from '../utils/ingredientUtils';
 import { getCustomLists, getButtonIcons, getEffectiveIcon, getDarkModePreference, addMissingConversionEntries } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import ShoppingListModal from './ShoppingListModal';
+import LockToggleButton from './LockToggleButton';
 import LockIcon from './icons/LockIcon';
 import UnlockIcon from './icons/UnlockIcon';
 
@@ -106,6 +115,76 @@ function getCascadePrefill(drinkGroups) {
   return { prefillMap, warnings };
 }
 
+// Rechnet die "Eingekauft"-Mengen einer Getraenke-Gruppe ueber alle Einheiten
+// (Fass, Kasten, Flasche, ...) in Liter um und summiert sie, damit eine
+// Unterdeckung nicht pro Einheit isoliert, sondern fuer das ganze Getraenk
+// geprueft werden kann (Fass ok + Flasche ok kann in Summe trotzdem zu wenig sein).
+function getGroupEingekauftLiter(group, values) {
+  const units = getGroupCascadeUnits(group);
+  let totalLiter = 0;
+  let anyFilled = false;
+  units.forEach((unit) => {
+    const qty = parseFractionQuantity(values[unit.key]?.eingekauft);
+    if (!Number.isFinite(qty) || qty <= 0) return;
+    anyFilled = true;
+    const perUnitLiter = Number.isFinite(unit.gebindeGroesseLiter) && unit.gebindeGroesseLiter > 0
+      ? unit.gebindeGroesseLiter
+      : unit.einheitsgroesseLiter;
+    if (Number.isFinite(perUnitLiter) && perUnitLiter > 0) {
+      totalLiter += qty * perUnitLiter;
+    }
+  });
+  return { totalLiter, anyFilled };
+}
+
+// Zeilen-Status einer Getraenke-Gruppe (nur visuell, wird nirgends gespeichert):
+// 'offen' (nichts befuellt), 'unentschieden' (befuellt, aber ungesperrt),
+// 'unterdeckung'/'ausreichend' (gesperrt, Vergleich Summe vs. Kalkuliert) oder
+// 'neutral' (gesperrt, aber kein kalkulierter Bedarf vorhanden -- kein Vergleich moeglich).
+function getGroupRowStatus(group, values, einkaufLocked) {
+  const { totalLiter, anyFilled } = getGroupEingekauftLiter(group, values);
+  if (!anyFilled) return 'offen';
+  if (!einkaufLocked) return 'unentschieden';
+  const bedarfLiter = getGroupBedarfLiter(group);
+  if (!(bedarfLiter > 0)) return 'neutral';
+  return totalLiter < bedarfLiter ? 'unterdeckung' : 'ausreichend';
+}
+
+// Liegt das Eventdatum in der Vergangenheit (fuer den "Verbrauch fehlt"-Hinweis)?
+function isEventPast(dateStr) {
+  if (!dateStr) return false;
+  const todayStr = new Date().toISOString().slice(0, 10);
+  return dateStr < todayStr;
+}
+
+function formatLiterShort(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '';
+  return num.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 2 });
+}
+
+const ROW_STATUS_ICON_PROPS = {
+  neutral: { Icon: LockIcon, color: '#999', title: 'Keine Kalkulation vorhanden - Unterdeckungs-Prüfung nicht möglich' },
+  unentschieden: { Icon: UnlockIcon, color: '#c9a227', title: 'Eingekaufte Menge noch nicht gesperrt' },
+  unterdeckung: { Icon: LockIcon, color: '#c0392b', title: 'Unterdeckung: eingekaufte Menge reicht nicht für den kalkulierten Bedarf' },
+  ausreichend: { Icon: LockIcon, color: '#1c6b46', title: 'Ausreichend eingekauft' },
+};
+
+// Zeigt den Zeilen-Status einer Getraenke-Gruppe als farbiges Schloss-Icon an
+// (wiederverwendet dieselben Lock-/Unlock-Icons wie der Sperren-Button, nur
+// nicht-interaktiv und mit Zustandsfarbe).
+function RowStatusIcon({ status }) {
+  if (!status || status === 'offen') return null;
+  const config = ROW_STATUS_ICON_PROPS[status];
+  if (!config) return null;
+  const { Icon, color, title } = config;
+  return (
+    <span className={`events-row-status-icon events-row-status-${status}`} title={title} aria-label={title}>
+      <Icon size={16} color={color} />
+    </span>
+  );
+}
+
 function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const kategorien = (event.berechnung?.ergebnis || []).filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter);
   const drinkGroups = groupKategorienByDrink(kategorien, recipes);
@@ -113,22 +192,36 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const [values, setValues] = useState(() => {
     const initial = {};
     kategorien.forEach((row) => {
-      const lockedValue = event.einkaufGesperrt?.[row.kategorie];
-      if (lockedValue !== undefined) {
-        initial[row.kategorie] = { eingekauft: lockedValue, uebrig: '' };
-        return;
+      const lockedEinkauf = event.einkaufGesperrt?.[row.kategorie];
+      const lockedVerbrauch = event.verbrauchGesperrt?.[row.kategorie];
+      let eingekauft;
+      if (lockedEinkauf !== undefined) {
+        eingekauft = lockedEinkauf;
+      } else {
+        const prefillValue = prefillMap[row.kategorie];
+        eingekauft = prefillValue !== undefined && prefillValue !== null ? formatQuantityFraction(prefillValue) : '';
       }
-      const prefillValue = prefillMap[row.kategorie];
       initial[row.kategorie] = {
-        eingekauft: prefillValue !== undefined && prefillValue !== null ? formatQuantityFraction(prefillValue) : '',
-        uebrig: '',
+        eingekauft,
+        uebrig: lockedVerbrauch !== undefined ? lockedVerbrauch : '',
       };
     });
     return initial;
   });
-  const [lockedKategorien, setLockedKategorien] = useState(
-    () => new Set(Object.keys(event.einkaufGesperrt || {}))
-  );
+  const einkaufLock = useGroupLock({
+    initialLocked: event.einkaufGesperrt,
+    currentUser,
+    eventId: event.id,
+    lockFn: lockEinkaufMengen,
+    unlockFn: unlockEinkaufMengen,
+  });
+  const verbrauchLock = useGroupLock({
+    initialLocked: event.verbrauchGesperrt,
+    currentUser,
+    eventId: event.id,
+    lockFn: lockVerbrauchMengen,
+    unlockFn: unlockVerbrauchMengen,
+  });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [changes, setChanges] = useState(null);
@@ -139,6 +232,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const [showPortionSelector, setShowPortionSelector] = useState(false);
   const [linkedPortionCounts, setLinkedPortionCounts] = useState({});
   const missingSavedRef = useRef(false);
+  const autoSubmitTriggeredRef = useRef(false);
   const {
     activeId: portionMinusLongPressActiveId,
     triggeredRef: portionMinusLongPressTriggeredRef,
@@ -234,60 +328,74 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     }));
   };
 
-  const isGroupLocked = (group) =>
-    group.rows.length > 0 && group.rows.every((row) => lockedKategorien.has(row.kategorie));
+  const allGroupsLockedIn = (lockedSet) =>
+    drinkGroups.length > 0 && drinkGroups.every((group) => group.rows.every((row) => lockedSet.has(row.kategorie)));
 
-  const handleToggleLock = (group) => {
-    const kategorienKeys = group.rows.map((row) => row.kategorie);
-    if (isGroupLocked(group)) {
-      setLockedKategorien((prev) => {
-        const next = new Set(prev);
-        kategorienKeys.forEach((kategorie) => next.delete(kategorie));
-        return next;
+  const handleToggleEinkaufLock = (group) => {
+    const nextLocked = einkaufLock.toggleGroupLock(group, (keys) => {
+      const werteByKategorie = {};
+      keys.forEach((kategorie) => {
+        werteByKategorie[kategorie] = values[kategorie]?.eingekauft || '';
       });
-      if (currentUser?.id) {
-        unlockEinkaufMengen(currentUser.id, event.id, kategorienKeys).catch((err) => {
-          console.error('Error unlocking eingekauft values:', err);
-        });
-      }
-    } else {
-      setLockedKategorien((prev) => {
-        const next = new Set(prev);
-        kategorienKeys.forEach((kategorie) => next.add(kategorie));
-        return next;
+      return werteByKategorie;
+    });
+    if (!currentUser?.id) return;
+    const allLocked = allGroupsLockedIn(nextLocked);
+    if (allLocked && event.status === 'berechnet') {
+      setEventStatus(currentUser.id, event.id, 'eingekauft').catch((err) => {
+        console.error('Error setting event status to eingekauft:', err);
       });
-      if (currentUser?.id) {
-        const werteByKategorie = {};
-        kategorienKeys.forEach((kategorie) => {
-          werteByKategorie[kategorie] = values[kategorie]?.eingekauft || '';
-        });
-        lockEinkaufMengen(currentUser.id, event.id, werteByKategorie).catch((err) => {
-          console.error('Error locking eingekauft values:', err);
-        });
-      }
+    } else if (!allLocked && event.status === 'eingekauft') {
+      setEventStatus(currentUser.id, event.id, 'berechnet').catch((err) => {
+        console.error('Error resetting event status to berechnet:', err);
+      });
     }
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  const buildGebindePayload = () => {
+    const gebinde = {};
+    Object.entries(values).forEach(([kategorie, { eingekauft, uebrig }]) => {
+      gebinde[kategorie] = {
+        eingekauft: parseFractionQuantity(eingekauft) || 0,
+        uebrig: Number(uebrig) || 0,
+      };
+    });
+    return gebinde;
+  };
+
+  const runSubmitConsumption = async () => {
     setSaving(true);
     setError('');
     try {
-      const gebinde = {};
-      Object.entries(values).forEach(([kategorie, { eingekauft, uebrig }]) => {
-        gebinde[kategorie] = {
-          eingekauft: parseFractionQuantity(eingekauft) || 0,
-          uebrig: Number(uebrig) || 0,
-        };
-      });
-      const result = await submitConsumption(event.id, gebinde);
+      const result = await submitConsumption(event.id, buildGebindePayload());
       setChanges(result.changes || []);
     } catch (err) {
       console.error('Error submitting consumption:', err);
       setError('Der Verbrauch konnte nicht gespeichert werden. Bitte versuche es erneut.');
+      autoSubmitTriggeredRef.current = false;
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleToggleVerbrauchLock = (group) => {
+    const nextLocked = verbrauchLock.toggleGroupLock(group, (keys) => {
+      const werteByKategorie = {};
+      keys.forEach((kategorie) => {
+        werteByKategorie[kategorie] = values[kategorie]?.uebrig ?? '';
+      });
+      return werteByKategorie;
+    });
+    const allLocked = allGroupsLockedIn(nextLocked);
+    if (allLocked && event.status !== 'verbrauchErfasst' && !autoSubmitTriggeredRef.current) {
+      autoSubmitTriggeredRef.current = true;
+      runSubmitConsumption();
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    runSubmitConsumption();
   };
 
   if (changes) {
@@ -346,25 +454,40 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
       )}
       <form className="events-form" onSubmit={handleSubmit}>
         {drinkGroups.map((group) => {
-          const groupLocked = isGroupLocked(group);
+          const einkaufGroupLocked = einkaufLock.isGroupLocked(group);
+          const verbrauchGroupLocked = verbrauchLock.isGroupLocked(group);
+          const rowStatus = event.status === 'geplant'
+            ? null
+            : getGroupRowStatus(group, values, einkaufGroupLocked);
+          const { totalLiter } = getGroupEingekauftLiter(group, values);
+          const bedarfLiter = getGroupBedarfLiter(group);
+          const verbrauchFehlt = isEventPast(event.date) && !verbrauchGroupLocked;
           return (
             <div className="events-consumption-group" key={group.key}>
               <div className="events-consumption-group-header">
-                <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
-                <button
-                  type="button"
-                  className="events-lock-btn"
-                  onClick={() => handleToggleLock(group)}
-                  aria-label={groupLocked ? 'Eingekaufte Menge entsperren' : 'Eingekaufte Menge sperren'}
-                  title={
-                    groupLocked
-                      ? 'Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)'
-                      : 'Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)'
-                  }
-                >
-                  {groupLocked ? <UnlockIcon size={18} /> : <LockIcon size={18} />}
-                </button>
+                <div className="events-consumption-title-group">
+                  <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
+                  <RowStatusIcon status={rowStatus} />
+                  {verbrauchFehlt && (
+                    <span className="events-consumption-missing-usage" title="Verbrauch fehlt" aria-label="Verbrauch fehlt">
+                      ⚠️
+                    </span>
+                  )}
+                </div>
+                <LockToggleButton
+                  locked={einkaufGroupLocked}
+                  onToggle={() => handleToggleEinkaufLock(group)}
+                  lockedLabel="Eingekaufte Menge entsperren"
+                  unlockedLabel="Eingekaufte Menge sperren"
+                  lockedTitle="Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)"
+                  unlockedTitle="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
+                />
               </div>
+              {rowStatus === 'unterdeckung' && (
+                <p className="events-warning-text events-consumption-underdeckung-warning">
+                  Unterdeckung: {formatLiterShort(totalLiter)} l eingekauft, aber {formatLiterShort(bedarfLiter)} l kalkuliert.
+                </p>
+              )}
               {group.rows.map((row) => (
                 <div className="events-form-row" key={row.kategorie}>
                   {getRowUnitSubtitle(row) && (
@@ -379,7 +502,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
                       title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
                       value={values[row.kategorie].eingekauft}
                       onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
-                      disabled={groupLocked}
+                      disabled={einkaufGroupLocked}
                     />
                   </label>
                   <label className="events-form-field">
@@ -389,10 +512,23 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
                       min="0"
                       value={values[row.kategorie].uebrig}
                       onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
+                      disabled={verbrauchGroupLocked}
                     />
                   </label>
                 </div>
               ))}
+              <div className="events-consumption-group-footer">
+                <span className="events-consumption-verbrauch-label">Verbrauch</span>
+                <LockToggleButton
+                  locked={verbrauchGroupLocked}
+                  onToggle={() => handleToggleVerbrauchLock(group)}
+                  lockedLabel="Verbrauchte Menge entsperren"
+                  unlockedLabel="Verbrauchte Menge sperren"
+                  lockedTitle="Verbrauchte Menge entsperren (kann wieder bearbeitet werden)"
+                  unlockedTitle="Verbrauchte Menge sperren (keine automatische Änderung mehr)"
+                  disabled={saving}
+                />
+              </div>
             </div>
           );
         })}

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -6,11 +6,17 @@ import { encodeRecipeLink } from '../utils/recipeLinks';
 const mockSubmitConsumption = jest.fn();
 const mockLockEinkaufMengen = jest.fn(() => Promise.resolve());
 const mockUnlockEinkaufMengen = jest.fn(() => Promise.resolve());
+const mockLockVerbrauchMengen = jest.fn(() => Promise.resolve());
+const mockUnlockVerbrauchMengen = jest.fn(() => Promise.resolve());
+const mockSetEventStatus = jest.fn(() => Promise.resolve());
 
 jest.mock('../utils/eventsFirestore', () => ({
   submitConsumption: (...args) => mockSubmitConsumption(...args),
   lockEinkaufMengen: (...args) => mockLockEinkaufMengen(...args),
   unlockEinkaufMengen: (...args) => mockUnlockEinkaufMengen(...args),
+  lockVerbrauchMengen: (...args) => mockLockVerbrauchMengen(...args),
+  unlockVerbrauchMengen: (...args) => mockUnlockVerbrauchMengen(...args),
+  setEventStatus: (...args) => mockSetEventStatus(...args),
 }));
 
 jest.mock('./EventForm', () => ({
@@ -30,6 +36,13 @@ describe('ConsumptionForm', () => {
     jest.clearAllMocks();
     mockLockEinkaufMengen.mockResolvedValue(undefined);
     mockUnlockEinkaufMengen.mockResolvedValue(undefined);
+    mockLockVerbrauchMengen.mockResolvedValue(undefined);
+    mockUnlockVerbrauchMengen.mockResolvedValue(undefined);
+    mockSetEventStatus.mockResolvedValue(undefined);
+    // Sperren der letzten Verbraucht/Uebrig-Gruppe loest submitConsumption automatisch aus
+    // (siehe handleToggleVerbrauchLock) -- Standard-Resolve, damit Tests, die das nur
+    // beilaeufig ausloesen, nicht an einem unbehandelten Promise-Fehler scheitern.
+    mockSubmitConsumption.mockResolvedValue({ changes: [] });
   });
 
   it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
@@ -324,5 +337,233 @@ describe('ConsumptionForm', () => {
     expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' })).toBeInTheDocument();
+  });
+
+  it('setzt den Event-Status auf "eingekauft", wenn beim Sperren alle Getraenke-Gruppen gesperrt sind', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'berechnet' };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' }));
+
+    expect(mockSetEventStatus).toHaveBeenCalledWith('user1', 'event1', 'eingekauft');
+  });
+
+  it('setzt den Event-Status zurueck auf "berechnet", wenn eine gesperrte Gruppe wieder entsperrt wird', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = {
+      ...makeEvent(ergebnis),
+      status: 'eingekauft',
+      einkaufGesperrt: { 'drink2:0': '3' },
+    };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' }));
+
+    expect(mockSetEventStatus).toHaveBeenCalledWith('user1', 'event1', 'berechnet');
+  });
+
+  it('zeigt eine Unterdeckungs-Warnung, wenn die ueber alle Einheiten summierte Liter-Menge unter dem kalkulierten Bedarf liegt', () => {
+    const einheiten = [
+      { einheitsgroesse: 50, einheit: 'Fass', gebindeinheit: '', einheitenProGebinde: '' },
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink1:0',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 62.7,
+        gebinde: null,
+        gebindeGroesseLiter: 50,
+        einheiten,
+      },
+      {
+        kategorie: 'drink1:1',
+        drinkId: 'drink1',
+        drinkLabel: 'Hausbier',
+        isCustomDrink: true,
+        einheitIdx: 1,
+        literMitPuffer: 62.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'berechnet' };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
+    fireEvent.change(eingekauftInputs[0], { target: { value: '1' } });
+    fireEvent.change(eingekauftInputs[1], { target: { value: '1 1/2' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' }));
+
+    // Fass 1x50L + Flasche 1,5 Kaesten x 7,92L = 61,88L < 62,7L kalkuliert -> Unterdeckung, trotz gesperrt.
+    expect(screen.getByText(/Unterdeckung: 61,88 l eingekauft, aber 62,7 l kalkuliert\./)).toBeInTheDocument();
+  });
+
+  it('zeigt "Ausreichend eingekauft", wenn die gesperrte Summe (Liter) den kalkulierten Bedarf deckt', () => {
+    const einheiten = [
+      { einheitsgroesse: 50, einheit: 'Fass', gebindeinheit: '', einheitenProGebinde: '' },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink5:0',
+        drinkId: 'drink5',
+        drinkLabel: 'Fassbier',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 40,
+        gebinde: null,
+        gebindeGroesseLiter: 50,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'berechnet' };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Eingekauft'), { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' }));
+
+    expect(screen.getByLabelText('Ausreichend eingekauft')).toBeInTheDocument();
+  });
+
+  it('sperrt die Verbraucht/Uebrig-Menge analog zur Eingekauft-Sperre und friert die Eingabe ein', async () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Übrig'), { target: { value: '1' } });
+
+    const verbrauchLockButton = screen.getByRole('button', { name: 'Verbrauchte Menge sperren' });
+    fireEvent.click(verbrauchLockButton);
+
+    expect(mockLockVerbrauchMengen).toHaveBeenCalledWith('user1', 'event1', { 'drink2:0': '1' });
+    expect(screen.getByLabelText('Übrig')).toBeDisabled();
+
+    // Diese Gruppe ist die einzige des Events -- das Sperren loest also auch
+    // automatisch submitConsumption aus; hier nur abwarten, damit der Test
+    // sauber endet (siehe eigener Test unten fuer die Details dazu).
+    await screen.findByText('Verbrauch gespeichert');
+  });
+
+  it('loest submitConsumption automatisch aus, sobald alle Getraenke-Gruppen fuer Verbraucht/Uebrig gesperrt sind', async () => {
+    mockSubmitConsumption.mockResolvedValue({ changes: [] });
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.change(screen.getByLabelText('Übrig'), { target: { value: '0' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Verbrauchte Menge sperren' }));
+
+    expect(await screen.findByText('Verbrauch gespeichert')).toBeInTheDocument();
+    expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } });
+  });
+
+  it('zeigt das Warn-Icon "Verbrauch fehlt", wenn das Eventdatum vergangen und Verbrauch/Uebrig noch nicht gesperrt ist', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'eingekauft', date: '2000-01-01' };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    expect(screen.getByLabelText('Verbrauch fehlt')).toBeInTheDocument();
   });
 });

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -115,6 +115,11 @@
   color: #1d4f8c;
 }
 
+.events-status-eingekauft {
+  background: #ede9fe;
+  color: #5b3fa8;
+}
+
 .events-status-verbrauchErfasst {
   background: #d7f0e3;
   color: #1c6b46;
@@ -306,10 +311,50 @@
   gap: 12px;
 }
 
+.events-consumption-title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .events-consumption-drink-name {
   margin: 0;
   font-weight: 600;
   color: #2F5D50;
+}
+
+.events-row-status-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.events-consumption-missing-usage {
+  font-size: 15px;
+  line-height: 1;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.events-warning-text.events-consumption-underdeckung-warning {
+  color: #c0392b;
+}
+
+.events-consumption-group-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px dashed #e2e2e2;
+}
+
+.events-consumption-verbrauch-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #666;
 }
 
 .events-consumption-unit-subtitle {

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -15,6 +15,7 @@ import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 const STATUS_LABELS = {
   geplant: 'Geplant',
   berechnet: 'Berechnet',
+  eingekauft: 'Eingekauft',
   verbrauchErfasst: 'Verbrauch erfasst',
 };
 
@@ -288,13 +289,13 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
           )}
 
           <div className="events-form-actions">
-            {selectedEvent.status === 'berechnet' && (
+            {(selectedEvent.status === 'berechnet' || selectedEvent.status === 'eingekauft') && (
               <button
                 type="button"
                 className="events-primary-btn"
                 onClick={() => setSubView('consumption')}
               >
-                Verbrauch nachtragen
+                Einkauf & Verbrauch
               </button>
             )}
             {!isMobileView && (

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -163,6 +163,31 @@ describe('EventsPage', () => {
     expect(screen.getByText('Fahrer: Anna Beispiel')).toBeInTheDocument();
   });
 
+  test('shows the "Eingekauft" status badge and the Einkauf & Verbrauch button for status eingekauft', () => {
+    const event = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'eingekauft',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([event]);
+      return jest.fn();
+    });
+
+    render(<EventsPage currentUser={currentUser} />);
+
+    expect(screen.getByText('Eingekauft')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Sommerfest'));
+
+    expect(screen.getByRole('button', { name: 'Einkauf & Verbrauch' })).toBeInTheDocument();
+  });
+
   test('does not show drink summary on event card when status is berechnet but only categories are present', () => {
     const event = {
       id: 'e2',

--- a/src/components/LockToggleButton.js
+++ b/src/components/LockToggleButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import LockIcon from './icons/LockIcon';
+import UnlockIcon from './icons/UnlockIcon';
+
+// Sperren/Entsperren-Button fuer eine Getraenke-Gruppe (z.B. Eingekauft- oder
+// Verbraucht/Uebrig-Menge). Wiederverwendet fuer beide Sperren-Arten in ConsumptionForm.
+function LockToggleButton({ locked, onToggle, lockedLabel, unlockedLabel, lockedTitle, unlockedTitle, disabled }) {
+  return (
+    <button
+      type="button"
+      className="events-lock-btn"
+      onClick={onToggle}
+      aria-label={locked ? lockedLabel : unlockedLabel}
+      title={locked ? lockedTitle : unlockedTitle}
+      disabled={disabled}
+    >
+      {locked ? <UnlockIcon size={18} /> : <LockIcon size={18} />}
+    </button>
+  );
+}
+
+export default LockToggleButton;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3857,6 +3857,11 @@
   color: #8fb8e8;
 }
 
+[data-theme="dark"] .events-status-eingekauft {
+  background: #362a52;
+  color: #c4a8f0;
+}
+
 [data-theme="dark"] .events-status-verbrauchErfasst {
   background: #1a3a2a;
   color: #7fd9a8;
@@ -3869,6 +3874,18 @@
 
 [data-theme="dark"] .events-warning-text {
   color: #e8c766;
+}
+
+[data-theme="dark"] .events-warning-text.events-consumption-underdeckung-warning {
+  color: #e8a0a0;
+}
+
+[data-theme="dark"] .events-consumption-group-footer {
+  border-top-color: #3a3a3a;
+}
+
+[data-theme="dark"] .events-consumption-verbrauch-label {
+  color: #aaa;
 }
 
 [data-theme="dark"] .events-table {

--- a/src/hooks/useGroupLock.js
+++ b/src/hooks/useGroupLock.js
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+/**
+ * Verwaltet den Sperren-Zustand von Getraenke-Gruppen (alle Zeilen/Einheiten
+ * einer Gruppe werden gemeinsam gesperrt/entsperrt) und synchronisiert die
+ * Sperre optimistisch nach Firestore. Wird sowohl fuer die "Eingekauft"- als
+ * auch die "Verbraucht/Uebrig"-Sperre in ConsumptionForm verwendet.
+ * @param {Object} options
+ * @param {Object} [options.initialLocked] - Bereits gesperrte Werte { kategorie: wert } aus Firestore
+ * @param {Object} [options.currentUser] - Aktueller Nutzer ({ id })
+ * @param {string} options.eventId - ID des Events
+ * @param {Function} options.lockFn - (uid, eventId, werteByKategorie) => Promise
+ * @param {Function} options.unlockFn - (uid, eventId, kategorien) => Promise
+ */
+export function useGroupLock({ initialLocked, currentUser, eventId, lockFn, unlockFn }) {
+  const [lockedKategorien, setLockedKategorien] = useState(
+    () => new Set(Object.keys(initialLocked || {}))
+  );
+
+  const isGroupLocked = (group) =>
+    group.rows.length > 0 && group.rows.every((row) => lockedKategorien.has(row.kategorie));
+
+  /**
+   * Sperrt/entsperrt eine Gruppe und gibt das neue Set der gesperrten Kategorien
+   * synchron zurueck (fuer Folgeprüfungen wie "sind jetzt alle Gruppen gesperrt?",
+   * ohne auf den naechsten Render warten zu muessen).
+   * @param {Object} group - Getraenke-Gruppe ({ rows: [...] })
+   * @param {Function} buildLockPayload - (kategorienKeys) => { kategorie: wert } beim Sperren
+   * @returns {Set<string>} Das neue Set der gesperrten Kategorien
+   */
+  const toggleGroupLock = (group, buildLockPayload) => {
+    const kategorienKeys = group.rows.map((row) => row.kategorie);
+    const next = new Set(lockedKategorien);
+    if (isGroupLocked(group)) {
+      kategorienKeys.forEach((kategorie) => next.delete(kategorie));
+      setLockedKategorien(next);
+      if (currentUser?.id) {
+        unlockFn(currentUser.id, eventId, kategorienKeys).catch((err) => {
+          console.error('Error unlocking values:', err);
+        });
+      }
+    } else {
+      kategorienKeys.forEach((kategorie) => next.add(kategorie));
+      setLockedKategorien(next);
+      if (currentUser?.id) {
+        lockFn(currentUser.id, eventId, buildLockPayload(kategorienKeys)).catch((err) => {
+          console.error('Error locking values:', err);
+        });
+      }
+    }
+    return next;
+  };
+
+  return { lockedKategorien, isGroupLocked, toggleGroupLock };
+}

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -145,6 +145,51 @@ export const unlockEinkaufMengen = async (uid, eventId, kategorien) => {
 };
 
 /**
+ * Sperrt die "Verbraucht/Uebrig"-Mengen aller Kategorien eines Getraenks auf einem
+ * Event, damit sie bei einer erneuten Kalibrierung nie ueberschrieben werden.
+ * Analog zu {@link lockEinkaufMengen}, nur fuer das zweite Sperren-Feld.
+ * @param {string} uid - Current user ID
+ * @param {string} eventId - ID of the event
+ * @param {Object} werteByKategorie - { kategorie: uebrig } der einzufrierenden Mengen
+ * @returns {Promise<void>}
+ */
+export const lockVerbrauchMengen = async (uid, eventId, werteByKategorie) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  await setDoc(eventRef, { verbrauchGesperrt: werteByKategorie }, { merge: true });
+};
+
+/**
+ * Entsperrt die "Verbraucht/Uebrig"-Mengen aller Kategorien eines Getraenks auf
+ * einem Event. Analog zu {@link unlockEinkaufMengen}.
+ * @param {string} uid - Current user ID
+ * @param {string} eventId - ID of the event
+ * @param {string[]} kategorien - Kategorie-Schluessel der zu entsperrenden Getraenke-Zeilen
+ * @returns {Promise<void>}
+ */
+export const unlockVerbrauchMengen = async (uid, eventId, kategorien) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  const updates = {};
+  kategorien.forEach((kategorie) => {
+    updates[kategorie] = deleteField();
+  });
+  await setDoc(eventRef, { verbrauchGesperrt: updates }, { merge: true });
+};
+
+/**
+ * Setzt den Event-Status direkt (ohne Neuberechnung), z.B. fuer den Uebergang
+ * "berechnet" -> "eingekauft" -> "berechnet", wenn alle bzw. nicht mehr alle
+ * Getraenke ueber die Eingekauft-Sperre fixiert sind.
+ * @param {string} uid - Current user ID
+ * @param {string} eventId - ID of the event
+ * @param {string} status - Neuer Status ("geplant" | "berechnet" | "eingekauft" | "verbrauchErfasst")
+ * @returns {Promise<void>}
+ */
+export const setEventStatus = async (uid, eventId, status) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  await setDoc(eventRef, { status }, { merge: true });
+};
+
+/**
  * Call the submitConsumption Cloud Function: records the actual consumption
  * of a finished event and updates the user's calibrated rates.
  * @param {string} eventId - ID of the event


### PR DESCRIPTION
- Event-Status um "eingekauft" erweitert (geplant -> berechnet -> eingekauft ->
  verbrauchErfasst), inkl. Badge, Label und Button-Sichtbarkeit in EventsPage.
- Sperren-Mechanik der Eingekauft-Sperre auf Verbraucht/Uebrig gespiegelt
  (neues Firestore-Feld verbrauchGesperrt, gleiches Sperren/Entsperren-Pattern),
  refactored in einen gemeinsamen useGroupLock-Hook und eine gemeinsame
  LockToggleButton-Komponente statt Duplikation.
- Sind alle Getraenke-Gruppen fuer Eingekauft gesperrt, wechselt der
  Event-Status automatisch auf "eingekauft" (und zurueck auf "berechnet" beim
  Entsperren). Sind alle Gruppen fuer Verbraucht/Uebrig gesperrt, wird
  submitConsumption automatisch ausgeloest (Status "verbrauchErfasst" +
  Kalibrierung), zusaetzlich zum bestehenden manuellen Speichern-Button.
- Unterdeckungs-Pruefung aggregiert die eingekauften Mengen eines Getraenks
  ueber alle Einheiten (Fass/Kasten/Flasche) in Liter statt pro Einheit isoliert
  zu vergleichen, unter Wiederverwendung der bestehenden Kaskaden-Umrechnung.
- Zeilen-Status pro Getraenk (offen/unentschieden/unterdeckung/ausreichend,
  visuell per farbigem Schloss-Icon, nicht in Firestore gespeichert) sowie ein
  separates "Verbrauch fehlt"-Warn-Icon nach dem Eventdatum.
- Unterdeckung ist rein informativ (rotes Schloss + Warnhinweis) und blockiert
  das Sperren nicht -- mit dem Nutzer abgestimmt, passend zum Beispiel im
  Feature-Prompt.
- reminderConsumption beruecksichtigt jetzt auch Events mit Status "eingekauft".

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XDJhU3cgJZf7c7XE666Xrc