### PR TITLE
Getränkeeinheitsgrößen 5,0 l / 10,0 l umbenennen, Pittermännchen und Fässchen als Gebindeeinheiten ergänzen

### DIFF
--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -195,8 +195,8 @@ function getConfiguredUnitLabel(liters) {
   if (value === 1) return '1,0 l';
   if (value === 1.5) return '1,5 l';
   if (value === 2) return '2,0 l';
-  if (value === 5) return '5,0 l (Pittermännchen)';
-  if (value === 10) return '10,0 l (Fässchen)';
+  if (value === 5) return '5,0 l';
+  if (value === 10) return '10,0 l';
   return null;
 }
 

--- a/functions/calculateEventDrinks.preferences.test.js
+++ b/functions/calculateEventDrinks.preferences.test.js
@@ -127,7 +127,7 @@ test('calculate normalizes configured custom drink unit labels for legacy entrie
   const customDrink = result.ergebnis.find((item) => item.kategorie === 'drink-1');
 
   assert.ok(customDrink);
-  assert.equal(customDrink.gebinde, '5,0 l (Pittermännchen)');
+  assert.equal(customDrink.gebinde, '5,0 l');
 });
 
 test('calculate includes new-model custom drinks with einheiten in results with null liter values', () => {

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -31,8 +31,8 @@ const UNIT_SIZES = [
   { label: '1,0 l', value: 1.0 },
   { label: '1,5 l', value: 1.5 },
   { label: '2,0 l', value: 2.0 },
-  { label: '5,0 l (Pittermännchen)', value: 5.0 },
-  { label: '10,0 l (Fässchen)', value: 10.0 },
+  { label: '5,0 l', value: 5.0 },
+  { label: '10,0 l', value: 10.0 },
 ];
 
 const getUnitSizeLabel = (liters) => {

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -135,8 +135,8 @@ describe('DrinkManagementPage', () => {
       '1,0 l',
       '1,5 l',
       '2,0 l',
-      '5,0 l (Pittermännchen)',
-      '10,0 l (Fässchen)',
+      '5,0 l',
+      '10,0 l',
     ]);
   });
 

--- a/src/utils/customLists.js
+++ b/src/utils/customLists.js
@@ -141,6 +141,8 @@ export const DEFAULT_PACKAGE_UNITS = [
   { id: 'kasten', singular: 'Kasten', plural: 'Kästen' },
   { id: 'kiste', singular: 'Kiste', plural: 'Kisten' },
   { id: 'fass', singular: 'Fass', plural: 'Fässer' },
+  { id: 'pittermännchen', singular: 'Pittermännchen', plural: 'Pittermännchen' },
+  { id: 'fässchen', singular: 'Fässchen', plural: 'Fässchen' },
 ];
 
 export const DEFAULT_DRINK_UNITS = [


### PR DESCRIPTION
Entfernt die Klammerzusätze "(Pittermännchen)" und "(Fässchen)" aus den
Größenbezeichnungen 5,0 l und 10,0 l und fügt Pittermännchen sowie
Fässchen als eigene Gebindeeinheiten (Singular/Plural) hinzu.