### PR TITLE
Redesign Einkauf/Verbrauch-Buttons als gleichwertiges Paar

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -22,6 +22,9 @@ import ShoppingListModal from './ShoppingListModal';
 import LockToggleButton from './LockToggleButton';
 import LockIcon from './icons/LockIcon';
 import UnlockIcon from './icons/UnlockIcon';
+import ShoppingCartIcon from './icons/ShoppingCartIcon';
+import CupIcon from './icons/CupIcon';
+import ChevronRightIcon from './icons/ChevronRightIcon';
 
 function getEinheitSizeLabel(einheitsgroesse) {
   const liters = Number(einheitsgroesse);
@@ -163,6 +166,61 @@ function formatLiterShort(value) {
   return num.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 2 });
 }
 
+// Kompakte Zusammenfassung der eingetragenen "Eingekauft"-Mengen fuer den Einkauf-Button, z.B. "1× Fass, 1× Flasche".
+function getGroupEinkaufSummary(group, values) {
+  const parts = [];
+  group.rows.forEach((row) => {
+    const qty = (values[row.kategorie]?.eingekauft || '').trim();
+    if (!qty || !parseFractionQuantity(qty)) return;
+    const unit = getRowPurchaseUnit(row);
+    parts.push(unit ? `${qty}× ${unit}` : qty);
+  });
+  return parts.join(', ');
+}
+
+// Zusammenfassung fuer den Verbrauch-Button: eingetragene "Uebrig"-Mengen, sonst der
+// kalkulierte Bedarf als Platzhalter, solange noch nichts erfasst wurde.
+function getGroupVerbrauchSummary(group, values, bedarfLiter) {
+  const parts = [];
+  group.rows.forEach((row) => {
+    const raw = values[row.kategorie]?.uebrig;
+    if (raw === '' || raw === undefined || raw === null) return;
+    const num = Number(raw);
+    if (!Number.isFinite(num)) return;
+    const unit = getRowPurchaseUnit(row);
+    parts.push(unit ? `${num}× ${unit} übrig` : `${num} übrig`);
+  });
+  if (parts.length > 0) return parts.join(', ');
+  return bedarfLiter > 0 ? `${formatLiterShort(bedarfLiter)} l` : '–';
+}
+
+// Gesamt-Sperrstatus einer Getraenke-Gruppe fuer die Status-Pill im Card-Header.
+// "Verbrauch gesperrt" ohne "Einkauf gesperrt" ist im normalen Ablauf nicht vorgesehen
+// und wird wie "voll gesperrt" behandelt.
+function getGroupLockState(einkaufLocked, verbrauchLocked) {
+  if (verbrauchLocked) return 'fullyLocked';
+  if (einkaufLocked) return 'purchaseLocked';
+  return 'open';
+}
+
+const LOCK_STATE_CONFIG = {
+  open: { label: 'Offen', color: '#999', filled: false, Icon: UnlockIcon },
+  purchaseLocked: { label: 'Einkauf gesperrt', color: '#c9a227', filled: false, Icon: LockIcon },
+  fullyLocked: { label: 'Einkauf & Verbrauch gesperrt', color: '#2F5D50', filled: true, Icon: LockIcon },
+};
+
+// Eigenstaendiges Status-Element oben rechts in der Card-Kopfzeile (keine Toggle-Funktion,
+// nur Anzeige -- die eigentlichen Sperren-Buttons sitzen im aufgeklappten Detailbereich).
+function LockStatusPill({ state }) {
+  const { label, color, filled, Icon } = LOCK_STATE_CONFIG[state];
+  return (
+    <span className={`events-lock-status-pill events-lock-status-${state}`} title={label}>
+      <Icon size={14} color={color} filled={filled} />
+      <span>{label}</span>
+    </span>
+  );
+}
+
 const ROW_STATUS_ICON_PROPS = {
   neutral: { Icon: LockIcon, color: '#999', title: 'Keine Kalkulation vorhanden - Unterdeckungs-Prüfung nicht möglich' },
   unentschieden: { Icon: UnlockIcon, color: '#c9a227', title: 'Eingekaufte Menge noch nicht gesperrt' },
@@ -231,6 +289,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const [showShoppingListModal, setShowShoppingListModal] = useState(false);
   const [showPortionSelector, setShowPortionSelector] = useState(false);
   const [linkedPortionCounts, setLinkedPortionCounts] = useState({});
+  const [expandedSection, setExpandedSection] = useState({});
   const missingSavedRef = useRef(false);
   const autoSubmitTriggeredRef = useRef(false);
   const {
@@ -319,6 +378,13 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
       missingSavedRef.current = false;
       setShowShoppingListModal(true);
     }
+  };
+
+  const toggleSection = (groupKey, section) => {
+    setExpandedSection((prev) => ({
+      ...prev,
+      [groupKey]: prev[groupKey] === section ? null : section,
+    }));
   };
 
   const updateValue = (kategorie, field, value) => {
@@ -462,9 +528,13 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
           const { totalLiter } = getGroupEingekauftLiter(group, values);
           const bedarfLiter = getGroupBedarfLiter(group);
           const verbrauchFehlt = isEventPast(event.date) && !verbrauchGroupLocked;
+          const lockState = getGroupLockState(einkaufGroupLocked, verbrauchGroupLocked);
+          const einkaufSummary = getGroupEinkaufSummary(group, values);
+          const verbrauchSummary = getGroupVerbrauchSummary(group, values, bedarfLiter);
+          const activeSection = expandedSection[group.key] || null;
           return (
             <div className="events-consumption-group" key={group.key}>
-              <div className="events-consumption-group-header">
+              <div className="events-consumption-card-header">
                 <div className="events-consumption-title-group">
                   <h3 className="events-consumption-drink-name">{group.drinkName}</h3>
                   <RowStatusIcon status={rowStatus} />
@@ -474,61 +544,113 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
                     </span>
                   )}
                 </div>
