### PR TITLE
Fix Einheit-Typeahead dropdown clipped by drink row

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1251,7 +1251,10 @@
 
 .events-drink-row {
   position: relative;
-  overflow: hidden;
+  /* Only clip horizontally (for the swipe-to-delete panel) so the unit
+     typeahead dropdown, which opens below the input, isn't cut off. */
+  overflow-x: hidden;
+  overflow-y: visible;
   border-radius: 10px;
   background: white;
   border: 1px solid #e8e8e8;


### PR DESCRIPTION
.events-drink-row used overflow:hidden (for the swipe-to-delete panel),
which also clipped the absolutely-positioned unit typeahead dropdown
opening below the input. Switch to overflow-x:hidden / overflow-y:visible
so horizontal swipe clipping is preserved while the dropdown can render
fully.