### PR TITLE
Getränkegewichtungsmatrizen (Erwachsene + Kinder) in Firebase editierbar machen

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -84,6 +84,19 @@ service cloud.firestore {
       allow create, update, delete: if isModeratorOrAdmin();
     }
 
+    // Getraenke-Gewichtungsmatrizen (Erwachsene + Kinder) fuer die Event-
+    // Getraenkekalkulation. Dokument-ID = Kategorie-ID (siehe
+    // functions/drinkRates.js DRINK_WEIGHTS / CHILDREN_DRINK_WEIGHTS).
+    match /drinkWeights/{categoryId} {
+      allow read: if isAnyUser();
+      allow create, update, delete: if isModeratorOrAdmin();
+    }
+
+    match /drinkWeightsChildren/{categoryId} {
+      allow read: if isAnyUser();
+      allow create, update, delete: if isModeratorOrAdmin();
+    }
+
     // Nutrition reference values (stored per 100g from OpenFoodFacts lookups)
     // Public read is required so unauthenticated share-link viewers can render nutrition data.
     match /nutritionReferences/{entryId} {

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -1,18 +1,18 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DRINK_WEIGHTS, SEASON_FACTORS, durationFactor, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, getWeightSubcategoryParents, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight} = require('./drinkRates');
+const {DRINK_WEIGHTS, CHILDREN_DRINK_WEIGHTS, SEASON_FACTORS, durationFactor, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, getDrinkWeight, getWeightSubcategoryParents, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, getChildrenDrinkWeight, loadDrinkWeightsFromFirestore, loadChildrenDrinkWeightsFromFirestore} = require('./drinkRates');
 
 /**
- * Laedt die kalibrierten Erfahrungswerte eines Nutzers und mischt sie mit
- * den Startwerten aus DRINK_WEIGHTS (Erfahrungswert gewinnt pro Kategorie,
- * wo vorhanden; ueberschreibt aber nicht die Gewichtsverteilung selbst,
- * siehe getDrinkWeight()).
+ * Laedt die admin-editierbare Erwachsenen-Gewichtungsmatrix aus Firestore und
+ * mischt zusaetzlich die kalibrierten Erfahrungswerte des Nutzers darueber
+ * (Erfahrungswert gewinnt pro Kategorie, wo vorhanden; ueberschreibt aber
+ * nicht die Gewichtsverteilung selbst, siehe getDrinkWeight()).
  * @param {object} db Firestore-Instanz.
  * @param {string} uid Firebase-Nutzer-ID.
  * @return {Promise<object>} Rate-DB, Kategorie -> Werte.
  */
 async function loadRatesDb(db, uid) {
-  const ratesDb = JSON.parse(JSON.stringify(DRINK_WEIGHTS)); // deep copy
+  const ratesDb = await loadDrinkWeightsFromFirestore(db);
   const snap = await db.collection('users').doc(uid).collection('erfahrungswerte').get();
   snap.forEach((doc) => {
     const cat = doc.id;
@@ -208,9 +208,10 @@ function getConfiguredUnitLabel(liters) {
  *   eventType, categories, customDrinkIds, drinkDistributionFactors, pufferProzent).
  * @param {object} ratesDb Rate-Datenbank (Default + ggf. Erfahrungswerte).
  * @param {object} [customDrinksMap] Map von drinkId -> Getraenke-Definition.
+ * @param {object} [childrenRatesDb] Kinder-Gewichtungsmatrix (Default oder admin-editiert).
  * @return {object} Ergebnis pro Kategorie + Warnungen.
  */
-function calculate(event, ratesDb, customDrinksMap) {
+function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_DRINK_WEIGHTS) {
   const adults = event.guests?.adults || 0;
   const children = event.guests?.children || 0;
   const hours = event.durationHours;
@@ -257,7 +258,7 @@ function calculate(event, ratesDb, customDrinksMap) {
   const categorySet = new Set(categories);
 
   for (const cat of categories) {
-    const drinkWeight = getDrinkWeight(cat, event.season);
+    const drinkWeight = getDrinkWeight(cat, event.season, undefined, ratesDb);
     if (drinkWeight <= 0) continue;
 
     categoryRawWeights[cat] = drinkWeight;
@@ -277,7 +278,7 @@ function calculate(event, ratesDb, customDrinksMap) {
         .some(([child, parent]) => parent === subCategory && categorySet.has(child));
     if (hasOfferedChild) continue;
 
-    const subCategoryWeight = getDrinkWeight(subCategory, event.season);
+    const subCategoryWeight = getDrinkWeight(subCategory, event.season, undefined, ratesDb);
     if (subCategoryWeight <= 0) continue;
 
     categoryRawWeights[parentCategory] = (categoryRawWeights[parentCategory] || 0) + subCategoryWeight;
@@ -289,7 +290,7 @@ function calculate(event, ratesDb, customDrinksMap) {
   let childrenTotalRawWeight = 0;
 
   for (const cat of categories) {
-    const childWeight = getChildrenDrinkWeight(cat, event.season);
+    const childWeight = getChildrenDrinkWeight(cat, event.season, undefined, childrenRatesDb);
     if (childWeight <= 0) continue;
 
     childrenCategoryRawWeights[cat] = childWeight;
@@ -304,7 +305,7 @@ function calculate(event, ratesDb, customDrinksMap) {
         .some(([child, parent]) => parent === subCategory && categorySet.has(child));
     if (hasOfferedChild) continue;
 
-    const subCategoryChildWeight = getChildrenDrinkWeight(subCategory, event.season);
+    const subCategoryChildWeight = getChildrenDrinkWeight(subCategory, event.season, undefined, childrenRatesDb);
     if (subCategoryChildWeight <= 0) continue;
 
     childrenCategoryRawWeights[parentCategory] =
@@ -647,11 +648,12 @@ exports.calculateEventDrinks = onCall({maxInstances: 10}, async (request) => {
   }
 
   const db = admin.firestore();
-  const [ratesDb, customDrinksMap] = await Promise.all([
+  const [ratesDb, customDrinksMap, childrenRatesDb] = await Promise.all([
     loadRatesDb(db, uid),
     loadCustomDrinks(db, uid, event.customDrinkIds),
+    loadChildrenDrinkWeightsFromFirestore(db),
   ]);
-  const result = calculate(event, ratesDb, customDrinksMap);
+  const result = calculate(event, ratesDb, customDrinksMap, childrenRatesDb);
 
   const eventsRef = db.collection('users').doc(uid).collection('events');
   let docRef;

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -210,8 +210,8 @@ function getParentTotal(categoryAmounts, parentKey) {
  * @param {string} [timeOfDay] Tageszeit (nachmittag) -- reserviert fuer spaeteren Einsatz.
  * @return {number} Gewicht fuer die Kategorie (0 wenn nicht bekannt).
  */
-function getDrinkWeight(category, season, timeOfDay) { // eslint-disable-line no-unused-vars
-  const entry = DRINK_WEIGHTS[category];
+function getDrinkWeight(category, season, timeOfDay, weightsTable = DRINK_WEIGHTS) { // eslint-disable-line no-unused-vars
+  const entry = weightsTable[category];
   if (!entry) return 0;
   const seasonDelta = (season === 'sommer' || season === 'winter') ? entry[season] : 0;
   return Math.max(0, entry.basis + seasonDelta);
@@ -246,11 +246,46 @@ const CHILDREN_DRINK_WEIGHTS = {
  * @param {string} [timeOfDay] Tageszeit (nachmittag) -- reserviert fuer spaeteren Einsatz.
  * @return {number} Kinder-Gewicht fuer die Kategorie (0 wenn nicht bekannt).
  */
-function getChildrenDrinkWeight(category, season, timeOfDay) { // eslint-disable-line no-unused-vars
-  const entry = CHILDREN_DRINK_WEIGHTS[category];
+function getChildrenDrinkWeight(category, season, timeOfDay, weightsTable = CHILDREN_DRINK_WEIGHTS) { // eslint-disable-line no-unused-vars
+  const entry = weightsTable[category];
   if (!entry) return 0;
   const seasonDelta = (season === 'sommer' || season === 'winter') ? entry[season] : 0;
   return Math.max(0, entry.basis + seasonDelta);
+}
+
+/**
+ * Laedt die admin-editierbare Erwachsenen-Gewichtungsmatrix aus Firestore
+ * (Collection 'drinkWeights', Dokument-ID = Kategorie) und mischt sie ueber
+ * die hartcodierten Startwerte aus DRINK_WEIGHTS (Firestore-Feld gewinnt pro
+ * Kategorie, wo vorhanden). Unbekannte Dokument-IDs (keine Entsprechung in
+ * DRINK_WEIGHTS) werden ignoriert, da Kategorien strukturell fest sind.
+ * @param {object} db Firestore-Instanz.
+ * @return {Promise<object>} Gewichtungsmatrix, Kategorie -> Werte.
+ */
+async function loadDrinkWeightsFromFirestore(db) {
+  const weights = JSON.parse(JSON.stringify(DRINK_WEIGHTS)); // deep copy
+  const snap = await db.collection('drinkWeights').get();
+  snap.forEach((doc) => {
+    const cat = doc.id;
+    if (weights[cat]) weights[cat] = {...weights[cat], ...doc.data()};
+  });
+  return weights;
+}
+
+/**
+ * Laedt die admin-editierbare Kinder-Gewichtungsmatrix aus Firestore
+ * (Collection 'drinkWeightsChildren'), analog zu loadDrinkWeightsFromFirestore().
+ * @param {object} db Firestore-Instanz.
+ * @return {Promise<object>} Kinder-Gewichtungsmatrix, Kategorie -> Werte.
+ */
+async function loadChildrenDrinkWeightsFromFirestore(db) {
+  const weights = JSON.parse(JSON.stringify(CHILDREN_DRINK_WEIGHTS)); // deep copy
+  const snap = await db.collection('drinkWeightsChildren').get();
+  snap.forEach((doc) => {
+    const cat = doc.id;
+    if (weights[cat]) weights[cat] = {...weights[cat], ...doc.data()};
+  });
+  return weights;
 }
 
 const EVENT_TYPE_FACTORS = {
@@ -273,4 +308,4 @@ function durationFactor(hours) {
   return Math.max(0.75, 1.0 - 0.03 * extra);
 }
 
-module.exports = {SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, TIME_FACTOR_BOUNDARY_HOUR, TIME_FACTOR_BEFORE_BOUNDARY, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight};
+module.exports = {SEASON_FACTORS, EVENT_TYPE_FACTORS, durationFactor, TIME_FACTOR_BOUNDARY_HOUR, TIME_FACTOR_BEFORE_BOUNDARY, timeFactor, BASE_RATE_PER_PERSON_PER_HOUR, DRINK_WEIGHTS, getDrinkWeight, getWeightSubcategoryParents, getParentTotal, CHILDREN_BASE_RATE_PER_PERSON_PER_HOUR, CHILDREN_DRINK_WEIGHTS, getChildrenDrinkWeight, loadDrinkWeightsFromFirestore, loadChildrenDrinkWeightsFromFirestore};

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -1,6 +1,6 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {DRINK_WEIGHTS} = require('./drinkRates');
+const {loadDrinkWeightsFromFirestore} = require('./drinkRates');
 
 /**
  * Rechnet aus "eingekauft minus uebrig" (in Gebinden) den tatsaechlichen
@@ -75,7 +75,8 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   }
   const event = eventSnap.data();
 
-  const literGemessen = gebindeZuLiter(gebinde, DRINK_WEIGHTS, event);
+  const ratesDb = await loadDrinkWeightsFromFirestore(db);
+  const literGemessen = gebindeZuLiter(gebinde, ratesDb, event);
 
   const batch = db.batch();
 

--- a/src/components/DrinkWeightsTab.css
+++ b/src/components/DrinkWeightsTab.css
@@ -1,0 +1,118 @@
+.drink-weights-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.drink-weights-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.drink-weights-section-header h3 {
+  margin: 0 0 0.2rem;
+  color: #402c1c;
+}
+
+.drink-weights-section-header .section-description {
+  margin: 0 0 0.3rem;
+}
+
+.drink-weights-basis-sum {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.drink-weights-table-container {
+  overflow-x: auto;
+}
+
+.drink-weights-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 850px;
+}
+
+.drink-weights-table th,
+.drink-weights-table td {
+  border-bottom: 1px solid #eee;
+  padding: 0.6rem 0.55rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.drink-weights-table th {
+  background: #f8f9fa;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #555;
+}
+
+.drink-weights-parent-hint {
+  color: #777;
+  font-size: 0.82rem;
+}
+
+.drink-weights-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.drink-weights-edit-btn,
+.drink-weights-delete-btn {
+  border: 1px solid #ddd;
+  background: white;
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.drink-weights-delete-btn {
+  border-color: #ffc7c7;
+  color: #b12626;
+}
+
+.drink-weights-inline-input {
+  width: 100%;
+  min-width: 4.5rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 0.25rem 0.35rem;
+  font-size: 0.84rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+[data-theme="dark"] .drink-weights-section-header h3 {
+  color: #f0e6da;
+}
+
+[data-theme="dark"] .drink-weights-basis-sum {
+  color: #d0d0d0;
+}
+
+[data-theme="dark"] .drink-weights-table th {
+  background: #2a2a2a;
+  color: #c7c7c7;
+}
+
+[data-theme="dark"] .drink-weights-table td {
+  border-bottom-color: #3a3a3a;
+}
+
+[data-theme="dark"] .drink-weights-parent-hint {
+  color: #999;
+}
+
+[data-theme="dark"] .drink-weights-edit-btn,
+[data-theme="dark"] .drink-weights-delete-btn,
+[data-theme="dark"] .drink-weights-inline-input {
+  background: #1d1d1d;
+  border-color: #444;
+  color: #e8e8e8;
+}

--- a/src/components/DrinkWeightsTab.js
+++ b/src/components/DrinkWeightsTab.js
@@ -1,0 +1,365 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './DrinkWeightsTab.css';
+import {
+  subscribeToDrinkWeights,
+  subscribeToChildrenDrinkWeights,
+  setDrinkWeightEntry,
+  setChildrenDrinkWeightEntry
+} from '../utils/drinkWeightsFirestore';
+import { DEFAULT_DRINK_WEIGHTS, DEFAULT_CHILDREN_DRINK_WEIGHTS, DRINK_WEIGHT_CATEGORY_ORDER } from '../utils/drinkWeightsDefaults';
+import { getDrinkCategoryLabel } from '../utils/drinkCategories';
+import { canManageDrinkWeights } from '../utils/userManagement';
+
+const NUMBER_FIELDS = ['basis', 'winter', 'sommer', 'nachmittag'];
+
+const createFormData = (row, hasGebinde) => ({
+  basis: row.basis,
+  winter: row.winter,
+  sommer: row.sommer,
+  nachmittag: row.nachmittag,
+  ...(hasGebinde ? {
+    gebindeLiter: row.gebindeLiter ?? '',
+    gebindeName: row.gebindeName ?? '',
+    anteilTrinker: row.anteilTrinker ?? ''
+  } : {})
+});
+
+const formatGermanDate = (timestamp) => {
+  if (!timestamp) return '—';
+  const date = typeof timestamp?.toDate === 'function' ? timestamp.toDate() : new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('de-DE', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+};
+
+const resolveUpdatedBy = (currentUser) => {
+  if (!currentUser) return undefined;
+  const fullName = [currentUser.vorname, currentUser.nachname].filter(Boolean).join(' ').trim();
+  return fullName || currentUser.email || currentUser.id || undefined;
+};
+
+const buildRows = (defaults, overrides) =>
+  DRINK_WEIGHT_CATEGORY_ORDER.map((id) => ({
+    id,
+    ...defaults[id],
+    ...(overrides[id] || {})
+  }));
+
+function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults, onSave, currentUser }) {
+  const [editingId, setEditingId] = useState(null);
+  const [formData, setFormData] = useState({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const basisSum = useMemo(() => rows.reduce((sum, row) => sum + (Number(row.basis) || 0), 0), [rows]);
+
+  const handleEdit = (row) => {
+    setEditingId(row.id);
+    setFormData(createFormData(row, hasGebinde));
+    setErrorMessage('');
+  };
+
+  const resetEditing = () => {
+    setEditingId(null);
+    setFormData({});
+    setErrorMessage('');
+  };
+
+  const handleResetToDefault = async (categoryId) => {
+    if (!window.confirm(`"${getDrinkCategoryLabel(categoryId)}" wirklich auf den Standardwert zurücksetzen?`)) return;
+    setErrorMessage('');
+    try {
+      await onSave(categoryId, defaults[categoryId], resolveUpdatedBy(currentUser));
+      if (editingId === categoryId) resetEditing();
+    } catch (error) {
+      setErrorMessage(`Fehler beim Zurücksetzen: ${error.message}`);
+    }
+  };
+
+  const validate = () => {
+    for (const field of NUMBER_FIELDS) {
+      if (!Number.isFinite(Number(formData[field]))) {
+        return `Bitte einen gültigen Wert für "${field}" eingeben.`;
+      }
+    }
+    if (Number(formData.basis) < 0) return 'Das Basis-Gewicht darf nicht negativ sein.';
+    if (hasGebinde) {
+      const gebindeLiter = Number(formData.gebindeLiter);
+      if (!Number.isFinite(gebindeLiter) || gebindeLiter <= 0) {
+        return 'Bitte eine gültige Gebinde-Größe (Liter) eingeben.';
+      }
+      if (!String(formData.gebindeName || '').trim()) {
+        return 'Bitte eine Gebinde-Bezeichnung eingeben.';
+      }
+      if (formData.anteilTrinker !== '' && formData.anteilTrinker !== undefined) {
+        const anteilTrinker = Number(formData.anteilTrinker);
+        if (!Number.isFinite(anteilTrinker) || anteilTrinker <= 0 || anteilTrinker > 1) {
+          return 'Der Anteil Trinker muss zwischen 0 (exklusiv) und 1 liegen.';
+        }
+      }
+    }
+    return '';
+  };
+
+  const handleSave = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setErrorMessage(validationError);
+      return;
+    }
+
+    setIsSaving(true);
+    setErrorMessage('');
+
+    const payload = {
+      basis: Number(formData.basis),
+      winter: Number(formData.winter),
+      sommer: Number(formData.sommer),
+      nachmittag: Number(formData.nachmittag)
+    };
+    if (hasGebinde) {
+      payload.gebindeLiter = Number(formData.gebindeLiter);
+      payload.gebindeName = String(formData.gebindeName).trim();
+      payload.anteilTrinker = formData.anteilTrinker === '' || formData.anteilTrinker === undefined
+        ? undefined
+        : Number(formData.anteilTrinker);
+    }
+
+    try {
+      await onSave(editingId, payload, resolveUpdatedBy(currentUser));
+      resetEditing();
+    } catch (error) {
+      setErrorMessage(`Fehler beim Speichern: ${error.message}`);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="drink-weights-section">
+      <div className="drink-weights-section-header">
+        <h3>{title}</h3>
+        <p className="section-description">{description}</p>
+        <span className="drink-weights-basis-sum" title="Die Basis-Gewichte aller Kategorien sollten in Summe ~1,0 ergeben.">
+          Summe Basis-Gewichte: {basisSum.toFixed(3)}
+        </span>
+      </div>
+
+      {errorMessage && <div className="message error">{errorMessage}</div>}
+
+      <div className="drink-weights-table-container">
+        <table className="drink-weights-table">
+          <thead>
+            <tr>
+              <th>Kategorie</th>
+              <th>Basis</th>
+              <th>Winter Δ</th>
+              <th>Sommer Δ</th>
+              <th>Nachmittag Δ</th>
+              {hasGebinde && <th>Gebinde-Größe (L)</th>}
+              {hasGebinde && <th>Gebinde-Bezeichnung</th>}
+              {hasGebinde && <th>Anteil Trinker</th>}
+              <th>Letzte Änderung</th>
+              <th>Aktionen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const isEditing = editingId === row.id;
+              const parentLabel = row.parent ? getDrinkCategoryLabel(row.parent) : null;
+              return (
+                <tr key={row.id}>
+                  <td>
+                    {getDrinkCategoryLabel(row.id)}
+                    {parentLabel && <span className="drink-weights-parent-hint"> (Unterkategorie von {parentLabel})</span>}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="0.001"
+                        className="drink-weights-inline-input"
+                        aria-label={`Basis für ${row.id}`}
+                        value={formData.basis}
+                        onChange={(event) => setFormData((prev) => ({ ...prev, basis: event.target.value }))}
+                      />
+                    ) : row.basis}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="0.001"
+                        className="drink-weights-inline-input"
+                        aria-label={`Winter-Delta für ${row.id}`}
+                        value={formData.winter}
+                        onChange={(event) => setFormData((prev) => ({ ...prev, winter: event.target.value }))}
+                      />
+                    ) : row.winter}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="0.001"
+                        className="drink-weights-inline-input"
+                        aria-label={`Sommer-Delta für ${row.id}`}
+                        value={formData.sommer}
+                        onChange={(event) => setFormData((prev) => ({ ...prev, sommer: event.target.value }))}
+                      />
+                    ) : row.sommer}
+                  </td>
+                  <td>
+                    {isEditing ? (
+                      <input
+                        type="number"
+                        step="0.001"
+                        className="drink-weights-inline-input"
+                        aria-label={`Nachmittag-Delta für ${row.id}`}
+                        value={formData.nachmittag}
+                        onChange={(event) => setFormData((prev) => ({ ...prev, nachmittag: event.target.value }))}
+                      />
+                    ) : row.nachmittag}
+                  </td>
+                  {hasGebinde && (
+                    <td>
+                      {isEditing ? (
+                        <input
+                          type="number"
+                          step="0.01"
+                          className="drink-weights-inline-input"
+                          aria-label={`Gebinde-Größe für ${row.id}`}
+                          value={formData.gebindeLiter}
+                          onChange={(event) => setFormData((prev) => ({ ...prev, gebindeLiter: event.target.value }))}
+                        />
+                      ) : row.gebindeLiter}
+                    </td>
+                  )}
+                  {hasGebinde && (
+                    <td>
+                      {isEditing ? (
+                        <input
+                          type="text"
+                          className="drink-weights-inline-input"
+                          aria-label={`Gebinde-Bezeichnung für ${row.id}`}
+                          value={formData.gebindeName}
+                          onChange={(event) => setFormData((prev) => ({ ...prev, gebindeName: event.target.value }))}
+                        />
+                      ) : row.gebindeName}
+                    </td>
+                  )}
+                  {hasGebinde && (
+                    <td>
+                      {isEditing ? (
+                        <input
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          max="1"
+                          className="drink-weights-inline-input"
+                          aria-label={`Anteil Trinker für ${row.id}`}
+                          placeholder="1.0"
+                          value={formData.anteilTrinker}
+                          onChange={(event) => setFormData((prev) => ({ ...prev, anteilTrinker: event.target.value }))}
+                        />
+                      ) : (row.anteilTrinker ?? '—')}
+                    </td>
+                  )}
+                  <td>{formatGermanDate(row.updatedAt)}</td>
+                  <td>
+                    <div className="drink-weights-actions">
+                      {isEditing ? (
+                        <>
+                          <button type="button" className="drink-weights-edit-btn" onClick={handleSave} disabled={isSaving}>
+                            {isSaving ? 'Speichern...' : 'Speichern'}
+                          </button>
+                          <button type="button" className="drink-weights-delete-btn" onClick={resetEditing}>
+                            Abbrechen
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button type="button" className="drink-weights-edit-btn" onClick={() => handleEdit(row)}>
+                            Bearbeiten
+                          </button>
+                          <button type="button" className="drink-weights-delete-btn" onClick={() => handleResetToDefault(row.id)}>
+                            Zurücksetzen
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DrinkWeightsTab({ currentUser }) {
+  const hasAccess = canManageDrinkWeights(currentUser);
+  const [adultsOverrides, setAdultsOverrides] = useState({});
+  const [childrenOverrides, setChildrenOverrides] = useState({});
+
+  useEffect(() => {
+    if (!hasAccess) return undefined;
+    const unsubscribeAdults = subscribeToDrinkWeights(setAdultsOverrides);
+    const unsubscribeChildren = subscribeToChildrenDrinkWeights(setChildrenOverrides);
+    return () => {
+      unsubscribeAdults();
+      unsubscribeChildren();
+    };
+  }, [hasAccess]);
+
+  const adultsRows = useMemo(() => buildRows(DEFAULT_DRINK_WEIGHTS, adultsOverrides), [adultsOverrides]);
+  const childrenRows = useMemo(() => buildRows(DEFAULT_CHILDREN_DRINK_WEIGHTS, childrenOverrides), [childrenOverrides]);
+
+  if (!hasAccess) {
+    return (
+      <div className="settings-section drink-weights-tab">
+        <h3>Getränkegewichtung</h3>
+        <div className="message error">
+          Nur Moderatoren und Administratoren können die Getränkegewichtung bearbeiten.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="settings-tab-header">
+        <h2>Getränkegewichtung</h2>
+      </div>
+      <div className="settings-section drink-weights-tab">
+        <p className="section-description">
+          Steuert, wie sich der Getränkebedarf eines Events auf die einzelnen Kategorien verteilt
+          (siehe Getränkekalkulation). Änderungen wirken sich auf alle künftigen Berechnungen aus.
+        </p>
+
+        <DrinkWeightMatrixTable
+          title="Erwachsene"
+          description="Basis-Gewichte und saisonale Anpassungen je Kategorie, inklusive Gebinde-Metadaten für Einkauf und Verbrauch."
+          rows={adultsRows}
+          hasGebinde
+          defaults={DEFAULT_DRINK_WEIGHTS}
+          onSave={setDrinkWeightEntry}
+          currentUser={currentUser}
+        />
+
+        <DrinkWeightMatrixTable
+          title="Kinder"
+          description="Basis-Gewichte und saisonale Anpassungen für den Kinderanteil des Getränkebedarfs. Alkoholische Kategorien bleiben bei 0."
+          rows={childrenRows}
+          hasGebinde={false}
+          defaults={DEFAULT_CHILDREN_DRINK_WEIGHTS}
+          onSave={setChildrenDrinkWeightEntry}
+          currentUser={currentUser}
+        />
+      </div>
+    </>
+  );
+}
+
+export default DrinkWeightsTab;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -5,7 +5,7 @@ import { getOnboardingTestmodeActive, saveOnboardingTestmodeActive } from '../ut
 import PrintFormatEditor from './PrintFormatEditor';
 import PrintPreview from './PrintPreview';
 import { invalidateUnitsCache } from '../utils/ingredientUtils';
-import { isCurrentUserAdmin, ROLES, getRolePermissions, canManageSeasonMatrix } from '../utils/userManagement';
+import { isCurrentUserAdmin, ROLES, getRolePermissions, canManageSeasonMatrix, canManageDrinkWeights } from '../utils/userManagement';
 import UserManagement from './UserManagement';
 import { getCategoryImages, addCategoryImage, updateCategoryImage, removeCategoryImage, getAlreadyAssignedCategories } from '../utils/categoryImages';
 import { fileToBase64, isBase64Image, compressImage } from '../utils/imageUtils';
@@ -14,6 +14,7 @@ import { uploadAppLogoToStorage, deleteAppLogoFromStorage } from '../utils/stora
 import { addFaq, updateFaq, deleteFaq, subscribeToFaqs, importFaqsFromMarkdown } from '../utils/faqFirestore';
 import SeasonMatrixTab from './SeasonMatrixTab';
 import NutritionReferenceTab from './NutritionReferenceTab';
+import DrinkWeightsTab from './DrinkWeightsTab';
 import {
   DndContext,
   closestCenter,
@@ -374,6 +375,7 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
   // Whether the current user can rename cuisine types and meal categories
   const canEditLists = isAdmin || rolePermissions?.[currentUser?.role]?.editLists === true;
   const canAccessSeasonMatrix = canManageSeasonMatrix(currentUser);
+  const canAccessDrinkWeights = canManageDrinkWeights(currentUser);
 
   const resizeInspirationTextarea = useCallback((textarea) => {
     if (!textarea) return;
@@ -1463,7 +1465,7 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
     { label: 'Zeitleisten-Icon (Kochereignisse)', icon: timelineCookEventBubbleIcon, uploading: uploadingTimelineCookEventBubbleIcon, onChange: handleTimelineCookEventBubbleIconUpload, onRemove: handleRemoveTimelineCookEventBubbleIcon, fileId: 'timelineCookEventBubbleIconFile' },
   ];
 
-  const isFullWidthTab = ['users', 'saisonmatrix', 'naehrwerte'].includes(activeTab);
+  const isFullWidthTab = ['users', 'saisonmatrix', 'naehrwerte', 'getraenkegewichte'].includes(activeTab);
 
   return (
     <div className="settings-container">
@@ -1554,6 +1556,14 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
                     onClick={() => setActiveTab('naehrwerte')}
                   >
                     Nährwerte
+                  </button>
+                )}
+                {canAccessDrinkWeights && (
+                  <button
+                    className={`tab-button ${activeTab === 'getraenkegewichte' ? 'active' : ''}`}
+                    onClick={() => setActiveTab('getraenkegewichte')}
+                  >
+                    Getränkegewichtung
                   </button>
                 )}
               </nav>
@@ -3270,6 +3280,8 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
           <SeasonMatrixTab currentUser={currentUser} />
         ) : activeTab === 'naehrwerte' ? (
           <NutritionReferenceTab currentUser={currentUser} allRecipes={allRecipes} />
+        ) : activeTab === 'getraenkegewichte' ? (
+          <DrinkWeightsTab currentUser={currentUser} />
         ) : (
           <UserManagement onBack={() => setActiveTab('general')} currentUser={currentUser} allUsers={allUsers} />
         )}

--- a/src/utils/drinkWeightsDefaults.js
+++ b/src/utils/drinkWeightsDefaults.js
@@ -1,0 +1,85 @@
+/**
+ * Standard-Startwerte fuer die Getraenke-Gewichtungsmatrizen (Erwachsene +
+ * Kinder). Spiegelt DRINK_WEIGHTS / CHILDREN_DRINK_WEIGHTS aus
+ * functions/drinkRates.js -- das ist die einzige Quelle der Wahrheit fuer
+ * diese Werte. Sie dienen hier nur als Vorbelegung, solange fuer eine
+ * Kategorie noch kein Firestore-Dokument existiert (siehe drinkWeightsFirestore.js).
+ */
+
+export const DEFAULT_DRINK_WEIGHTS = {
+  bier: {
+    parent: null,
+    basis: 0.221, winter: -0.016, sommer: 0.010, nachmittag: -0.040,
+    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+  },
+  bier_alkoholfrei: {
+    parent: 'bier',
+    basis: 0.039, winter: -0.002, sommer: 0.004, nachmittag: 0.005,
+    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+  },
+  wein: {
+    parent: null,
+    basis: 0.137, winter: 0.042, sommer: -0.053, nachmittag: -0.020,
+    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.3,
+  },
+  sekt: {
+    parent: null,
+    basis: 0.015, winter: 0.010, sommer: -0.008, nachmittag: -0.006,
+    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.4,
+  },
+  softdrinks: {
+    parent: null,
+    basis: 0.260, winter: -0.048, sommer: 0.056, nachmittag: 0.020,
+    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
+  },
+  saft: {
+    parent: null,
+    basis: 0.025, winter: -0.005, sommer: 0.006, nachmittag: 0.002,
+    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
+  },
+  spirituosen: {
+    parent: null,
+    basis: 0.011, winter: 0.007, sommer: -0.010, nachmittag: -0.010,
+    gebindeLiter: 0.7, gebindeName: '0,7L-Flasche', anteilTrinker: 0.25,
+  },
+  longdrinks: {
+    parent: 'spirituosen',
+    basis: 0.017, winter: -0.002, sommer: 0.002, nachmittag: -0.005,
+    gebindeLiter: 1.0, gebindeName: '1L-Flasche (Mixer)', anteilTrinker: 0.35,
+  },
+  kaffee: {
+    parent: null,
+    basis: 0.083, winter: 0.046, sommer: -0.039, nachmittag: 0.035,
+    gebindeLiter: 0.0625, gebindeName: 'Tasse (125ml)',
+  },
+  tee: {
+    parent: null,
+    basis: 0.037, winter: 0.025, sommer: -0.021, nachmittag: 0.015,
+    gebindeLiter: 0.2, gebindeName: 'Tasse (200ml)',
+  },
+  wasser: {
+    parent: null,
+    basis: 0.155, winter: -0.051, sommer: 0.050, nachmittag: 0.000,
+    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
+  },
+};
+
+export const DEFAULT_CHILDREN_DRINK_WEIGHTS = {
+  bier: { parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  bier_alkoholfrei: { parent: 'bier', basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  wein: { parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  sekt: { parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  spirituosen: { parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  longdrinks: { parent: 'spirituosen', basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  softdrinks: { parent: null, basis: 0.280, winter: -0.040, sommer: 0.050, nachmittag: 0.010 },
+  saft: { parent: null, basis: 0.320, winter: 0.010, sommer: 0.030, nachmittag: 0.015 },
+  kaffee: { parent: null, basis: 0.0, winter: 0.0, sommer: 0.0, nachmittag: 0.0 },
+  tee: { parent: null, basis: 0.030, winter: 0.030, sommer: -0.010, nachmittag: 0.010 },
+  wasser: { parent: null, basis: 0.370, winter: -0.020, sommer: 0.060, nachmittag: -0.005 },
+};
+
+// Reihenfolge der Kategorien fuer die Anzeige in der Admin-Tabelle -- spiegelt
+// die Reihenfolge in functions/drinkRates.js. Die Kategorien selbst sind fest
+// (siehe DRINK_CATEGORY_PARENTS in functions/calculateEventDrinks.js) und
+// koennen ueber die Admin-Oberflaeche nicht hinzugefuegt oder geloescht werden.
+export const DRINK_WEIGHT_CATEGORY_ORDER = Object.keys(DEFAULT_DRINK_WEIGHTS);

--- a/src/utils/drinkWeightsFirestore.js
+++ b/src/utils/drinkWeightsFirestore.js
@@ -1,0 +1,91 @@
+/**
+ * Getraenke-Gewichtungsmatrizen (Erwachsene + Kinder) Firestore Utilities.
+ * Speichert die admin-editierbaren Basiswerte, die functions/drinkRates.js
+ * fuer die Event-Getraenkekalkulation laedt (Collections 'drinkWeights' und
+ * 'drinkWeightsChildren', Dokument-ID = Kategorie-ID, siehe
+ * DEFAULT_DRINK_WEIGHTS / DEFAULT_CHILDREN_DRINK_WEIGHTS fuer die Vorbelegung).
+ */
+import { db } from '../firebase';
+import {
+  collection,
+  doc,
+  setDoc,
+  getDocs,
+  onSnapshot,
+  serverTimestamp
+} from 'firebase/firestore';
+import { removeUndefinedFields } from './firestoreUtils';
+
+export const DRINK_WEIGHTS_COLLECTION = 'drinkWeights';
+export const CHILDREN_DRINK_WEIGHTS_COLLECTION = 'drinkWeightsChildren';
+
+const snapshotToMap = (snapshot) => {
+  const entries = {};
+  snapshot.forEach((entryDoc) => {
+    entries[entryDoc.id] = entryDoc.data();
+  });
+  return entries;
+};
+
+const subscribeToCollection = (collectionName, callback) => {
+  return onSnapshot(collection(db, collectionName), (snapshot) => {
+    callback(snapshotToMap(snapshot));
+  }, (error) => {
+    if (error?.code === 'permission-denied') {
+      console.warn(`${collectionName} subscription skipped: permission denied`);
+    } else {
+      console.error(`Error subscribing to ${collectionName}:`, error);
+    }
+    callback({});
+  });
+};
+
+const getCollectionOnce = async (collectionName) => {
+  try {
+    const snapshot = await getDocs(collection(db, collectionName));
+    return snapshotToMap(snapshot);
+  } catch (error) {
+    console.error(`Error loading ${collectionName}:`, error);
+    return {};
+  }
+};
+
+const setCollectionEntry = async (collectionName, categoryId, data, updatedBy) => {
+  const entryRef = doc(db, collectionName, categoryId);
+  const payload = removeUndefinedFields({
+    ...data,
+    updatedAt: serverTimestamp(),
+    updatedBy: updatedBy ?? data?.updatedBy
+  });
+  await setDoc(entryRef, payload, { merge: true });
+};
+
+/** Subscribe to the adults drink weight matrix in realtime. */
+export const subscribeToDrinkWeights = (callback) => subscribeToCollection(DRINK_WEIGHTS_COLLECTION, callback);
+
+/** Subscribe to the children drink weight matrix in realtime. */
+export const subscribeToChildrenDrinkWeights = (callback) => subscribeToCollection(CHILDREN_DRINK_WEIGHTS_COLLECTION, callback);
+
+/** Load the adults drink weight matrix once (no realtime subscription). */
+export const getDrinkWeightsOnce = () => getCollectionOnce(DRINK_WEIGHTS_COLLECTION);
+
+/** Load the children drink weight matrix once (no realtime subscription). */
+export const getChildrenDrinkWeightsOnce = () => getCollectionOnce(CHILDREN_DRINK_WEIGHTS_COLLECTION);
+
+/**
+ * Create or update one category entry of the adults drink weight matrix.
+ * @param {string} categoryId Category id (document id).
+ * @param {Object} data Fields to write (basis, winter, sommer, nachmittag, gebindeLiter, gebindeName, anteilTrinker).
+ * @param {string} [updatedBy] Optional user name / email for the audit field.
+ */
+export const setDrinkWeightEntry = (categoryId, data, updatedBy) =>
+  setCollectionEntry(DRINK_WEIGHTS_COLLECTION, categoryId, data, updatedBy);
+
+/**
+ * Create or update one category entry of the children drink weight matrix.
+ * @param {string} categoryId Category id (document id).
+ * @param {Object} data Fields to write (basis, winter, sommer, nachmittag).
+ * @param {string} [updatedBy] Optional user name / email for the audit field.
+ */
+export const setChildrenDrinkWeightEntry = (categoryId, data, updatedBy) =>
+  setCollectionEntry(CHILDREN_DRINK_WEIGHTS_COLLECTION, categoryId, data, updatedBy);

--- a/src/utils/userManagement.js
+++ b/src/utils/userManagement.js
@@ -598,6 +598,17 @@ export const canManageSeasonMatrix = (user) => {
 };
 
 /**
+ * Check if user may manage the Getraenke-Gewichtungsmatrizen (Erwachsene + Kinder)
+ * in the admin area. Moderators and administrators may edit entries.
+ * @param {Object} user - User object
+ * @returns {boolean}
+ */
+export const canManageDrinkWeights = (user) => {
+  if (!user) return false;
+  return hasPermission(user, ROLES.MODERATOR);
+};
+
+/**
  * Check if user may view the recipe index field in recipe detail.
  * If role-based feature permissions are loaded, use the dedicated recipeIndex flag.
  * Otherwise fall back to moderators/administrators by hierarchy.


### PR DESCRIPTION
Fügt eine neue Admin-Oberfläche (Settings > Getränkegewichtung, Moderator/
Admin) hinzu, über die die bisher hartcodierten DRINK_WEIGHTS und
CHILDREN_DRINK_WEIGHTS aus functions/drinkRates.js pro Kategorie in
Firestore (Collections 'drinkWeights' / 'drinkWeightsChildren') bearbeitet
werden können. Die Cloud Functions (calculateEventDrinks, submitConsumption)
laden diese Werte jetzt zur Laufzeit aus Firestore und fallen auf die
hartcodierten Startwerte zurück, wenn noch keine Firestore-Overrides
existieren.