-                <LockToggleButton
-                  locked={einkaufGroupLocked}
-                  onToggle={() => handleToggleEinkaufLock(group)}
-                  lockedLabel="Eingekaufte Menge entsperren"
-                  unlockedLabel="Eingekaufte Menge sperren"
-                  lockedTitle="Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)"
-                  unlockedTitle="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
-                />
+                <LockStatusPill state={lockState} />
               </div>
               {rowStatus === 'unterdeckung' && (
                 <p className="events-warning-text events-consumption-underdeckung-warning">
                   Unterdeckung: {formatLiterShort(totalLiter)} l eingekauft, aber {formatLiterShort(bedarfLiter)} l kalkuliert.
                 </p>
               )}
-              {group.rows.map((row) => (
-                <div className="events-form-row" key={row.kategorie}>
-                  {getRowUnitSubtitle(row) && (
-                    <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
-                  )}
-                  <label className="events-form-field">
-                    <span>Eingekauft</span>
-                    <input
-                      type="text"
-                      inputMode="text"
-                      placeholder="z.B. 1 3/4"
-                      title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
-                      value={values[row.kategorie].eingekauft}
-                      onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
-                      disabled={einkaufGroupLocked}
-                    />
-                  </label>
-                  <label className="events-form-field">
-                    <span>Übrig</span>
-                    <input
-                      type="number"
-                      min="0"
-                      value={values[row.kategorie].uebrig}
-                      onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
-                      disabled={verbrauchGroupLocked}
-                    />
-                  </label>
-                </div>
-              ))}
-              <div className="events-consumption-group-footer">
-                <span className="events-consumption-verbrauch-label">Verbrauch</span>
-                <LockToggleButton
-                  locked={verbrauchGroupLocked}
-                  onToggle={() => handleToggleVerbrauchLock(group)}
-                  lockedLabel="Verbrauchte Menge entsperren"
-                  unlockedLabel="Verbrauchte Menge sperren"
-                  lockedTitle="Verbrauchte Menge entsperren (kann wieder bearbeitet werden)"
-                  unlockedTitle="Verbrauchte Menge sperren (keine automatische Änderung mehr)"
-                  disabled={saving}
-                />
+
+              <div className="events-consumption-button-grid">
+                <button
+                  type="button"
+                  className={`events-consumption-toggle-btn${einkaufGroupLocked ? ' is-locked' : ''}${activeSection === 'einkauf' ? ' is-expanded' : ''}`}
+                  onClick={() => toggleSection(group.key, 'einkauf')}
+                  aria-expanded={activeSection === 'einkauf'}
+                  aria-label="Einkauf bearbeiten"
+                  title="Einkauf bearbeiten"
+                >
+                  <ShoppingCartIcon size={16} />
+                  <span className="events-consumption-toggle-text">
+                    <span className="events-consumption-toggle-label">Einkauf</span>
+                    <span className="events-consumption-toggle-value">{einkaufSummary || '–'}</span>
+                  </span>
+                  <ChevronRightIcon size={14} />
+                </button>
+                <button
+                  type="button"
+                  className={`events-consumption-toggle-btn${verbrauchGroupLocked ? ' is-locked' : ''}${activeSection === 'verbrauch' ? ' is-expanded' : ''}`}
+                  onClick={() => toggleSection(group.key, 'verbrauch')}
+                  aria-expanded={activeSection === 'verbrauch'}
+                  aria-label="Verbrauch bearbeiten"
+                  title="Verbrauch bearbeiten"
+                >
+                  <CupIcon size={16} />
+                  <span className="events-consumption-toggle-text">
+                    <span className="events-consumption-toggle-label">Verbrauch</span>
+                    <span className="events-consumption-toggle-value">{verbrauchSummary}</span>
+                  </span>
+                  <ChevronRightIcon size={14} />
+                </button>
               </div>
