### PR TITLE
Implement seasonal drink weight adjustments

### DIFF
--- a/functions/calculateEventDrinks.preferences.test.js
+++ b/functions/calculateEventDrinks.preferences.test.js
@@ -201,11 +201,15 @@ test('calculate uses calibrated rates (erfahrungswert) when available', () => {
   assert.equal(wasser.ratenQuelle, 'erfahrungswert');
   assert.equal(bier.ratenQuelle, 'standard-faustwert');
   // bier erhaelt hier auch das bier_alkoholfrei-Gewicht per Fallback, da bier_alkoholfrei nicht angeboten ist.
-  // totalRawWeight = wasser + bier + bier_alkoholfrei
+  // Saison ist 'winter' -> die jeweiligen winter-Deltas werden auf die Basis-Gewichte addiert.
+  // totalRawWeight = wasser + bier + bier_alkoholfrei (jeweils Basis+winter-Delta)
   // totalBeverage = 10 * 0.5 (BASE_RATE) * 3 * 0.85 = 12.75
-  const totalRawWeight = DRINK_WEIGHTS.wasser.basis + DRINK_WEIGHTS.bier.basis + DRINK_WEIGHTS.bier_alkoholfrei.basis;
-  assert.equal(wasser.literOhnePuffer, roundTo2(12.75 * DRINK_WEIGHTS.wasser.basis / totalRawWeight));
-  assert.equal(bier.literOhnePuffer, roundTo2(12.75 * (DRINK_WEIGHTS.bier.basis + DRINK_WEIGHTS.bier_alkoholfrei.basis) / totalRawWeight));
+  const wasserWeight = DRINK_WEIGHTS.wasser.basis + DRINK_WEIGHTS.wasser.winter;
+  const bierWeight = DRINK_WEIGHTS.bier.basis + DRINK_WEIGHTS.bier.winter +
+      DRINK_WEIGHTS.bier_alkoholfrei.basis + DRINK_WEIGHTS.bier_alkoholfrei.winter;
+  const totalRawWeight = wasserWeight + bierWeight;
+  assert.equal(wasser.literOhnePuffer, roundTo2(12.75 * wasserWeight / totalRawWeight));
+  assert.equal(bier.literOhnePuffer, roundTo2(12.75 * bierWeight / totalRawWeight));
   assert.ok(bier.literOhnePuffer > wasser.literOhnePuffer,
       'bier (higher DRINK_WEIGHT) should dominate wasser');
 });

--- a/functions/drinkRates.drinkWeights.test.js
+++ b/functions/drinkRates.drinkWeights.test.js
@@ -25,15 +25,32 @@ test('getDrinkWeight gibt Basis-Gewicht fuer bekannte Kategorien zurueck', () =>
   assert.equal(getDrinkWeight('wasser'), DRINK_WEIGHTS.wasser.basis);
 });
 
