### PR TITLE
Consolidate actual consumption per drink across multiple units

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -869,7 +869,8 @@
   border-bottom: none;
 }
 
-.events-table-amount {
+.events-table th.events-table-amount,
+.events-table td.events-table-amount {
   text-align: right;
 }
 

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -49,6 +49,29 @@ const groupErgebnisRowsByDrink = (rows) => {
   return grouped;
 };
 
+// Fasst den tatsaechlichen Verbrauch pro Getraenk zusammen (istVerbrauch ist
+// pro Ergebniszeile gespeichert, also ggf. mehrere Eintraege pro Getraenk,
+// wenn mehrere Gebinde-Einheiten ausgewaehlt wurden).
+const groupIstVerbrauchByDrink = (istVerbrauch, ergebnis, recipes) => {
+  const groups = [];
+  const groupsByKey = new Map();
+  Object.entries(istVerbrauch || {}).forEach(([kategorie, liter]) => {
+    const ergebnisRow = (ergebnis || []).find((row) => row.kategorie === kategorie);
+    const key = ergebnisRow?.drinkId || kategorie;
+    let group = groupsByKey.get(key);
+    if (!group) {
+      const label = ergebnisRow?.isCustomDrink && ergebnisRow.drinkLabel
+        ? resolveDrinkDisplay(ergebnisRow.drinkLabel, recipes).displayName
+        : (CATEGORY_LABELS[kategorie] || kategorie);
+      group = { key, label, liter: 0 };
+      groupsByKey.set(key, group);
+      groups.push(group);
+    }
+    group.liter += Number(liter) || 0;
+  });
+  return groups;
+};
+
 const formatDrinkSummary = (berechnung) => {
   const ergebnis = berechnung?.ergebnis;
   if (!ergebnis || ergebnis.length === 0) return null;
@@ -291,18 +314,12 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
                     </tr>
                   </thead>
                   <tbody>
-                    {Object.entries(selectedEvent.istVerbrauch).map(([kategorie, liter]) => {
-                      const ergebnisRow = (berechnung?.ergebnis || []).find((row) => row.kategorie === kategorie);
-                      const label = ergebnisRow?.isCustomDrink && ergebnisRow.drinkLabel
-                        ? resolveDrinkDisplay(ergebnisRow.drinkLabel, recipes).displayName
-                        : (CATEGORY_LABELS[kategorie] || kategorie);
-                      return (
-                        <tr key={kategorie}>
-                          <td>{label}</td>
-                          <td className="events-table-amount">{formatLiter(liter)} l</td>
-                        </tr>
-                      );
-                    })}
+                    {groupIstVerbrauchByDrink(selectedEvent.istVerbrauch, berechnung?.ergebnis, recipes).map((group) => (
+                      <tr key={group.key}>
+                        <td>{group.label}</td>
+                        <td className="events-table-amount">{formatLiter(group.liter)} l</td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
               </div>

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -383,4 +383,48 @@ describe('EventsPage', () => {
     expect(screen.getAllByText('Mineralwasser')).toHaveLength(2);
     expect(screen.getByText('6,8 l')).toBeInTheDocument();
   });
+
+  test('consolidates tatsächlicher Verbrauch per Getränk, even when multiple Einheiten wurden erfasst', () => {
+    const event = {
+      id: 'e9',
+      eventName: 'Bierfest',
+      date: '2026-01-10',
+      durationHours: 3,
+      eventType: 'party',
+      status: 'verbrauchErfasst',
+      guests: { adults: 20, children: 0 },
+      berechnung: {
+        ergebnis: [
+          {
+            kategorie: 'custom_1:0',
+            drinkId: 'custom_1',
+            drinkLabel: 'Craft Bier',
+            literMitPuffer: 24,
+            isCustomDrink: true,
+            einheitIdx: 0,
+          },
+          {
+            kategorie: 'custom_1:1',
+            drinkId: 'custom_1',
+            drinkLabel: 'Craft Bier',
+            literMitPuffer: 24,
+            isCustomDrink: true,
+            einheitIdx: 1,
+          },
+        ],
+      },
+      istVerbrauch: { 'custom_1:0': 10, 'custom_1:1': 5.5 },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([event]);
+      return jest.fn();
+    });
+
+    render(<EventsPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByText('Bierfest'));
+
+    expect(screen.getAllByText('Craft Bier')).toHaveLength(2);
+    expect(screen.getByText('15,5 l')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
This PR fixes the display of actual consumption (`istVerbrauch`) when multiple container units are selected for the same drink. Previously, each unit was shown as a separate line item; now they are consolidated into a single row with the total consumption.

## Key Changes
- **New function `groupIstVerbrauchByDrink()`**: Consolidates actual consumption entries by drink ID, summing up consumption across multiple units. Handles both custom drinks and standard categories with proper label resolution.
- **Updated consumption table rendering**: Replaced inline mapping logic with the new grouping function to display consolidated consumption data.
- **CSS refinement**: Updated `.events-table-amount` selector to apply to both table headers and data cells for consistent right-alignment.
- **Test coverage**: Added comprehensive test case verifying that multiple units of the same drink (e.g., "Craft Bier" with 2 units) are properly consolidated into a single row showing total consumption (15.5 l).

## Implementation Details
The `groupIstVerbrauchByDrink()` function:
- Iterates through `istVerbrauch` entries (keyed by `kategorie`)
- Matches each entry to its corresponding `ergebnis` row to extract drink metadata
- Groups entries by `drinkId` (for custom drinks) or `kategorie` (for standard categories)
- Accumulates liter values for duplicate drinks
- Properly resolves display names using the existing `resolveDrinkDisplay()` utility

https://claude.ai/code/session_01MRoubhbJY9guubxjkDd1Xq