### PR TITLE
Remove Verbrauch-Bestätigungsseite und selbstlernende Kalibrierung

### DIFF
--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -2,9 +2,7 @@
  * Startwerte, Anpassungsfaktoren und Formel-Bausteine fuer die
  * Getraenkekalkulation fuer Events.
  *
- * Das sind KEINE gemessenen Werte, sondern konservative Startpunkte, die
- * durch die Kalibrierung (submitConsumption) pro Nutzer ueberschrieben
- * werden, sobald echte Event-Daten vorliegen.
+ * Das sind KEINE gemessenen Werte, sondern konservative Startpunkte.
  */
 
 // Gesamter Getraenkebedarf pro Person und Stunde (alle Kategorien zusammen).

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -1,24 +1,6 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DEFAULT_RATES, SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, timeFactor} = require('./drinkRates');
-
-/**
- * Rundet auf 2 Nachkommastellen.
- * @param {number} n Zahl.
- * @return {number} Gerundete Zahl.
- */
-function round2(n) {
-  return Math.round(n * 100) / 100;
-}
-
-/**
- * Rundet auf 4 Nachkommastellen.
- * @param {number} n Zahl.
- * @return {number} Gerundete Zahl.
- */
-function round4(n) {
-  return Math.round(n * 10000) / 10000;
-}
+const {DEFAULT_RATES} = require('./drinkRates');
 
 /**
  * Rechnet aus "eingekauft minus uebrig" (in Gebinden) den tatsaechlichen
@@ -50,47 +32,6 @@ function gebindeZuLiter(gebinde, ratesDb, event) {
 }
 
 /**
- * Rechnet aus dem gemessenen Gesamtverbrauch einer Kategorie die implizite
- * Rate (Liter pro trinkendem Erwachsenen pro Stunde bzw. pauschal) zurueck,
- * unter denselben Saison-/Event-Typ-/Dauer-Anpassungen wie bei der
- * Vorwaerts-Berechnung, damit die Rate wieder "roh" gespeichert wird.
- * @param {string} cat Kategorie.
- * @param {number} literGemessen Gemessener Gesamtverbrauch.
- * @param {object} event Event-Dokument.
- * @param {object} ratesDb Aktuelle Rate-DB.
- * @return {?number} Implizite Rate oder null wenn nicht berechenbar.
- */
-function impliedRate(cat, literGemessen, event, ratesDb) {
-  const adults = event.guests?.adults || 0;
-  const children = event.guests?.children || 0;
-  const hours = event.durationHours;
-  const seasonFactor = SEASON_FACTORS[event.season] ?? 1.0;
-  const timeFac = timeFactor(event.startTime, hours);
-  const typeFactor = (EVENT_TYPE_FACTORS[event.eventType] || {})[cat] ?? 1.0;
-  const durFactor = durationFactor(hours);
-  const entry = ratesDb[cat] || DEFAULT_RATES[cat];
-  if (!entry) return null;
-
-  const anteilTrinker = entry.anteilTrinker ?? 1.0;
-  const modus = entry.modus || 'stunde';
-  const rateKinderAlt = entry.kinder || 0;
-
-  let literKinderGeschaetzt;
-  let nenner;
-  if (modus === 'pauschal') {
-    literKinderGeschaetzt = children * rateKinderAlt * seasonFactor * timeFac;
-    nenner = adults * anteilTrinker * seasonFactor * timeFac * typeFactor;
-  } else {
-    literKinderGeschaetzt = children * rateKinderAlt * hours * durFactor;
-    nenner = adults * anteilTrinker * hours * seasonFactor * timeFac * typeFactor * durFactor;
-  }
-
-  const literErwachsene = Math.max(literGemessen - literKinderGeschaetzt, 0);
-  if (nenner <= 0) return null;
-  return literErwachsene / nenner;
-}
-
-/**
  * Prueft, ob fuer alle Getraenke-Kategorien eines Events die "Verbraucht/Uebrig"-Menge
  * gesperrt (also final erfasst) ist. Nur dann darf der Event-Status auf
  * "verbrauchErfasst" gesetzt werden.
@@ -111,10 +52,9 @@ function alleGetraenkeVerbrauchGesperrt(event, verbrauchGesperrt) {
  * - eventId: ID des Event-Dokuments (muss existieren und berechnet sein)
  * - gebinde: { kategorie: { eingekauft: <Anzahl>, uebrig: <Anzahl> } }
  *   in Gebinde-Einheiten (Flaschen/Kisten/Tassen je nach Kategorie)
- * Aktualisiert users/{uid}/erfahrungswerte/* per gewichtetem Durchschnitt und
- * setzt den Event-Status erst dann auf "verbrauchErfasst", wenn fuer ALLE
- * Getraenke des Events die Verbraucht/Uebrig-Menge gesperrt ist.
- * Gibt eine Zusammenfassung der Aenderungen zurueck.
+ * Speichert den tatsaechlichen Verbrauch am Event und setzt den Event-Status
+ * erst dann auf "verbrauchErfasst", wenn fuer ALLE Getraenke des Events die
+ * Verbraucht/Uebrig-Menge gesperrt ist.
  */
 exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   if (!request.auth) {
@@ -135,44 +75,9 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   }
   const event = eventSnap.data();
 
