### PR TITLE
Show favorite drinks on guest cards and fix Kind spacing

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -94,6 +94,10 @@
   font-size: 13px;
 }
 
+.events-card-main .events-info-text {
+  margin: 4px 0 0;
+}
+
 .events-status-badge {
   flex-shrink: 0;
   padding: 4px 10px;

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -498,17 +498,23 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         <div className="events-list">
           {profiles.map((profile) => {
             const fullName = getGuestDisplayName(profile);
-            const preferredCategories = Array.isArray(profile.bevorzugteKategorien)
-              ? profile.bevorzugteKategorien
+            const preferredDrinkNames = Array.isArray(profile.bevorzugteGetraenke)
+              ? profile.bevorzugteGetraenke.map(
+                  (drinkId) => availableDrinks.find((d) => d.id === drinkId)?.label || drinkId
+                )
               : [];
+            const preferredCategoryNames = Array.isArray(profile.bevorzugteKategorien)
+              ? profile.bevorzugteKategorien.map(getDrinkCategoryLabel)
+              : [];
+            const preferredSummary = [...preferredDrinkNames, ...preferredCategoryNames];
             return (
               <div key={profile.id} className="events-card" onClick={() => openEdit(profile)}>
                 <div className="events-card-main">
                   <h3>{fullName || 'Unbenannter Gast'}</h3>
                   {profile.kind === true && <p className="events-info-text">Kind</p>}
-                  {preferredCategories.length > 0 && (
+                  {preferredSummary.length > 0 && (
                     <p className="events-card-drink-summary">
-                      Bevorzugt: {preferredCategories.map(getDrinkCategoryLabel).join(', ')}
+                      Bevorzugt: {preferredSummary.join(', ')}
                     </p>
                   )}
                 </div>


### PR DESCRIPTION
Guest cards only read bevorzugteKategorien, so guests with only
individual bevorzugte Getränke selected showed no preference summary.
Now both preferred drinks and categories are combined into the card
summary. Also aligned the "Kind" badge's top margin with the drink
summary line, which previously relied on the browser's default <p>
margin and sat much further from the guest name.