### PR TITLE
Fix light divider lines between drinks in dark mode

### DIFF
--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3884,6 +3884,11 @@
   border-top-color: #3a3a3a;
 }
 
+[data-theme="dark"] .events-consumption-group + .events-consumption-group,
+[data-theme="dark"] .events-einheit-group + .events-einheit-group {
+  border-top-color: #3a3a3a;
+}
+
 [data-theme="dark"] .events-consumption-verbrauch-label {
   color: #aaa;
 }


### PR DESCRIPTION
The border-top separating consecutive drink groups (and Einheit
groups) on the Einkauf & Verbrauch screen still used the light-mode
#eee color, making it stand out against the dark background.