-  const erfahrungswerteRef = db.collection('users').doc(uid).collection('erfahrungswerte');
-  const ratesSnap = await erfahrungswerteRef.get();
-  const ratesDb = JSON.parse(JSON.stringify(DEFAULT_RATES));
-  ratesSnap.forEach((doc) => {
-    ratesDb[doc.id] = {...(ratesDb[doc.id] || {}), ...doc.data()};
-  });
+  const literGemessen = gebindeZuLiter(gebinde, DEFAULT_RATES, event);
 
-  const literGemessen = gebindeZuLiter(gebinde, ratesDb, event);
-
-  const changes = [];
   const batch = db.batch();
-
-  for (const [cat, liter] of Object.entries(literGemessen)) {
-    const alteEntry = ratesDb[cat] || DEFAULT_RATES[cat];
-    if (!alteEntry) continue;
-    const alteRate = alteEntry.erwachsene;
-    const nEvents = alteEntry._nEvents || 0;
-
-    const neueImpliziteRate = impliedRate(cat, liter, event, ratesDb);
-    if (neueImpliziteRate === null) continue;
-
-    const neueRate = (alteRate * nEvents + neueImpliziteRate) / (nEvents + 1);
-
-    const docRef = erfahrungswerteRef.doc(cat);
-    batch.set(docRef, {
-      ...alteEntry,
-      erwachsene: round4(neueRate),
-      _nEvents: nEvents + 1,
-    }, {merge: true});
-
-    changes.push({
-      kategorie: cat,
-      alteRateProErwStunde: round4(alteRate),
-      neueRateProErwStunde: round4(neueRate),
-      beobachteteLiter: round2(liter),
-      anzahlEventsGesamt: nEvents + 1,
-    });
-  }
 
   const eventUpdate = {
     istVerbrauch: literGemessen,
@@ -193,7 +98,7 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
 
   await batch.commit();
 
-  return {eventId, changes};
+  return {eventId};
 });
 
-exports._internal = {gebindeZuLiter, impliedRate, alleGetraenkeVerbrauchGesperrt};
+exports._internal = {gebindeZuLiter, alleGetraenkeVerbrauchGesperrt};

--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -288,7 +288,6 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-  const [changes, setChanges] = useState(null);
   const [conversionTable, setConversionTable] = useState([]);
   const [bringButtonIcon, setBringButtonIcon] = useState('Bring');
   const [shoppingListIcon, setShoppingListIcon] = useState('Einkauf');
@@ -466,8 +465,8 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     setError('');
     try {
       const gesperrt = verbrauchGesperrtKategorien || verbrauchLock.lockedKategorien;
-      const result = await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt));
-      setChanges(result.changes || []);
+      await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt));
+      onDone(event.id);
     } catch (err) {
       console.error('Error submitting consumption:', err);
       setError('Der Verbrauch konnte nicht gespeichert werden. Bitte versuche es erneut.');
@@ -502,40 +501,6 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     e.preventDefault();
     runSubmitConsumption();
   };
