### PR TITLE
Event-Status "Verbrauch erfasst" erst setzen, wenn alle Getraenke gesperrt sind

### DIFF
--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -79,12 +79,29 @@ function impliedRate(cat, literGemessen, event, ratesDb) {
 }
 
 /**
+ * Prueft, ob fuer alle Getraenke-Kategorien eines Events die "Verbraucht/Uebrig"-Menge
+ * gesperrt (also final erfasst) ist. Nur dann darf der Event-Status auf
+ * "verbrauchErfasst" gesetzt werden.
+ * @param {object} event Event-Dokument.
+ * @param {object} verbrauchGesperrt Aktuelle (bzw. gemergte) Sperren-Map { kategorie: wert }.
+ * @return {boolean} true, wenn alle relevanten Kategorien gesperrt sind.
+ */
+function alleGetraenkeVerbrauchGesperrt(event, verbrauchGesperrt) {
+  const kategorien = (event.berechnung?.ergebnis || [])
+      .filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter);
+  if (kategorien.length === 0) return false;
+  return kategorien.every((row) =>
+    Object.prototype.hasOwnProperty.call(verbrauchGesperrt || {}, row.kategorie));
+}
+
+/**
  * Callable: submitConsumption({ eventId, gebinde })
  * - eventId: ID des Event-Dokuments (muss existieren und berechnet sein)
  * - gebinde: { kategorie: { eingekauft: <Anzahl>, uebrig: <Anzahl> } }
  *   in Gebinde-Einheiten (Flaschen/Kisten/Tassen je nach Kategorie)
- * Aktualisiert users/{uid}/erfahrungswerte/* per gewichtetem Durchschnitt
- * und setzt den Event-Status auf "verbrauchErfasst".
+ * Aktualisiert users/{uid}/erfahrungswerte/* per gewichtetem Durchschnitt und
+ * setzt den Event-Status erst dann auf "verbrauchErfasst", wenn fuer ALLE
+ * Getraenke des Events die Verbraucht/Uebrig-Menge gesperrt ist.
  * Gibt eine Zusammenfassung der Aenderungen zurueck.
  */
 exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
@@ -92,7 +109,7 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
     throw new HttpsError('unauthenticated', 'Login erforderlich.');
   }
   const uid = request.auth.uid;
-  const {eventId, gebinde} = request.data || {};
+  const {eventId, gebinde, verbrauchGesperrtKategorien} = request.data || {};
 
   if (!eventId || !gebinde) {
     throw new HttpsError('invalid-argument', 'eventId und gebinde sind erforderlich.');
@@ -145,15 +162,26 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
     });
   }
 
-  batch.set(eventRef, {
-    status: 'verbrauchErfasst',
+  const eventUpdate = {
     istVerbrauch: literGemessen,
     istVerbrauchEingegeben: gebinde,
-  }, {merge: true});
+  };
+  // Die vom Client mitgesendeten, gerade gesperrten Kategorien werden mit dem
+  // in Firestore gespeicherten Stand vereinigt, damit ein noch nicht
+  // durchgeschriebener Sperren-Aufruf (Race Condition beim automatischen
+  // Absenden nach dem letzten Sperren) den Status nicht faelschlich blockiert.
+  const verbrauchGesperrt = {...(event.verbrauchGesperrt || {})};
+  (verbrauchGesperrtKategorien || []).forEach((kategorie) => {
+    verbrauchGesperrt[kategorie] = true;
+  });
+  if (alleGetraenkeVerbrauchGesperrt(event, verbrauchGesperrt)) {
+    eventUpdate.status = 'verbrauchErfasst';
+  }
+  batch.set(eventRef, eventUpdate, {merge: true});
 
   await batch.commit();
 
   return {eventId, changes};
 });
 
-exports._internal = {gebindeZuLiter, impliedRate};
+exports._internal = {gebindeZuLiter, impliedRate, alleGetraenkeVerbrauchGesperrt};

--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -461,11 +461,12 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     return gebinde;
   };
 
-  const runSubmitConsumption = async () => {
+  const runSubmitConsumption = async (verbrauchGesperrtKategorien) => {
     setSaving(true);
     setError('');
     try {
-      const result = await submitConsumption(event.id, buildGebindePayload());
+      const gesperrt = verbrauchGesperrtKategorien || verbrauchLock.lockedKategorien;
+      const result = await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt));
       setChanges(result.changes || []);
     } catch (err) {
       console.error('Error submitting consumption:', err);
@@ -493,7 +494,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     const allLocked = allGroupsLockedIn(nextLocked);
     if (allLocked && event.status !== 'verbrauchErfasst' && !autoSubmitTriggeredRef.current) {
       autoSubmitTriggeredRef.current = true;
-      runSubmitConsumption();
+      runSubmitConsumption(nextLocked);
     }
   };
 

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -557,7 +557,7 @@ describe('ConsumptionForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Verbrauchte Menge sperren' }));
 
     expect(await screen.findByText('Verbrauch gespeichert')).toBeInTheDocument();
-    expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } });
+    expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } }, ['drink2:0']);
   });
 
   it('sperrt beim Sperren der Verbraucht/Uebrig-Menge automatisch auch die noch ungesperrte Eingekauft-Menge', async () => {

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -191,14 +191,18 @@ export const setEventStatus = async (uid, eventId, status) => {
 
 /**
  * Call the submitConsumption Cloud Function: records the actual consumption
- * of a finished event and updates the user's calibrated rates.
+ * of a finished event and updates the user's calibrated rates. Der Event-Status
+ * wird serverseitig nur dann auf "verbrauchErfasst" gesetzt, wenn alle Getraenke
+ * des Events gesperrt sind (siehe verbrauchGesperrtKategorien).
  * @param {string} eventId - ID of the event
  * @param {Object} gebinde - { kategorie: { eingekauft, uebrig } } in Gebinde-Einheiten
+ * @param {string[]} [verbrauchGesperrtKategorien] - Kategorien, die aktuell (auch
+ *   client-seitig noch nicht durchgeschrieben) als "Verbrauch gesperrt" gelten
  * @returns {Promise<Object>} { eventId, changes }
  */
-export const submitConsumption = async (eventId, gebinde) => {
+export const submitConsumption = async (eventId, gebinde, verbrauchGesperrtKategorien) => {
   const fn = httpsCallable(functions, 'submitConsumption');
-  const result = await fn({ eventId, gebinde });
+  const result = await fn({ eventId, gebinde, verbrauchGesperrtKategorien });
   return result.data;
 };
 


### PR DESCRIPTION
Die Cloud Function submitConsumption setzte den Event-Status bislang
unconditional auf "verbrauchErfasst", sobald sie aufgerufen wurde --
auch wenn der manuelle "Verbrauch speichern"-Button gedrueckt wurde,
ohne dass zuvor alle Getraenke-Gruppen ueber die Verbraucht/Uebrig-Sperre
fixiert waren. Jetzt wird der Status nur noch gesetzt, wenn fuer alle
Getraenke des Events die Verbrauchsmenge gesperrt ist. Die gerade
gesperrten Kategorien werden vom Client mitgeschickt, damit der
automatische Trigger nach dem letzten Sperren nicht durch eine noch
nicht durchgeschriebene Firestore-Sperre ausgebremst wird.