-test('getDrinkWeight gibt Basis-Gewicht unabhaengig von uebergebener Saison zurueck', () => {
-  // Saisonfaktoren werden in separatem Ticket implementiert; Ergebnis ist derzeit
-  // immer die Basis-Gewichtung.
-  assert.equal(getDrinkWeight('bier', 'sommer'), DRINK_WEIGHTS.bier.basis);
-  assert.equal(getDrinkWeight('bier', 'winter'), DRINK_WEIGHTS.bier.basis);
+test('getDrinkWeight wendet das saisonale Delta additiv auf die Basis an', () => {
+  assert.equal(getDrinkWeight('bier', 'sommer'), DRINK_WEIGHTS.bier.basis + DRINK_WEIGHTS.bier.sommer);
+  assert.equal(getDrinkWeight('bier', 'winter'), DRINK_WEIGHTS.bier.basis + DRINK_WEIGHTS.bier.winter);
+  // uebergang und unbekannte/fehlende Saison bekommen kein Delta -> nur Basis.
   assert.equal(getDrinkWeight('bier', 'uebergang'), DRINK_WEIGHTS.bier.basis);
+  assert.equal(getDrinkWeight('bier'), DRINK_WEIGHTS.bier.basis);
+});
+
+test('getDrinkWeight kappt das Ergebnis bei 0, falls Basis+Delta negativ waere', () => {
+  assert.ok(getDrinkWeight('wasser', 'winter') >= 0);
+});
+
+test('DRINK_WEIGHTS Basis+Delta ergibt je Saison in Summe weiterhin ~1.0', () => {
+  for (const season of ['sommer', 'winter']) {
+    const sum = Object.values(DRINK_WEIGHTS)
+        .reduce((acc, entry) => acc + Math.max(0, entry.basis + entry[season]), 0);
+    assert.ok(
+        Math.abs(sum - 1.0) < 0.005,
+        `Summe fuer ${season} sollte ~1.0 sein, ist aber ${sum.toFixed(4)}`,
+    );
+  }
 });
 
 test('getDrinkWeight gibt Basis-Gewicht unabhaengig von Tageszeit zurueck', () => {
+  // timeOfDay ('nachmittag') ist noch nicht verdrahtet -- keine Aufrufstelle
+  // uebergibt ihn derzeit, daher bleibt er ohne Effekt (reserviert).
   assert.equal(getDrinkWeight('kaffee', 'uebergang', 'nachmittag'), DRINK_WEIGHTS.kaffee.basis);
   assert.equal(getDrinkWeight('kaffee', undefined, 'nachmittag'), DRINK_WEIGHTS.kaffee.basis);
 });

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -99,8 +99,12 @@ function timeFactor(startTime, hours) {
 /**
  * Gewichtungsmatrix fuer Getraenkekategorien.
  * Basis-Gewicht bestimmt den proportionalen Anteil einer Kategorie am
- * Gesamtgetraenkebedarf. Saisonale und Tageszeit-Anpassungen folgen in
- * separaten Tickets.
+ * Gesamtgetraenkebedarf. `winter`/`sommer` sind additive Verschiebungen auf
+ * `basis`, die in getDrinkWeight() fuer die jeweilige Saison angewendet
+ * werden (uebergang bleibt bei `basis`, ohne Delta). Je Saison summieren
+ * sich die Deltas ueber alle Kategorien auf ~0, sodass die Gesamtsumme aller
+ * Gewichte weiterhin ~1.0 ergibt. `nachmittag` ist bislang nicht verdrahtet
+ * (keine Aufrufstelle uebergibt timeOfDay) und bleibt reserviert.
  *
  * `parent` verweist auf den Key der uebergeordneten Kategorie (oder null bei
  * Top-Level-Kategorien) und ist die Referenz-Quelle fuer alle Eltern/Kind-
@@ -214,17 +218,22 @@ function getParentTotal(categoryAmounts, parentKey) {
 
 /**
  * Gibt das Gewicht einer Getraenkekategorie zurueck.
- * Aktuell wird nur die Basis-Gewichtung verwendet; Saison- und Tageszeitanpassungen
- * folgen in einem separaten Ticket.
+ * Bei season 'sommer'/'winter' wird das jeweilige Delta additiv auf die
+ * Basis-Gewichtung angewendet (uebergang/unbekannt -> nur Basis). Das
+ * Ergebnis wird bei 0 gekappt, falls ein Delta die Basis rechnerisch
+ * unterschreiten wuerde. Tageszeitanpassungen (timeOfDay) sind noch nicht
+ * verdrahtet -- keine Aufrufstelle uebergibt sie derzeit -- und bleiben
+ * fuer ein separates Ticket reserviert.
  * @param {string} category Getraenkekategorie-ID.
- * @param {string} [season] Jahreszeit (sommer/winter/uebergang) -- reserviert fuer spaeteren Einsatz.
+ * @param {string} [season] Jahreszeit (sommer/winter/uebergang).
  * @param {string} [timeOfDay] Tageszeit (nachmittag) -- reserviert fuer spaeteren Einsatz.
  * @return {number} Gewicht fuer die Kategorie (0 wenn nicht bekannt).
  */
 function getDrinkWeight(category, season, timeOfDay) { // eslint-disable-line no-unused-vars
   const entry = DRINK_WEIGHTS[category];
   if (!entry) return 0;
-  return entry.basis;
+  const seasonDelta = (season === 'sommer' || season === 'winter') ? entry[season] : 0;
+  return Math.max(0, entry.basis + seasonDelta);
 }
 
 /**
@@ -247,17 +256,19 @@ const CHILDREN_DRINK_WEIGHTS = {
 
 /**
  * Gibt das Kinder-Gewicht einer Getraenkekategorie zurueck.
- * Aktuell wird nur die Basis-Gewichtung verwendet; Saison- und Tageszeitanpassungen
- * folgen in einem separaten Ticket.
+ * Wendet wie getDrinkWeight() das saisonale Delta additiv auf die
+ * Basis-Gewichtung an (uebergang/unbekannt -> nur Basis), gekappt bei 0.
+ * Tageszeitanpassungen (timeOfDay) sind noch nicht verdrahtet.
  * @param {string} category Getraenkekategorie-ID.
- * @param {string} [season] Jahreszeit (sommer/winter/uebergang) -- reserviert fuer spaeteren Einsatz.
+ * @param {string} [season] Jahreszeit (sommer/winter/uebergang).
  * @param {string} [timeOfDay] Tageszeit (nachmittag) -- reserviert fuer spaeteren Einsatz.
  * @return {number} Kinder-Gewicht fuer die Kategorie (0 wenn nicht bekannt).
  */
 function getChildrenDrinkWeight(category, season, timeOfDay) { // eslint-disable-line no-unused-vars
   const entry = CHILDREN_DRINK_WEIGHTS[category];
   if (!entry) return 0;
-  return entry.basis;
+  const seasonDelta = (season === 'sommer' || season === 'winter') ? entry[season] : 0;
+  return Math.max(0, entry.basis + seasonDelta);
 }
 
 const EVENT_TYPE_FACTORS = {


### PR DESCRIPTION
## Summary
This PR implements seasonal adjustments for beverage category weights. Previously, only base weights were used; now summer and winter seasons apply additive deltas to the base weights while maintaining the total weight sum at ~1.0.

## Key Changes
- **getDrinkWeight() and getChildrenDrinkWeight()**: Now apply seasonal deltas additively to base weights for 'sommer' and 'winter' seasons, with results clamped to a minimum of 0
- **Documentation updates**: Clarified that seasonal adjustments are now active (not reserved for future work), while time-of-day adjustments remain reserved
- **Test coverage**: 
  - Updated existing tests to verify seasonal delta application
  - Added test to verify total weights sum to ~1.0 per season
  - Added test to verify negative results are clamped to 0
  - Updated integration test to account for seasonal weights in calculations

## Implementation Details
- Seasonal deltas are only applied for explicit 'sommer' or 'winter' values; 'uebergang' and undefined seasons use base weight only
- The constraint that per-season deltas sum to ~0 across all categories ensures the total weight remains normalized
- Time-of-day adjustments (timeOfDay parameter) remain unimplemented with no call sites currently passing them

https://claude.ai/code/session_01Wdpr6s7fWUMu9R5D7eBwTa