-
-  if (changes) {
-    return (
-      <div className="events-page-container">
-        <div className="events-page-header">
-          <h2>Verbrauch gespeichert</h2>
-        </div>
-        <div className="events-result-card">
-          <p className="events-info-text">
-            Danke! Die Kalkulation wird für zukünftige Events genauer.
-          </p>
-          {changes.length === 0 ? (
-            <p className="events-empty-hint">Keine Rate konnte angepasst werden.</p>
-          ) : (
-            <ul className="events-changes-list">
-              {changes.map((change) => (
-                <li key={change.kategorie}>
-                  <strong>{CATEGORY_LABELS[change.kategorie] || change.kategorie}</strong>
-                  {'-Rate angepasst: '}
-                  {change.alteRateProErwStunde} → {change.neueRateProErwStunde} L/Person/Std.
-                  {' '}(Event Nr. {change.anzahlEventsGesamt})
-                </li>
-              ))}
-            </ul>
-          )}
-          <div className="events-form-actions">
-            <button type="button" className="events-primary-btn" onClick={() => onDone(event.id)}>
-              Fertig
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="events-page-container">

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ConsumptionForm from './ConsumptionForm';
 import { encodeRecipeLink } from '../utils/recipeLinks';
 
@@ -42,7 +42,7 @@ describe('ConsumptionForm', () => {
     // Sperren der letzten Verbraucht/Uebrig-Gruppe loest submitConsumption automatisch aus
     // (siehe handleToggleVerbrauchLock) -- Standard-Resolve, damit Tests, die das nur
     // beilaeufig ausloesen, nicht an einem unbehandelten Promise-Fehler scheitern.
-    mockSubmitConsumption.mockResolvedValue({ changes: [] });
+    mockSubmitConsumption.mockResolvedValue({ eventId: 'event1' });
   });
 
   it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
@@ -508,9 +508,10 @@ describe('ConsumptionForm', () => {
       },
     ];
     const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+    const onDone = jest.fn();
 
     render(
-      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+      <ConsumptionForm event={event} recipes={[]} onDone={onDone} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Verbrauch bearbeiten' }));
@@ -523,13 +524,13 @@ describe('ConsumptionForm', () => {
     expect(screen.getByLabelText('Übrig (Flasche)')).toBeDisabled();
 
     // Diese Gruppe ist die einzige des Events -- das Sperren loest also auch
-    // automatisch submitConsumption aus; hier nur abwarten, damit der Test
-    // sauber endet (siehe eigener Test unten fuer die Details dazu).
-    await screen.findByText('Verbrauch gespeichert');
+    // automatisch submitConsumption aus, das die Seite direkt verlaesst
+    // (siehe eigener Test unten fuer die Details dazu).
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith('event1'));
   });
 
-  it('loest submitConsumption automatisch aus, sobald alle Getraenke-Gruppen fuer Verbraucht/Uebrig gesperrt sind', async () => {
-    mockSubmitConsumption.mockResolvedValue({ changes: [] });
+  it('loest submitConsumption automatisch aus, sobald alle Getraenke-Gruppen fuer Verbraucht/Uebrig gesperrt sind, und verlaesst die Seite', async () => {
+    mockSubmitConsumption.mockResolvedValue({ eventId: 'event1' });
     const einheiten = [
       { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
     ];
@@ -547,16 +548,17 @@ describe('ConsumptionForm', () => {
       },
     ];
     const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+    const onDone = jest.fn();
 
     render(
-      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+      <ConsumptionForm event={event} recipes={[]} onDone={onDone} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Verbrauch bearbeiten' }));
     fireEvent.change(screen.getByLabelText('Übrig (Flasche)'), { target: { value: '0' } });
     fireEvent.click(screen.getByRole('button', { name: 'Verbrauchte Menge sperren' }));
 
-    expect(await screen.findByText('Verbrauch gespeichert')).toBeInTheDocument();
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith('event1'));
     expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } }, ['drink2:0']);
   });
 
@@ -578,9 +580,10 @@ describe('ConsumptionForm', () => {
       },
     ];
     const event = { ...makeEvent(ergebnis), status: 'berechnet' };
+    const onDone = jest.fn();
 
     render(
-      <ConsumptionForm event={event} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+      <ConsumptionForm event={event} recipes={[]} onDone={onDone} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
@@ -594,7 +597,39 @@ describe('ConsumptionForm', () => {
     expect(mockLockEinkaufMengen).toHaveBeenCalledWith('user1', 'event1', { 'drink2:0': '2' });
     expect(mockSetEventStatus).toHaveBeenCalledWith('user1', 'event1', 'eingekauft');
 
-    await screen.findByText('Verbrauch gespeichert');
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith('event1'));
+  });
+
+  it('verlaesst die Seite ueber onDone beim Klick auf "Verbrauch speichern", ohne Bestaetigungsseite anzuzeigen', async () => {
+    mockSubmitConsumption.mockResolvedValue({ eventId: 'event1' });
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+    const event = { ...makeEvent(ergebnis), status: 'eingekauft', einkaufGesperrt: { 'drink2:0': '2' } };
+    const onDone = jest.fn();
+
+    render(
+      <ConsumptionForm event={event} recipes={[]} onDone={onDone} onCancel={jest.fn()} currentUser={{ id: 'user1' }} />
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Verbrauch speichern' })[0]);
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith('event1'));
+    expect(mockSubmitConsumption).toHaveBeenCalledWith('event1', { 'drink2:0': { eingekauft: 2, uebrig: 0 } }, []);
+    expect(screen.queryByText('Verbrauch gespeichert')).not.toBeInTheDocument();
   });
 
   it('zeigt im Verbrauch-Button immer Einkauf minus Uebrig als Liter-Menge an', () => {

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -958,14 +958,6 @@
   color: #888;
 }
 
-.events-changes-list {
-  margin: 0;
-  padding-left: 20px;
-  color: #444;
-  font-size: 14px;
-  line-height: 1.6;
-}
-
 .events-manage-links {
   display: flex;
   gap: 10px;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3759,8 +3759,7 @@
 [data-theme="dark"] .events-empty-state,
 [data-theme="dark"] .events-card-meta,
 [data-theme="dark"] .events-info-text,
-[data-theme="dark"] .events-detail-meta,
-[data-theme="dark"] .events-changes-list {
+[data-theme="dark"] .events-detail-meta {
   color: #bbb;
 }
 

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -191,14 +191,14 @@ export const setEventStatus = async (uid, eventId, status) => {
 
 /**
  * Call the submitConsumption Cloud Function: records the actual consumption
- * of a finished event and updates the user's calibrated rates. Der Event-Status
- * wird serverseitig nur dann auf "verbrauchErfasst" gesetzt, wenn alle Getraenke
- * des Events gesperrt sind (siehe verbrauchGesperrtKategorien).
+ * of a finished event. Der Event-Status wird serverseitig nur dann auf
+ * "verbrauchErfasst" gesetzt, wenn alle Getraenke des Events gesperrt sind
+ * (siehe verbrauchGesperrtKategorien).
  * @param {string} eventId - ID of the event
  * @param {Object} gebinde - { kategorie: { eingekauft, uebrig } } in Gebinde-Einheiten
  * @param {string[]} [verbrauchGesperrtKategorien] - Kategorien, die aktuell (auch
  *   client-seitig noch nicht durchgeschrieben) als "Verbrauch gesperrt" gelten
- * @returns {Promise<Object>} { eventId, changes }
+ * @returns {Promise<Object>} { eventId }
  */
 export const submitConsumption = async (eventId, gebinde, verbrauchGesperrtKategorien) => {
   const fn = httpsCallable(functions, 'submitConsumption');


### PR DESCRIPTION
submitConsumption speichert weiterhin den gemessenen Verbrauch am Event,
rechnet daraus aber keine implizite Rate mehr zurück und schreibt keine
erfahrungswerte-Dokumente mehr. Der Speichern-Button verlässt die Seite
direkt über onDone statt eine Zusammenfassung der Ratenänderungen zu
zeigen.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RnAD5aGou9CfFTW575a13U