+
+              {activeSection === 'einkauf' && (
+                <div className="events-consumption-detail">
+                  {group.rows.map((row) => (
+                    <div className="events-form-row" key={row.kategorie}>
+                      {getRowUnitSubtitle(row) && (
+                        <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
+                      )}
+                      <label className="events-form-field">
+                        <span>Eingekauft</span>
+                        <input
+                          type="text"
+                          inputMode="text"
+                          placeholder="z.B. 1 3/4"
+                          title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
+                          value={values[row.kategorie].eingekauft}
+                          onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
+                          disabled={einkaufGroupLocked}
+                        />
+                      </label>
+                    </div>
+                  ))}
+                  <div className="events-consumption-detail-footer">
+                    <LockToggleButton
+                      locked={einkaufGroupLocked}
+                      onToggle={() => handleToggleEinkaufLock(group)}
+                      lockedLabel="Eingekaufte Menge entsperren"
+                      unlockedLabel="Eingekaufte Menge sperren"
+                      lockedTitle="Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)"
+                      unlockedTitle="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {activeSection === 'verbrauch' && (
+                <div className="events-consumption-detail">
+                  {group.rows.map((row) => (
+                    <div className="events-form-row" key={row.kategorie}>
+                      {getRowUnitSubtitle(row) && (
+                        <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
+                      )}
+                      <label className="events-form-field">
+                        <span>Übrig</span>
+                        <input
+                          type="number"
+                          min="0"
+                          value={values[row.kategorie].uebrig}
+                          onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
+                          disabled={verbrauchGroupLocked}
+                        />
+                      </label>
+                    </div>
+                  ))}
+                  <div className="events-consumption-detail-footer">
+                    <LockToggleButton
+                      locked={verbrauchGroupLocked}
+                      onToggle={() => handleToggleVerbrauchLock(group)}
+                      lockedLabel="Verbrauchte Menge entsperren"
+                      unlockedLabel="Verbrauchte Menge sperren"
+                      lockedTitle="Verbrauchte Menge entsperren (kann wieder bearbeitet werden)"
+                      unlockedTitle="Verbrauchte Menge sperren (keine automatische Änderung mehr)"
+                      disabled={saving}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -77,6 +77,8 @@ describe('ConsumptionForm', () => {
 
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
     expect(eingekauftInputs).toHaveLength(2);
     expect(eingekauftInputs[0]).toHaveValue('1');
@@ -103,6 +105,8 @@ describe('ConsumptionForm', () => {
 
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     const eingekauftInput = screen.getByLabelText('Eingekauft');
     expect(eingekauftInput).toHaveValue('1 3/4');
   });
@@ -126,6 +130,8 @@ describe('ConsumptionForm', () => {
     ];
 
     render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
 
     const eingekauftInput = screen.getByLabelText('Eingekauft');
     expect(eingekauftInput).toHaveValue('');
@@ -239,6 +245,8 @@ describe('ConsumptionForm', () => {
       />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     const lockButton = screen.getByRole('button', { name: 'Eingekaufte Menge sperren' });
     fireEvent.click(lockButton);
 
@@ -297,6 +305,8 @@ describe('ConsumptionForm', () => {
       />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     const eingekauftInputsLocked = screen.getAllByLabelText('Eingekauft');
     expect(eingekauftInputsLocked[0]).toBeDisabled();
     expect(eingekauftInputsLocked[1]).toBeDisabled();
@@ -333,6 +343,8 @@ describe('ConsumptionForm', () => {
 
     render(<ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     expect(screen.getByLabelText('Eingekauft')).toHaveValue('3');
     expect(screen.getByLabelText('Eingekauft')).toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Eingekaufte Menge sperren' })).not.toBeInTheDocument();
@@ -362,6 +374,7 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
     fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' }));
 
     expect(mockSetEventStatus).toHaveBeenCalledWith('user1', 'event1', 'eingekauft');
@@ -394,6 +407,7 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
     fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge entsperren' }));
 
     expect(mockSetEventStatus).toHaveBeenCalledWith('user1', 'event1', 'berechnet');
@@ -434,6 +448,8 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+
     const eingekauftInputs = screen.getAllByLabelText('Eingekauft');
     fireEvent.change(eingekauftInputs[0], { target: { value: '1' } });
     fireEvent.change(eingekauftInputs[1], { target: { value: '1 1/2' } });
@@ -467,6 +483,7 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
     fireEvent.change(screen.getByLabelText('Eingekauft'), { target: { value: '1' } });
     fireEvent.click(screen.getByRole('button', { name: 'Eingekaufte Menge sperren' }));
 
@@ -496,6 +513,7 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Verbrauch bearbeiten' }));
     fireEvent.change(screen.getByLabelText('Übrig'), { target: { value: '1' } });
 
     const verbrauchLockButton = screen.getByRole('button', { name: 'Verbrauchte Menge sperren' });
@@ -534,6 +552,7 @@ describe('ConsumptionForm', () => {
       <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
+    fireEvent.click(screen.getByRole('button', { name: 'Verbrauch bearbeiten' }));
     fireEvent.change(screen.getByLabelText('Übrig'), { target: { value: '0' } });
     fireEvent.click(screen.getByRole('button', { name: 'Verbrauchte Menge sperren' }));
 

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -304,9 +304,9 @@
   border-top: 1px solid #eee;
 }
 
-.events-consumption-group-header {
+.events-consumption-card-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
 }
@@ -341,20 +341,119 @@
   color: #c0392b;
 }
 
-.events-consumption-group-footer {
+.events-lock-status-pill {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  font-size: 11px;
+  font-weight: 500;
+  color: #777;
+  white-space: nowrap;
+}
+
+.events-lock-status-pill svg {
+  flex-shrink: 0;
+}
+
+.events-lock-status-purchaseLocked {
+  color: #96751a;
+}
+
+.events-lock-status-fullyLocked {
+  color: #2F5D50;
+}
+
+.events-consumption-button-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.events-consumption-toggle-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-top: 4px;
-  padding-top: 8px;
-  border-top: 1px dashed #e2e2e2;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid #d8d8d3;
+  border-radius: 12px;
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  font-family: inherit;
 }
 
-.events-consumption-verbrauch-label {
+.events-consumption-toggle-btn:hover {
+  border-color: #2F5D50;
+}
+
+.events-consumption-toggle-btn.is-expanded {
+  border-color: #2F5D50;
+  box-shadow: 0 0 0 2px rgba(47, 93, 80, 0.12);
+}
+
+.events-consumption-toggle-btn.is-locked {
+  background: #f7f7f5;
+  border-color: #ececec;
+  color: #999;
+}
+
+.events-consumption-toggle-btn.is-locked:hover {
+  border-color: #ececec;
+}
+
+.events-consumption-toggle-btn svg {
+  flex-shrink: 0;
+}
+
+.events-consumption-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  text-align: left;
+}
+
+.events-consumption-toggle-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.events-consumption-toggle-value {
   font-size: 13px;
   font-weight: 500;
-  color: #666;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.events-consumption-toggle-btn svg:last-child {
+  opacity: 0.4;
+}
+
+.events-consumption-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+  padding: 12px;
+  border-radius: 10px;
+  background: #fafaf8;
+}
+
+.events-consumption-detail-footer {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .events-consumption-unit-subtitle {

--- a/src/components/icons/ChevronRightIcon.js
+++ b/src/components/icons/ChevronRightIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const ChevronRightIcon = ({ color = 'currentColor', size = 24 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M9 6l6 6-6 6"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+};
+
+export default ChevronRightIcon;

--- a/src/components/icons/CupIcon.js
+++ b/src/components/icons/CupIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const CupIcon = ({ color = 'currentColor', size = 24 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M6 3h12l-1.2 15.2A2 2 0 0 1 14.8 20H9.2a2 2 0 0 1-2-1.8L6 3z"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path d="M7 9h10" stroke={color} strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+};
+
+export default CupIcon;

--- a/src/components/icons/LockIcon.js
+++ b/src/components/icons/LockIcon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const LockIcon = ({ color = 'currentColor', size = 24 }) => {
+const LockIcon = ({ color = 'currentColor', size = 24, filled = false }) => {
   return (
     <svg
       width={size}
@@ -17,7 +17,7 @@ const LockIcon = ({ color = 'currentColor', size = 24 }) => {
         rx="2"
         stroke={color}
         strokeWidth="2"
-        fill="none"
+        fill={filled ? color : 'none'}
       />
       <path
         d="M8 11V7a4 4 0 0 1 8 0v4"

--- a/src/components/icons/ShoppingCartIcon.js
+++ b/src/components/icons/ShoppingCartIcon.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const ShoppingCartIcon = ({ color = 'currentColor', size = 24 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="9" cy="20" r="1.5" fill={color} />
+      <circle cx="18" cy="20" r="1.5" fill={color} />
+      <path
+        d="M2 3h2l2.4 12.2a2 2 0 0 0 2 1.6h8.6a2 2 0 0 0 2-1.6L21 7H6"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+};
+
+export default ShoppingCartIcon;


### PR DESCRIPTION
Einkauf und Verbrauch sitzen jetzt als gleich große Buttons (Icon,
Label, Wert, Chevron) nebeneinander in einem 2-Spalten-Grid statt an
unterschiedlichen Stellen der Card. Der Lock-Status ist als eigene
Pill oben rechts im Card-Header ausgelagert und nicht mehr an einen
der beiden Buttons gekoppelt. Tippen auf einen Button klappt die
bestehenden Eingabefelder inline auf; gesperrte Buttons wirken
blasser, bleiben aber lesbar, lange Einkaufswerte werden per Ellipsis
abgeschnitten statt umzubrechen.