### PR TITLE
Fässer strukturell vor Kästen priorisieren in Einkauf-Kaskade

### DIFF
--- a/src/utils/einkaufCascade.js
+++ b/src/utils/einkaufCascade.js
@@ -41,12 +41,18 @@ function roundToWholeNumber(value) {
  *
  * Ablauf: Fuer jede Einheit wird zunaechst ihre Basisgroesse ermittelt --
  * die Groesse ihrer Gebindeeinheit (falls vorhanden, z.B. Kasten), sonst ihre
- * eigene Groesse (z.B. Fass ohne Gebinde). Die Einheiten werden nach dieser
- * Basisgroesse absteigend sortiert. Fuer alle bis auf die kleinste Einheit
- * wird ganzzahlig so viel wie moeglich vom Restbedarf abgezogen (floor),
- * gerechnet in ihrer Basisgroesse -- damit auch eine "mittlere" Einheit mit
- * eigenem Gebinde (z.B. Flasche mit Kasten) in Gebindeeinheiten befuellt
- * wird und nicht in Einzel-Einheiten. Die kleinste Einheit erhaelt den
+ * eigene Groesse (z.B. Fass ohne Gebinde). Einheiten ohne Gebindeeinheit
+ * (Faesser) werden immer vor Einheiten mit Gebindeeinheit (Kaesten)
+ * verarbeitet -- wenn ein Fass am Getraenk hinterlegt ist, geschah das
+ * bewusst (z.B. aus kulinarischen Gruenden) und soll bevorzugt ausgeschoepft
+ * werden, unabhaengig davon wie seine Basisgroesse im Vergleich zu Kaesten
+ * ausfaellt. Innerhalb der beiden Gruppen wird weiterhin absteigend nach
+ * Basisgroesse sortiert. Fuer alle bis auf die letzte (kleinste) Einheit
+ * dieser Reihenfolge wird ganzzahlig so viel wie moeglich vom Restbedarf
+ * abgezogen (floor), gerechnet in ihrer Basisgroesse -- damit auch eine
+ * "mittlere" Einheit mit eigenem Gebinde (z.B. Flasche mit Kasten) in
+ * Gebindeeinheiten befuellt wird und nicht in Einzel-Einheiten. Die letzte
+ * Einheit (ein Kasten, falls vorhanden, sonst das kleinste Fass) erhaelt den
  * verbleibenden Rest, umgerechnet in ihre Basisgroesse und auf die naechste
  * Rundungsstufe aufgerundet.
  *
@@ -84,7 +90,12 @@ export function calculateCascadingEinkauf(units, bedarfLiter) {
     return { values, warnings };
   }
 
-  const sorted = [...validUnits].sort((a, b) => b.basisLiter - a.basisLiter);
+  const byBasisDesc = (a, b) => b.basisLiter - a.basisLiter;
+  // Faesser (ohne Gebindeeinheit) kommen immer zuerst -- sie wurden bewusst
+  // zum Getraenk hinzugefuegt und sollen vor Kaesten ausgeschoepft werden.
+  const ohneGebinde = validUnits.filter((u) => !u.hatGebindeeinheit).sort(byBasisDesc);
+  const mitGebinde = validUnits.filter((u) => u.hatGebindeeinheit).sort(byBasisDesc);
+  const sorted = [...ohneGebinde, ...mitGebinde];
   const smallest = sorted[sorted.length - 1];
   const grossUnits = sorted.slice(0, -1);
 

--- a/src/utils/einkaufCascade.test.js
+++ b/src/utils/einkaufCascade.test.js
@@ -95,4 +95,28 @@ describe('calculateCascadingEinkauf', () => {
     expect(values.fass).toBe(0);
     expect(values.flasche).toBe(0);
   });
+
+  it('bevorzugt ein Fass ohne Gebinde vor einem Kasten mit gleicher Basisgroesse', () => {
+    // 500-ml-Flasche im 20er-Kasten (Basis 10 l) und 10-l-Faesschen ohne
+    // Gebinde (Basis 10 l) sind gleich gross -- das Fass muss trotzdem
+    // zuerst (per floor) ausgeschoepft werden.
+    const units = [
+      { key: 'kasten500', einheitsgroesseLiter: 0.5, gebindeGroesseLiter: 10 },
+      { key: 'fass10', einheitsgroesseLiter: 10, gebindeGroesseLiter: null },
+    ];
+    const { values } = calculateCascadingEinkauf(units, 10);
+    expect(values.fass10).toBe(1);
+    expect(values.kasten500).toBe(0);
+  });
+
+  it('bevorzugt ein Fass sogar dann, wenn seine Basisgroesse kleiner als die eines Kastens ist', () => {
+    const units = [
+      { key: 'kasten500', einheitsgroesseLiter: 0.5, gebindeGroesseLiter: 10 },
+      { key: 'fass5', einheitsgroesseLiter: 5, gebindeGroesseLiter: null },
+    ];
+    const { values } = calculateCascadingEinkauf(units, 15);
+    // Fass zuerst: floor(15/5) = 3 Faesser, Rest 0 -> Kasten bekommt 0.
+    expect(values.fass5).toBe(3);
+    expect(values.kasten500).toBe(0);
+  });
 });


### PR DESCRIPTION
Faesser (Einheiten ohne Gebindeeinheit) wurden bisher rein nach
Basisgroesse einsortiert und konnten dadurch hinter gleich- oder
groesseren Kaesten landen. Da ein Fass am Getraenk bewusst hinzugefuegt
wird, soll es unabhaengig von seiner Basisgroesse immer vor Kaesten
ausgeschoepft werden.