### PR TITLE
Bevorzugte Getränkekategorien auf Gästekarte anzeigen

### DIFF
--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -498,11 +498,19 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         <div className="events-list">
           {profiles.map((profile) => {
             const fullName = getGuestDisplayName(profile);
+            const preferredCategories = Array.isArray(profile.bevorzugteKategorien)
+              ? profile.bevorzugteKategorien
+              : [];
             return (
               <div key={profile.id} className="events-card" onClick={() => openEdit(profile)}>
                 <div className="events-card-main">
                   <h3>{fullName || 'Unbenannter Gast'}</h3>
                   {profile.kind === true && <p className="events-info-text">Kind</p>}
+                  {preferredCategories.length > 0 && (
+                    <p className="events-card-drink-summary">
+                      Bevorzugt: {preferredCategories.map(getDrinkCategoryLabel).join(', ')}
+                    </p>
+                  )}
                 </div>
               </div>
             );

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -243,4 +243,46 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
 
     expect(screen.getByLabelText('Rotwein entfernen')).toBeInTheDocument();
   });
+
+  test('guest overview card shows preferred drink categories', () => {
+    mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
+      cb([
+        {
+          id: 'g3',
+          vorname: 'Petra',
+          nachname: 'Beispiel',
+          alkoholischeGetränke: true,
+          bevorzugteGetränke: [],
+          bevorzugteKategorien: ['wein_rotwein', 'bier'],
+          präferenzFaktor: 0.5,
+        },
+      ]);
+      return jest.fn();
+    });
+
+    render(<GuestManagementPage currentUser={currentUser} />);
+
+    expect(screen.getByText('Bevorzugt: Rotwein, Bier')).toBeInTheDocument();
+  });
+
+  test('guest overview card shows no preference line when no categories are set', () => {
+    mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
+      cb([
+        {
+          id: 'g4',
+          vorname: 'Otto',
+          nachname: 'Beispiel',
+          alkoholischeGetränke: true,
+          bevorzugteGetränke: [],
+          bevorzugteKategorien: [],
+          präferenzFaktor: 0.5,
+        },
+      ]);
+      return jest.fn();
+    });
+
+    render(<GuestManagementPage currentUser={currentUser} />);
+
+    expect(screen.queryByText(/Bevorzugt:/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Die Gästeübersicht zeigt bisher nicht an, welche Getränkekategorien ein
Gast bevorzugt, obwohl diese Präferenz beim Anlegen/Bearbeiten bereits
erfasst wird. Ergänzt eine Zusammenfassungszeile auf der Gästekarte.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012DstNPpM5S1f3ir6sXVC4h