### PR TITLE
Tatsächlicher Verbrauch für benutzerdefinierte Getränke korrekt erfassen

### DIFF
--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -22,18 +22,29 @@ function round4(n) {
 
 /**
  * Rechnet aus "eingekauft minus uebrig" (in Gebinden) den tatsaechlichen
- * Verbrauch in Litern pro Kategorie.
+ * Verbrauch in Litern pro Kategorie. Fuer benutzerdefinierte Getraenke gibt es
+ * keinen Eintrag in der Rate-DB (die ist nur nach den festen Standard-
+ * Kategorien indiziert) -- dafuer wird die Gebindegroesse aus der Event-
+ * Berechnung (event.berechnung.ergebnis[].gebindeGroesseLiter) verwendet.
  * @param {object} gebinde { kategorie: { eingekauft, uebrig } }
  * @param {object} ratesDb Rate-DB fuer Gebindegroessen.
+ * @param {object} event Event-Dokument (fuer Custom-Drink-Gebindegroessen).
  * @return {object} { kategorie: literGemessen }
  */
-function gebindeZuLiter(gebinde, ratesDb) {
+function gebindeZuLiter(gebinde, ratesDb, event) {
+  const gebindeLiterAusBerechnung = {};
+  (event?.berechnung?.ergebnis || []).forEach((row) => {
+    if (row.kategorie && Number.isFinite(row.gebindeGroesseLiter) && row.gebindeGroesseLiter > 0) {
+      gebindeLiterAusBerechnung[row.kategorie] = row.gebindeGroesseLiter;
+    }
+  });
+
   const result = {};
   for (const [cat, {eingekauft, uebrig}] of Object.entries(gebinde)) {
-    const entry = ratesDb[cat];
-    if (!entry || !entry.gebindeLiter) continue;
+    const gebindeLiter = ratesDb[cat]?.gebindeLiter || gebindeLiterAusBerechnung[cat];
+    if (!gebindeLiter) continue;
     const verbrauchtGebinde = Math.max((eingekauft || 0) - (uebrig || 0), 0);
-    result[cat] = verbrauchtGebinde * entry.gebindeLiter;
+    result[cat] = verbrauchtGebinde * gebindeLiter;
   }
   return result;
 }
@@ -131,7 +142,7 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
     ratesDb[doc.id] = {...(ratesDb[doc.id] || {}), ...doc.data()};
   });
 
-  const literGemessen = gebindeZuLiter(gebinde, ratesDb);
+  const literGemessen = gebindeZuLiter(gebinde, ratesDb, event);
 
   const changes = [];
   const batch = db.batch();

--- a/functions/submitConsumption.test.js
+++ b/functions/submitConsumption.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {_internal} = require('./submitConsumption');
+const {DEFAULT_RATES} = require('./drinkRates');
+
+test('gebindeZuLiter berechnet Liter fuer Standard-Kategorien aus der Rate-DB', () => {
+  const gebinde = {bier: {eingekauft: 10, uebrig: 4}};
+  const result = _internal.gebindeZuLiter(gebinde, DEFAULT_RATES, {});
+  assert.equal(result.bier, 3);
+});
+
+test('gebindeZuLiter faellt fuer Custom-Drinks auf die Gebindegroesse aus der Event-Berechnung zurueck', () => {
+  const gebinde = {
+    customDrink1: {eingekauft: 6, uebrig: 2},
+  };
+  const event = {
+    berechnung: {
+      ergebnis: [
+        {kategorie: 'customDrink1', isCustomDrink: true, drinkLabel: 'Mineralwasser', gebindeGroesseLiter: 1.5},
+      ],
+    },
+  };
+  const result = _internal.gebindeZuLiter(gebinde, {}, event);
+  assert.equal(result.customDrink1, 6);
+});
+
+test('gebindeZuLiter ueberspringt Kategorien ohne bekannte Gebindegroesse', () => {
+  const gebinde = {unbekannt: {eingekauft: 3, uebrig: 1}};
+  const result = _internal.gebindeZuLiter(gebinde, {}, {});
+  assert.deepEqual(result, {});
+});
+
+test('gebindeZuLiter behandelt fehlenden/negativen Verbrauch als 0', () => {
+  const gebinde = {bier: {eingekauft: 2, uebrig: 5}};
+  const result = _internal.gebindeZuLiter(gebinde, DEFAULT_RATES, {});
+  assert.equal(result.bier, 0);
+});

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -291,12 +291,18 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
                     </tr>
                   </thead>
                   <tbody>
-                    {Object.entries(selectedEvent.istVerbrauch).map(([kategorie, liter]) => (
-                      <tr key={kategorie}>
-                        <td>{CATEGORY_LABELS[kategorie] || kategorie}</td>
-                        <td className="events-table-amount">{formatLiter(liter)} l</td>
-                      </tr>
-                    ))}
+                    {Object.entries(selectedEvent.istVerbrauch).map(([kategorie, liter]) => {
+                      const ergebnisRow = (berechnung?.ergebnis || []).find((row) => row.kategorie === kategorie);
+                      const label = ergebnisRow?.isCustomDrink && ergebnisRow.drinkLabel
+                        ? resolveDrinkDisplay(ergebnisRow.drinkLabel, recipes).displayName
+                        : (CATEGORY_LABELS[kategorie] || kategorie);
+                      return (
+                        <tr key={kategorie}>
+                          <td>{label}</td>
+                          <td className="events-table-amount">{formatLiter(liter)} l</td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -346,4 +346,41 @@ describe('EventsPage', () => {
     expect(screen.getAllByText('Craft Bier')).toHaveLength(1);
     expect(screen.getAllByText(/24,0 l/)).toHaveLength(1);
   });
+
+  test('shows tatsächlicher Verbrauch table with resolved custom drink names when status is verbrauchErfasst', () => {
+    const event = {
+      id: 'e8',
+      eventName: 'Gartenparty',
+      date: '2026-06-01',
+      durationHours: 6,
+      eventType: 'party',
+      status: 'verbrauchErfasst',
+      guests: { adults: 8, children: 0 },
+      berechnung: {
+        ergebnis: [
+          {
+            kategorie: 'custom_2',
+            drinkId: 'custom_2',
+            drinkLabel: 'Mineralwasser',
+            literMitPuffer: 7.1,
+            isCustomDrink: true,
+            gebindeGroesseLiter: 1.5,
+          },
+        ],
+      },
+      istVerbrauch: { custom_2: 6.75 },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([event]);
+      return jest.fn();
+    });
+
+    render(<EventsPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByText('Gartenparty'));
+
+    expect(screen.getByText('Tatsächlicher Verbrauch')).toBeInTheDocument();
+    expect(screen.getAllByText('Mineralwasser')).toHaveLength(2);
+    expect(screen.getByText('6,8 l')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
submitConsumption berechnete istVerbrauch bisher nur für Kategorien, die in
der Erfahrungswerte-/Standard-Rate-DB vorhanden sind. Benutzerdefinierte
Getränke sind dort nie hinterlegt (ihre "Kategorie" ist die Getränke-ID),
wodurch sie beim Speichern des Verbrauchs stillschweigend übersprungen
wurden - das istVerbrauch-Objekt blieb leer, obwohl "Übrig" vollständig
gepflegt war. gebindeZuLiter nutzt jetzt zusätzlich die Gebindegröße aus
event.berechnung.ergebnis als Fallback. Auf der Eventkarte wird der Name
von benutzerdefinierten Getränken in der Tabelle "Tatsächlicher Verbrauch"
jetzt genauso aufgelöst wie in der Tabelle "Getränke".