### PR TITLE
Verbrauch-Anzeige zeigt immer Einkauf minus Uebrig

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -188,20 +188,36 @@ function getGroupEinkaufSummary(group, values) {
   return parts.join(', ');
 }
 
-// Zusammenfassung fuer den Verbrauch-Button: eingetragene "Uebrig"-Mengen, sonst der
-// kalkulierte Bedarf als Platzhalter, solange noch nichts erfasst wurde.
-function getGroupVerbrauchSummary(group, values, bedarfLiter) {
-  const parts = [];
-  group.rows.forEach((row) => {
-    const raw = values[row.kategorie]?.uebrig;
-    if (raw === '' || raw === undefined || raw === null) return;
-    const num = Number(raw);
-    if (!Number.isFinite(num)) return;
-    const unit = getRowConsumptionUnit(row);
-    parts.push(unit ? `${num}× ${unit} übrig` : `${num} übrig`);
+// Berechnet den tatsaechlichen Verbrauch einer Getraenke-Gruppe in Litern als
+// Einkauf minus Uebrig -- analog zur Backend-Berechnung in submitConsumption
+// (gebindeZuLiter), damit die Anzeige immer der spaeter gespeicherten Menge entspricht.
+function getGroupVerbrauchLiter(group, values) {
+  const units = getGroupCascadeUnits(group);
+  let totalLiter = 0;
+  units.forEach((unit) => {
+    const eingekauft = parseFractionQuantity(values[unit.key]?.eingekauft) || 0;
+    const uebrigEinheiten = Number(values[unit.key]?.uebrig) || 0;
+    const hatGebinde = Number.isFinite(unit.einheitsgroesseLiter) && unit.einheitsgroesseLiter > 0
+      && Number.isFinite(unit.gebindeGroesseLiter) && unit.gebindeGroesseLiter > 0;
+    const uebrigGebinde = hatGebinde
+      ? (uebrigEinheiten * unit.einheitsgroesseLiter) / unit.gebindeGroesseLiter
+      : uebrigEinheiten;
+    const verbrauchtGebinde = Math.max(eingekauft - uebrigGebinde, 0);
+    const perUnitLiter = Number.isFinite(unit.gebindeGroesseLiter) && unit.gebindeGroesseLiter > 0
+      ? unit.gebindeGroesseLiter
+      : unit.einheitsgroesseLiter;
+    if (Number.isFinite(perUnitLiter) && perUnitLiter > 0) {
+      totalLiter += verbrauchtGebinde * perUnitLiter;
+    }
   });
-  if (parts.length > 0) return parts.join(', ');
-  return bedarfLiter > 0 ? `${formatLiterShort(bedarfLiter)} l` : '–';
+  return totalLiter;
+}
+
+// Zusammenfassung fuer den Verbrauch-Button: zeigt immer den berechneten
+// Verbrauch (Einkauf minus Uebrig) der Gruppe in Litern.
+function getGroupVerbrauchSummary(group, values) {
+  const verbrauchLiter = getGroupVerbrauchLiter(group, values);
+  return verbrauchLiter > 0 ? `${formatLiterShort(verbrauchLiter)} l` : '–';
 }
 
 // Ermittelt den Sperr-Zustand einer Getraenke-Gruppe aus den getrennten
@@ -539,7 +555,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
           const verbrauchFehlt = isEventPast(event.date) && !verbrauchGroupLocked;
           const lockState = getLockIconState(einkaufGroupLocked, verbrauchGroupLocked);
           const einkaufSummary = getGroupEinkaufSummary(group, values);
-          const verbrauchSummary = getGroupVerbrauchSummary(group, values, bedarfLiter);
+          const verbrauchSummary = getGroupVerbrauchSummary(group, values);
           const activeSection = expandedSection[group.key] || null;
           return (
             <div className="events-consumption-group" key={group.key}>

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -560,6 +560,39 @@ describe('ConsumptionForm', () => {
     expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } });
   });
 
+  it('zeigt im Verbrauch-Button immer Einkauf minus Uebrig als Liter-Menge an', () => {
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    // Eingekauft = 2 Kasten (gesperrt), noch nichts uebrig eingetragen -> Verbrauch = 2 Kasten x 7,92l.
+    expect(screen.getByText('15,84 l')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Verbrauch bearbeiten' }));
+    fireEvent.change(screen.getByLabelText('Übrig (Flasche)'), { target: { value: '12' } });
+
+    // Uebrig = 12 Flaschen = 0,5 Kasten -> Verbrauch = 1,5 Kasten x 7,92l = 11,88l.
+    expect(screen.getByText('11,88 l')).toBeInTheDocument();
+  });
+
   it('zeigt das Warn-Icon "Verbrauch fehlt", wenn das Eventdatum vergangen und Verbrauch/Uebrig noch nicht gesperrt ist', () => {
     const einheiten = [
       { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },


### PR DESCRIPTION
Der Verbrauch-Button auf der Seite Einkauf & Verbrauch zeigte bisher
entweder die eingetragene Uebrig-Menge (faelschlich als "Verbrauch"
gelabelt) oder den kalkulierten Bedarf als Platzhalter an. Jetzt wird
immer der tatsaechliche Verbrauch als Einkauf minus Uebrig in Litern
berechnet und angezeigt, analog zur Backend-Logik in submitConsumption.