### PR TITLE
Sommer-Faktor auf 1,3 erhoehen, TIME_FACTOR fuer Stunden vor 18 Uhr ergaenzen

### DIFF
--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -1,6 +1,6 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DEFAULT_RATES, SEASON_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, getWeightSubcategoryParents, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight} = require('./drinkRates');
+const {DEFAULT_RATES, SEASON_FACTORS, durationFactor, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, getWeightSubcategoryParents, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight} = require('./drinkRates');
 
 /**
  * Laedt die kalibrierten Erfahrungswerte eines Nutzers und mischt sie mit
@@ -213,6 +213,7 @@ function calculate(event, ratesDb, customDrinksMap) {
   const children = event.guests?.children || 0;
   const hours = event.durationHours;
   const seasonFactor = SEASON_FACTORS[event.season] ?? 1.0;
+  const timeFac = timeFactor(event.startTime, hours);
   const pufferProzent = normalizePufferProzent(event.pufferProzent);
   const puffer = pufferProzent / 100;
   const durFactor = durationFactor(hours);
@@ -237,13 +238,14 @@ function calculate(event, ratesDb, customDrinksMap) {
   const warnungen = [];
 
   // --- Step 1: Compute total beverage requirement for the event ---
-  // Adults: total = adults x base_rate x hours x season_factor x duration_factor.
-  // Children: total = children x children_base_rate x hours x season_factor x duration_factor.
+  // Adults: total = adults x base_rate x hours x season_factor x time_factor x duration_factor.
+  // Children: total = children x children_base_rate x hours x season_factor x time_factor x duration_factor.
+  // season_factor is applied first, time_factor (hours before 18:00) reduces the result further.
   // Both budgets are distributed independently across selected categories and then summed.
   const totalBeverage =
-      adults * BASE_RATE_PER_PERSON_PER_HOUR * hours * seasonFactor * durFactor;
+      adults * BASE_RATE_PER_PERSON_PER_HOUR * hours * seasonFactor * timeFac * durFactor;
   const childrenTotalBeverage =
-      children * CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR * hours * seasonFactor * durFactor;
+      children * CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR * hours * seasonFactor * timeFac * durFactor;
 
   // --- Step 2: Compute effective category weights from DRINK_WEIGHTS (adults) ---
   // Each offered category receives its raw DRINK_WEIGHTS basis value.
@@ -582,10 +584,10 @@ function calculate(event, ratesDb, customDrinksMap) {
 
     let literErwachsene;
     if (modus === 'pauschal') {
-      literErwachsene = adults * anteilTrinker * (entry.erwachsene || 0) * seasonFactor;
+      literErwachsene = adults * anteilTrinker * (entry.erwachsene || 0) * seasonFactor * timeFac;
     } else {
       literErwachsene =
-          adults * anteilTrinker * (entry.erwachsene || 0) * hours * seasonFactor * durFactor;
+          adults * anteilTrinker * (entry.erwachsene || 0) * hours * seasonFactor * timeFac * durFactor;
     }
 
     const preferenceMultiplier = 1;
@@ -614,6 +616,7 @@ function calculate(event, ratesDb, customDrinksMap) {
     gaeste: {erwachsene: adults, kinder: children},
     dauerStunden: hours,
     saisonFaktor: seasonFactor,
+    zeitFaktor: timeFac,
     eventTyp: event.eventType,
     pufferProzent,
     ergebnis,

--- a/functions/calculateEventDrinks.preferences.test.js
+++ b/functions/calculateEventDrinks.preferences.test.js
@@ -44,7 +44,7 @@ test('calculate distributes budget based on per-guest preferences (wein preferre
   // With preference: wein should have more than baseline (wasser dominated by weight).
   // Key: total budget is still the same (2 guests x budget).
   const totalLiters = wein.literOhnePuffer + wasser.literOhnePuffer;
-  const expectedTotal = 2 * BASE_RATE_PER_PERSON_PER_HOUR * 2 * 1.2; // 2 adults, 2 hours, sommer 1.2
+  const expectedTotal = 2 * BASE_RATE_PER_PERSON_PER_HOUR * 2 * 1.3; // 2 adults, 2 hours, sommer 1.3
   assert.ok(Math.abs(totalLiters - expectedTotal) < 0.05,
       `Total should be ~${expectedTotal} L, got ${totalLiters.toFixed(4)} L`);
   // Wein should be higher than it would be for a guest with no preference

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -62,7 +62,39 @@ const DEFAULT_RATES = {
   },
 };
 
-const SEASON_FACTORS = {sommer: 1.2, uebergang: 1.0, winter: 0.85};
+const SEASON_FACTORS = {sommer: 1.3, uebergang: 1.0, winter: 0.85};
+
+// Uhrzeit-Grenze: Stunden vor 18 Uhr gelten als "tagsueber" und werden
+// geringer gewichtet (weniger Konsum als am Abend).
+const TIME_FACTOR_BOUNDARY_HOUR = 18;
+const TIME_FACTOR_BEFORE_BOUNDARY = 0.8;
+
+/**
+ * Berechnet den Zeitfaktor eines Events aus Startuhrzeit und Dauer.
+ * Der SEASON_FACTOR wird zuerst auf den Gesamtbedarf angewendet, danach
+ * zusaetzlich dieser Zeitfaktor: Stunden vor 18:00 Uhr zaehlen mit
+ * TIME_FACTOR_BEFORE_BOUNDARY (0.8), Stunden ab 18:00 Uhr mit 1.0. Der
+ * zurueckgegebene Wert ist der stundengewichtete Mittelwert ueber die
+ * gesamte Event-Dauer. Ohne bekannte Startuhrzeit laesst sich der Anteil
+ * nicht bestimmen -- dann wird 1.0 (keine Anpassung) zurueckgegeben.
+ * @param {string} [startTime] Startuhrzeit im Format "HH:MM".
+ * @param {number} hours Dauer des Events in Stunden.
+ * @return {number} Multiplikator zwischen TIME_FACTOR_BEFORE_BOUNDARY und 1.0.
+ */
+function timeFactor(startTime, hours) {
+  if (!startTime || !hours || hours <= 0) return 1.0;
+  const match = /^(\d{1,2}):(\d{2})$/.exec(startTime);
+  if (!match) return 1.0;
+  const startHour = Number(match[1]) + Number(match[2]) / 60;
+  if (!Number.isFinite(startHour)) return 1.0;
+
+  const hoursBeforeBoundary = Math.min(
+      Math.max(TIME_FACTOR_BOUNDARY_HOUR - startHour, 0),
+      hours,
+  );
+  const hoursAfterBoundary = hours - hoursBeforeBoundary;
+  return (hoursBeforeBoundary * TIME_FACTOR_BEFORE_BOUNDARY + hoursAfterBoundary * 1.0) / hours;
+}
 
 /**
  * Gewichtungsmatrix fuer Getraenkekategorien.
@@ -248,4 +280,4 @@ function durationFactor(hours) {
   return Math.max(0.75, 1.0 - 0.03 * extra);
 }
 
-module.exports = {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight};
+module.exports = {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, TIME_FACTOR_BOUNDARY_HOUR, TIME_FACTOR_BEFORE_BOUNDARY, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight};

--- a/functions/drinkRates.timeFactor.test.js
+++ b/functions/drinkRates.timeFactor.test.js
@@ -1,0 +1,100 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  SEASON_FACTORS,
+  TIME_FACTOR_BOUNDARY_HOUR,
+  TIME_FACTOR_BEFORE_BOUNDARY,
+  timeFactor,
+  BASE_RATE_PER_PERSON_PER_HOUR,
+} = require('./drinkRates');
+const {_internal} = require('./calculateEventDrinks');
+
+test('SEASON_FACTORS.sommer ist 1.3', () => {
+  assert.equal(SEASON_FACTORS.sommer, 1.3);
+});
+
+test('TIME_FACTOR_BOUNDARY_HOUR ist 18, TIME_FACTOR_BEFORE_BOUNDARY ist 0.8', () => {
+  assert.equal(TIME_FACTOR_BOUNDARY_HOUR, 18);
+  assert.equal(TIME_FACTOR_BEFORE_BOUNDARY, 0.8);
+});
+
+test('timeFactor gibt 1.0 zurueck, wenn keine Startuhrzeit bekannt ist', () => {
+  assert.equal(timeFactor(undefined, 4), 1.0);
+  assert.equal(timeFactor('', 4), 1.0);
+  assert.equal(timeFactor(null, 4), 1.0);
+});
+
+test('timeFactor gibt 1.0 zurueck, wenn keine Dauer bekannt ist', () => {
+  assert.equal(timeFactor('14:00', 0), 1.0);
+  assert.equal(timeFactor('14:00', undefined), 1.0);
+});
+
+test('timeFactor gibt 0.8 zurueck, wenn das gesamte Event vor 18:00 endet', () => {
+  // 14:00 - 17:00 (3h), komplett vor 18 Uhr
+  assert.ok(Math.abs(timeFactor('14:00', 3) - TIME_FACTOR_BEFORE_BOUNDARY) < 1e-9);
+});
+
+test('timeFactor gibt 1.0 zurueck, wenn das gesamte Event ab 18:00 startet', () => {
+  // 19:00 - 22:00 (3h), komplett ab 18 Uhr
+  assert.equal(timeFactor('19:00', 3), 1.0);
+  // Start genau um 18:00
+  assert.equal(timeFactor('18:00', 4), 1.0);
+});
+
+test('timeFactor gewichtet Events, die die 18-Uhr-Grenze ueberschreiten, anteilig', () => {
+  // 16:00 - 20:00 (4h): 2h vor 18 Uhr (Faktor 0.8), 2h ab 18 Uhr (Faktor 1.0)
+  // erwartet: (2*0.8 + 2*1.0) / 4 = 0.9
+  const result = timeFactor('16:00', 4);
+  assert.ok(Math.abs(result - 0.9) < 1e-9, `erwartet 0.9, erhalten ${result}`);
+});
+
+test('calculate wendet SEASON_FACTOR und TIME_FACTOR multiplikativ auf den Gesamtbedarf an', () => {
+  // 10 Erwachsene, 4 Stunden, sommer (1.3), Start 14:00 (komplett vor 18 Uhr -> 0.8)
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 4,
+        guests: {adults: 10, children: 0},
+        season: 'sommer',
+        startTime: '14:00',
+        eventType: 'familienfeier',
+        categories: ['wasser'],
+        customDrinkIds: [],
+        pufferProzent: 0,
+      },
+      require('./drinkRates').DEFAULT_RATES,
+      {},
+  );
+
+  const wasser = result.ergebnis.find((item) => item.kategorie === 'wasser');
+  const expectedTotal = 10 * BASE_RATE_PER_PERSON_PER_HOUR * 4 *
+      SEASON_FACTORS.sommer * TIME_FACTOR_BEFORE_BOUNDARY;
+
+  assert.ok(wasser, 'wasser vorhanden');
+  assert.equal(result.zeitFaktor, TIME_FACTOR_BEFORE_BOUNDARY);
+  assert.equal(result.saisonFaktor, SEASON_FACTORS.sommer);
+  assert.ok(
+      Math.abs(wasser.literOhnePuffer - expectedTotal) < 0.05,
+      `Gesamtbedarf sollte ~${expectedTotal} L sein, ist ${wasser.literOhnePuffer} L`,
+  );
+});
+
+test('calculate wendet TIME_FACTOR nicht an, wenn keine Startuhrzeit gesetzt ist', () => {
+  const result = _internal.calculate(
+      {
+        eventName: 'Test',
+        durationHours: 4,
+        guests: {adults: 10, children: 0},
+        season: 'sommer',
+        eventType: 'familienfeier',
+        categories: ['wasser'],
+        customDrinkIds: [],
+        pufferProzent: 0,
+      },
+      require('./drinkRates').DEFAULT_RATES,
+      {},
+  );
+
+  assert.equal(result.zeitFaktor, 1.0);
+});

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -1,6 +1,6 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor} = require('./drinkRates');
+const {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, timeFactor} = require('./drinkRates');
 
 /**
  * Rundet auf 2 Nachkommastellen.
@@ -54,6 +54,7 @@ function impliedRate(cat, literGemessen, event, ratesDb) {
   const children = event.guests?.children || 0;
   const hours = event.durationHours;
   const seasonFactor = SEASON_FACTORS[event.season] ?? 1.0;
+  const timeFac = timeFactor(event.startTime, hours);
   const typeFactor = (EVENT_TYPE_FACTORS[event.eventType] || {})[cat] ?? 1.0;
   const durFactor = durationFactor(hours);
   const entry = ratesDb[cat] || DEFAULT_RATES[cat];
@@ -66,11 +67,11 @@ function impliedRate(cat, literGemessen, event, ratesDb) {
   let literKinderGeschaetzt;
   let nenner;
   if (modus === 'pauschal') {
-    literKinderGeschaetzt = children * rateKinderAlt * seasonFactor;
-    nenner = adults * anteilTrinker * seasonFactor * typeFactor;
+    literKinderGeschaetzt = children * rateKinderAlt * seasonFactor * timeFac;
+    nenner = adults * anteilTrinker * seasonFactor * timeFac * typeFactor;
   } else {
     literKinderGeschaetzt = children * rateKinderAlt * hours * durFactor;
-    nenner = adults * anteilTrinker * hours * seasonFactor * typeFactor * durFactor;
+    nenner = adults * anteilTrinker * hours * seasonFactor * timeFac * typeFactor * durFactor;
   }
 
   const literErwachsene = Math.max(literGemessen - literKinderGeschaetzt, 0);


### PR DESCRIPTION
SEASON_FACTORS.sommer wird von 1.2 auf 1.3 angehoben. Neu: timeFactor()
in drinkRates.js reduziert den Getraenkegesamtbedarf fuer Event-Stunden
vor 18:00 Uhr um 20% (stundengewichteter Mittelwert bei Events, die die
Grenze ueberschreiten). Der SEASON_FACTOR wird zuerst angewendet, danach
zusaetzlich der TIME_FACTOR. Ohne bekannte Startuhrzeit bleibt der Faktor
1.0 (keine Anpassung).

Die Kalibrierungslogik in submitConsumption.js wird ebenfalls angepasst,
da sie laut Doku-Kommentar dieselben Anpassungen wie die Vorwaerts-
berechnung spiegeln muss, sonst wuerde die Zeitreduktion faelschlich in
die kalibrierten Basisraten einfliessen.