### PR TITLE
Fix: Bedarfsberechnung-Kaskade nutzt Gebindegroesse auch fuer mittlere Einheiten

### DIFF
--- a/src/utils/einkaufCascade.js
+++ b/src/utils/einkaufCascade.js
@@ -39,11 +39,16 @@ function roundToWholeNumber(value) {
 /**
  * Verteilt den Liter-Bedarf eines Getraenks kaskadierend auf seine Einheiten.
  *
- * Ablauf: Einheiten werden nach ihrer eigenen Groesse (Liter) absteigend
- * sortiert. Fuer alle bis auf die kleinste Einheit wird ganzzahlig so viel
- * wie moeglich vom Restbedarf abgezogen (floor). Die kleinste Einheit erhaelt
- * den verbleibenden Rest, umgerechnet in ihre Gebindegroesse (falls vorhanden,
- * sonst ihre eigene Groesse) und auf die naechste Rundungsstufe aufgerundet.
+ * Ablauf: Fuer jede Einheit wird zunaechst ihre Basisgroesse ermittelt --
+ * die Groesse ihrer Gebindeeinheit (falls vorhanden, z.B. Kasten), sonst ihre
+ * eigene Groesse (z.B. Fass ohne Gebinde). Die Einheiten werden nach dieser
+ * Basisgroesse absteigend sortiert. Fuer alle bis auf die kleinste Einheit
+ * wird ganzzahlig so viel wie moeglich vom Restbedarf abgezogen (floor),
+ * gerechnet in ihrer Basisgroesse -- damit auch eine "mittlere" Einheit mit
+ * eigenem Gebinde (z.B. Flasche mit Kasten) in Gebindeeinheiten befuellt
+ * wird und nicht in Einzel-Einheiten. Die kleinste Einheit erhaelt den
+ * verbleibenden Rest, umgerechnet in ihre Basisgroesse und auf die naechste
+ * Rundungsstufe aufgerundet.
  *
  * @param {Array<{key: string, einheitsgroesseLiter: number, gebindeGroesseLiter?: number|null}>} units
  *   Einheiten des Getraenks. `einheitsgroesseLiter` ist die Groesse der Einheit selbst
@@ -69,14 +74,17 @@ export function calculateCascadingEinkauf(units, bedarfLiter) {
       warnings.push(`Einheit "${unit.key}" hat keine gültige Größe (Liter) - Feld bleibt leer.`);
       return;
     }
-    validUnits.push({ ...unit, einheitsgroesseLiter: size });
+    const gebindeSize = Number(unit.gebindeGroesseLiter);
+    const hatGebindeeinheit = Number.isFinite(gebindeSize) && gebindeSize > 0;
+    const basisLiter = hatGebindeeinheit ? gebindeSize : size;
+    validUnits.push({ ...unit, einheitsgroesseLiter: size, basisLiter, hatGebindeeinheit });
   });
 
   if (validUnits.length === 0) {
     return { values, warnings };
   }
 
-  const sorted = [...validUnits].sort((a, b) => b.einheitsgroesseLiter - a.einheitsgroesseLiter);
+  const sorted = [...validUnits].sort((a, b) => b.basisLiter - a.basisLiter);
   const smallest = sorted[sorted.length - 1];
   const grossUnits = sorted.slice(0, -1);
 
@@ -84,25 +92,16 @@ export function calculateCascadingEinkauf(units, bedarfLiter) {
   if (!Number.isFinite(rest) || rest < 0) rest = 0;
 
   grossUnits.forEach((unit) => {
-    const anzahl = Math.floor(rest / unit.einheitsgroesseLiter);
-    rest -= anzahl * unit.einheitsgroesseLiter;
+    const anzahl = Math.floor(rest / unit.basisLiter);
+    rest -= anzahl * unit.basisLiter;
     values[unit.key] = anzahl;
   });
 
-  const gebindeSize = Number(smallest.gebindeGroesseLiter);
-  const hatGebindeeinheit = Number.isFinite(gebindeSize) && gebindeSize > 0;
-  const basisLiter = hatGebindeeinheit ? gebindeSize : smallest.einheitsgroesseLiter;
-
-  if (!Number.isFinite(basisLiter) || basisLiter <= 0) {
-    values[smallest.key] = null;
-    warnings.push(`Einheit "${smallest.key}" hat keine gültige Gebinde-/Einheitsgröße - Feld bleibt leer.`);
-  } else {
-    const verhaeltnis = rest / basisLiter;
-    // Ohne Gebindeeinheit (z.B. lose Flaschen ohne Kasten) wird immer auf
-    // ganze Zahlen aufgerundet, da Bruchteile einer Einheit nicht gekauft
-    // werden koennen.
-    values[smallest.key] = hatGebindeeinheit ? roundToNextStage(verhaeltnis) : roundToWholeNumber(verhaeltnis);
-  }
+  const verhaeltnis = rest / smallest.basisLiter;
+  // Ohne Gebindeeinheit (z.B. lose Flaschen ohne Kasten) wird immer auf
+  // ganze Zahlen aufgerundet, da Bruchteile einer Einheit nicht gekauft
+  // werden koennen.
+  values[smallest.key] = smallest.hatGebindeeinheit ? roundToNextStage(verhaeltnis) : roundToWholeNumber(verhaeltnis);
 
   return { values, warnings };
 }

--- a/src/utils/einkaufCascade.test.js
+++ b/src/utils/einkaufCascade.test.js
@@ -69,6 +69,23 @@ describe('calculateCascadingEinkauf', () => {
     expect(calculateCascadingEinkauf(undefined, 10).values).toEqual({});
   });
 
+  it('befuellt eine mittlere (nicht kleinste) Einheit mit eigenem Gebinde in Gebindeeinheiten, nicht in Einzel-Einheiten', () => {
+    // große Flasche (0,5 l) mit Gebinde Kasten (10 l) und kleine Flasche
+    // (0,33 l) mit Gebinde Kasten (7,92 l). Die große Flasche ist nicht die
+    // kleinste Einheit, hat aber trotzdem ein eigenes Gebinde -- die Anzahl
+    // muss in Kästen (nicht in Einzelflaschen) übergeben werden.
+    const units = [
+      { key: 'grosseFlasche', einheitsgroesseLiter: 0.5, gebindeGroesseLiter: 10 },
+      { key: 'kleineFlasche', einheitsgroesseLiter: 0.33, gebindeGroesseLiter: 7.92 },
+    ];
+    const { values, warnings } = calculateCascadingEinkauf(units, 22);
+    // 22 / 10 = 2,2 -> 2 ganze Kästen (nicht 44 Einzelflaschen), Rest 2 l
+    expect(values.grosseFlasche).toBe(2);
+    // Rest 2 l / 7,92 = 0,2525... -> naechste Stufe 1/3 -> 0,333...
+    expect(values.kleineFlasche).toBeCloseTo(0.333, 3);
+    expect(warnings).toHaveLength(0);
+  });
+
   it('behandelt Bedarf 0 als 0 in allen Feldern', () => {
     const units = [
       { key: 'fass', einheitsgroesseLiter: 50, gebindeGroesseLiter: null },


### PR DESCRIPTION
Bisher wurde bei calculateCascadingEinkauf nur die kleinste Einheit ueber
ihre Gebindegroesse (z.B. Kasten) befuellt; alle groesseren Einheiten
wurden immer ueber ihre rohe Einheitsgroesse (Einzel-Einheiten) berechnet,
auch wenn sie selbst ein eigenes Gebinde hatten. Dadurch wurde bei einem
Getraenk mit mehreren Einheiten mit eigenem Gebinde das Feld "Eingekauft"
der zweiten (nicht kleinsten) Einheit faelschlich in Einzel-Einheiten statt
in Gebindeeinheiten vorbefuellt, obwohl UI und Folgeberechnungen
(getGroupEingekauftLiter, buildGebindePayload) diesen Wert als
Gebinde-Anzahl interpretieren.