### PR TITLE
Remove gebinde metadata from drink weights matrix

### DIFF
--- a/functions/calculateEventDrinks.categoryDistribution.test.js
+++ b/functions/calculateEventDrinks.categoryDistribution.test.js
@@ -800,7 +800,9 @@ test('loadCustomDrinks verwendet fallback fuer predefined_mineralwasser ohne Fir
   const result = await _internal.loadCustomDrinks(db, 'user-1', ['predefined_mineralwasser']);
 
   assert.ok(result.predefined_mineralwasser, 'predefined_mineralwasser wurde aufgeloest');
-  assert.deepEqual(result.predefined_mineralwasser.einheiten, []);
+  assert.deepEqual(result.predefined_mineralwasser.einheiten, [
+    {einheitsgroesse: 1.0, gebindeinheit: 'Flasche', einheitenProGebinde: 1},
+  ]);
   assert.equal(result.predefined_mineralwasser.name, 'Mineralwasser');
   assert.equal(result.predefined_mineralwasser.kategorie, 'wasser');
   assert.equal(result.predefined_mineralwasser.predefined, true);
@@ -839,6 +841,6 @@ test('calculate erzeugt fuer "predefined_mineralwasser" keine Warnung und eine i
   assert.equal(predefinedRow.isPredefinedDrink, true, 'Zeile ist als isPredefinedDrink markiert');
   assert.equal(predefinedRow.drinkLabel, 'Mineralwasser', 'drinkLabel ist gesetzt');
   assert.equal(predefinedRow.drinkKategorie, 'wasser', 'drinkKategorie ist gesetzt');
-  assert.equal(predefinedRow.gebindeGroesseLiter, wasser.gebindeGroesseLiter, 'Gebinde aus Kategorie-Zeile uebernommen');
+  assert.equal(predefinedRow.gebindeGroesseLiter, null, 'Kategorie-Zeile liefert keine Gebinde-Daten mehr (kommen aus einheiten)');
   assert.equal(predefinedRow.literOhnePuffer, wasser.literOhnePuffer, 'Literbedarf aus Kategorie-Zeile uebernommen');
 });

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -29,7 +29,7 @@ const PREDEFINED_DRINKS = {
   predefined_mineralwasser: {
     name: 'Mineralwasser',
     kategorie: 'wasser',
-    einheiten: [],
+    einheiten: [{einheitsgroesse: 1.0, gebindeinheit: 'Flasche', einheitenProGebinde: 1}],
     predefined: true,
   },
 };
@@ -433,16 +433,17 @@ function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_D
         0;
     const literGesamt = adultsLiterGesamt + childrenLiterGesamt;
     const literMitPuffer = literGesamt * (1 + puffer);
-    const anzahlGebinde =
-        entry.gebindeLiter ? Math.ceil(literMitPuffer / entry.gebindeLiter) : null;
 
+    // Gebindegroesse/-bezeichnung kommen nicht mehr aus DRINK_WEIGHTS, sondern
+    // ausschliesslich von den einzelnen Getraenken (deren `einheiten`) -- die
+    // Kategorie-Zeile selbst liefert daher keine Gebinde-Angaben mehr.
     ergebnis.push({
       kategorie: cat,
       literOhnePuffer: round2(literGesamt),
       literMitPuffer: round2(literMitPuffer),
-      gebinde: entry.gebindeName,
-      gebindeGroesseLiter: entry.gebindeLiter,
-      anzahlGebinde,
+      gebinde: null,
+      gebindeGroesseLiter: null,
+      anzahlGebinde: null,
       ratenQuelle: entry._nEvents ? 'erfahrungswert' : 'standard-faustwert',
       anteilTrinkerAngenommen: anteilTrinker !== 1.0 ? anteilTrinker : null,
       praeferenzFaktor: null,
@@ -496,11 +497,13 @@ function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_D
       continue;
     }
 
-    // Vordefinierte Getraenke ohne eigene Gebinde (z.B. Mineralwasser) haben
-    // keine eigenen Einheiten. Ihr Bedarf steckt bereits in der normalen
-    // Kategorie-Zeile. Wir erzeugen trotzdem eine eigene Zeile mit
-    // isPredefinedDrink: true, damit die Verbrauch-Form das Getraenk
-    // anzeigen kann (mit den Gebinde-Daten der Kategorie-Zeile).
+    // Fallback fuer vordefinierte Getraenke, denen (noch) keine eigene
+    // Einheit zugewiesen wurde -- eigentlich sollte z.B. Mineralwasser immer
+    // eine Einheit haben (siehe PREDEFINED_DRINKS), das hier faengt nur
+    // unvollstaendig gepflegte Bestandsdaten ab. Ihr Bedarf steckt bereits in
+    // der normalen Kategorie-Zeile, Gebinde-Angaben (gebinde/gebindeGroesseLiter)
+    // liefert diese Zeile aber nicht mehr, da DRINK_WEIGHTS keine
+    // Gebinde-Metadaten mehr fuehrt.
     if (entry.predefined && (!Array.isArray(entry.einheiten) || entry.einheiten.length === 0)) {
       const catRow = ergebnis.find((r) => !r.isCustomDrink && r.kategorie === entry.kategorie);
       ergebnis.push({

--- a/functions/drinkRates.drinkWeights.test.js
+++ b/functions/drinkRates.drinkWeights.test.js
@@ -70,13 +70,6 @@ test('DRINK_WEIGHTS enthaelt alle erwarteten Kategorien', () => {
   }
 });
 
-test('DRINK_WEIGHTS-Eintraege enthalten Gebinde-Metadaten fuer Einkauf/Verbrauch', () => {
-  for (const [cat, entry] of Object.entries(DRINK_WEIGHTS)) {
-    assert.ok(entry.gebindeLiter > 0, `${cat} hat keine gebindeLiter`);
-    assert.ok(entry.gebindeName, `${cat} hat keinen gebindeName`);
-  }
-});
-
 // --- parent / getWeightSubcategoryParents / getParentTotal ---
 
 test('DRINK_WEIGHTS.parent bildet die Eltern/Kind-Beziehungen ab', () => {

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -61,11 +61,11 @@ function timeFactor(startTime, hours) {
  * Beziehungen im Getraenke-Modell (siehe getWeightSubcategoryParents(),
  * getParentTotal() sowie DRINK_CATEGORY_PARENTS in calculateEventDrinks.js).
  *
- * `gebindeLiter`/`gebindeName` beschreiben die Standard-Gebindegroesse der
- * Kategorie (Einkaufs-/Verbrauchseinheit), `anteilTrinker` den angenommenen
- * Anteil der erwachsenen Gaeste, der die Kategorie ueberhaupt konsumiert
- * (fehlt das Feld, wird 1.0 angenommen). Dies ist die einzige Quelle der
- * Wahrheit fuer beides -- es gibt keine separate Raten-Tabelle mehr.
+ * `anteilTrinker` beschreibt den angenommenen Anteil der erwachsenen Gaeste,
+ * der die Kategorie ueberhaupt konsumiert (fehlt das Feld, wird 1.0
+ * angenommen). Gebindegroessen fuer Einkauf/Verbrauch kommen ausschliesslich
+ * von den einzelnen Getraenken (deren `einheiten`), nicht mehr aus dieser
+ * Matrix.
  *
  * bier_alkoholfrei (85/15-Split von "bier") und longdrinks (40/60-Split von
  * "spirituosen") sind beides ungeprueft geschaetzte Aufteilungen ohne
@@ -79,7 +79,7 @@ const DRINK_WEIGHTS = {
     winter: -0.016,
     sommer: 0.010,
     nachmittag: -0.040,
-    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+    anteilTrinker: 0.5,
   },
   bier_alkoholfrei: {
     parent: 'bier',
@@ -87,7 +87,7 @@ const DRINK_WEIGHTS = {
     winter: -0.002,
     sommer: 0.004,
     nachmittag: 0.005,
-    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+    anteilTrinker: 0.5,
   },
   wein: {
     parent: null,
@@ -95,7 +95,7 @@ const DRINK_WEIGHTS = {
     winter: 0.042,
     sommer: -0.053,
     nachmittag: -0.020,
-    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.3,
+    anteilTrinker: 0.3,
   },
   sekt: {
     parent: null,
@@ -103,7 +103,7 @@ const DRINK_WEIGHTS = {
     winter: 0.010,
     sommer: -0.008,
     nachmittag: -0.006,
-    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.4,
+    anteilTrinker: 0.4,
   },
   softdrinks: {
     parent: null,
@@ -111,7 +111,6 @@ const DRINK_WEIGHTS = {
     winter: -0.048,
     sommer: 0.056,
     nachmittag: 0.020,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
   saft: {
     parent: null,
@@ -119,7 +118,6 @@ const DRINK_WEIGHTS = {
     winter: -0.005,
     sommer: 0.006,
     nachmittag: 0.002,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
   spirituosen: {
     parent: null,
@@ -127,7 +125,7 @@ const DRINK_WEIGHTS = {
     winter: 0.007,
     sommer: -0.010,
     nachmittag: -0.010,
-    gebindeLiter: 0.7, gebindeName: '0,7L-Flasche', anteilTrinker: 0.25,
+    anteilTrinker: 0.25,
   },
   longdrinks: {
     parent: 'spirituosen',
@@ -135,7 +133,7 @@ const DRINK_WEIGHTS = {
     winter: -0.002,
     sommer: 0.002,
     nachmittag: -0.005,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche (Mixer)', anteilTrinker: 0.35,
+    anteilTrinker: 0.35,
   },
   kaffee: {
     parent: null,
@@ -143,7 +141,6 @@ const DRINK_WEIGHTS = {
     winter: 0.046,
     sommer: -0.039,
     nachmittag: 0.035,
-    gebindeLiter: 0.0625, gebindeName: 'Tasse (125ml)',
   },
   tee: {
     parent: null,
@@ -151,7 +148,6 @@ const DRINK_WEIGHTS = {
     winter: 0.025,
     sommer: -0.021,
     nachmittag: 0.015,
-    gebindeLiter: 0.2, gebindeName: 'Tasse (200ml)',
   },
   wasser: {
     parent: null,
@@ -159,7 +155,6 @@ const DRINK_WEIGHTS = {
     winter: -0.051,
     sommer: 0.050,
     nachmittag: 0.000,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
 };
 

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -1,19 +1,16 @@
 const {onCall, HttpsError} = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
-const {loadDrinkWeightsFromFirestore} = require('./drinkRates');
 
 /**
  * Rechnet aus "eingekauft minus uebrig" (in Gebinden) den tatsaechlichen
- * Verbrauch in Litern pro Kategorie. Fuer benutzerdefinierte Getraenke gibt es
- * keinen Eintrag in DRINK_WEIGHTS (das ist nur nach den festen Standard-
- * Kategorien indiziert) -- dafuer wird die Gebindegroesse aus der Event-
- * Berechnung (event.berechnung.ergebnis[].gebindeGroesseLiter) verwendet.
+ * Verbrauch in Litern pro Kategorie. Die Gebindegroesse je Kategorie kommt
+ * aus der Event-Berechnung (event.berechnung.ergebnis[].gebindeGroesseLiter),
+ * die wiederum von der eigenen Einheit des jeweiligen Getraenks stammt.
  * @param {object} gebinde { kategorie: { eingekauft, uebrig } }
- * @param {object} ratesDb Rate-DB fuer Gebindegroessen.
  * @param {object} event Event-Dokument (fuer Custom-Drink-Gebindegroessen).
  * @return {object} { kategorie: literGemessen }
  */
-function gebindeZuLiter(gebinde, ratesDb, event) {
+function gebindeZuLiter(gebinde, event) {
   const gebindeLiterAusBerechnung = {};
   (event?.berechnung?.ergebnis || []).forEach((row) => {
     if (row.kategorie && Number.isFinite(row.gebindeGroesseLiter) && row.gebindeGroesseLiter > 0) {
@@ -23,7 +20,7 @@ function gebindeZuLiter(gebinde, ratesDb, event) {
 
   const result = {};
   for (const [cat, {eingekauft, uebrig}] of Object.entries(gebinde)) {
-    const gebindeLiter = ratesDb[cat]?.gebindeLiter || gebindeLiterAusBerechnung[cat];
+    const gebindeLiter = gebindeLiterAusBerechnung[cat];
     if (!gebindeLiter) continue;
     const verbrauchtGebinde = Math.max((eingekauft || 0) - (uebrig || 0), 0);
     result[cat] = verbrauchtGebinde * gebindeLiter;
@@ -75,8 +72,7 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   }
   const event = eventSnap.data();
 
-  const ratesDb = await loadDrinkWeightsFromFirestore(db);
-  const literGemessen = gebindeZuLiter(gebinde, ratesDb, event);
+  const literGemessen = gebindeZuLiter(gebinde, event);
 
   const batch = db.batch();
 

--- a/functions/submitConsumption.test.js
+++ b/functions/submitConsumption.test.js
@@ -2,11 +2,17 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {_internal} = require('./submitConsumption');
-const {DRINK_WEIGHTS} = require('./drinkRates');
 
-test('gebindeZuLiter berechnet Liter fuer Standard-Kategorien aus der Rate-DB', () => {
+test('gebindeZuLiter berechnet Liter aus der Gebindegroesse der Event-Berechnung', () => {
   const gebinde = {bier: {eingekauft: 10, uebrig: 4}};
-  const result = _internal.gebindeZuLiter(gebinde, DRINK_WEIGHTS, {});
+  const event = {
+    berechnung: {
+      ergebnis: [
+        {kategorie: 'bier', isCustomDrink: true, drinkLabel: 'Bitburger', gebindeGroesseLiter: 0.5},
+      ],
+    },
+  };
+  const result = _internal.gebindeZuLiter(gebinde, event);
   assert.equal(result.bier, 3);
 });
 
@@ -21,18 +27,25 @@ test('gebindeZuLiter faellt fuer Custom-Drinks auf die Gebindegroesse aus der Ev
       ],
     },
   };
-  const result = _internal.gebindeZuLiter(gebinde, {}, event);
+  const result = _internal.gebindeZuLiter(gebinde, event);
   assert.equal(result.customDrink1, 6);
 });
 
 test('gebindeZuLiter ueberspringt Kategorien ohne bekannte Gebindegroesse', () => {
   const gebinde = {unbekannt: {eingekauft: 3, uebrig: 1}};
-  const result = _internal.gebindeZuLiter(gebinde, {}, {});
+  const result = _internal.gebindeZuLiter(gebinde, {});
   assert.deepEqual(result, {});
 });
 
 test('gebindeZuLiter behandelt fehlenden/negativen Verbrauch als 0', () => {
   const gebinde = {bier: {eingekauft: 2, uebrig: 5}};
-  const result = _internal.gebindeZuLiter(gebinde, DRINK_WEIGHTS, {});
+  const event = {
+    berechnung: {
+      ergebnis: [
+        {kategorie: 'bier', isCustomDrink: true, drinkLabel: 'Bitburger', gebindeGroesseLiter: 0.5},
+      ],
+    },
+  };
+  const result = _internal.gebindeZuLiter(gebinde, event);
   assert.equal(result.bier, 0);
 });

--- a/src/components/DrinkWeightsTab.js
+++ b/src/components/DrinkWeightsTab.js
@@ -12,14 +12,12 @@ import { canManageDrinkWeights } from '../utils/userManagement';
 
 const NUMBER_FIELDS = ['basis', 'winter', 'sommer', 'nachmittag'];
 
-const createFormData = (row, hasGebinde) => ({
+const createFormData = (row, hasAnteilTrinker) => ({
   basis: row.basis,
   winter: row.winter,
   sommer: row.sommer,
   nachmittag: row.nachmittag,
-  ...(hasGebinde ? {
-    gebindeLiter: row.gebindeLiter ?? '',
-    gebindeName: row.gebindeName ?? '',
+  ...(hasAnteilTrinker ? {
     anteilTrinker: row.anteilTrinker ?? ''
   } : {})
 });
@@ -44,7 +42,7 @@ const buildRows = (defaults, overrides) =>
     ...(overrides[id] || {})
   }));
 
-function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults, onSave, currentUser }) {
+function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, defaults, onSave, currentUser }) {
   const [editingId, setEditingId] = useState(null);
   const [formData, setFormData] = useState({});
   const [isSaving, setIsSaving] = useState(false);
@@ -54,7 +52,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults
 
   const handleEdit = (row) => {
     setEditingId(row.id);
-    setFormData(createFormData(row, hasGebinde));
+    setFormData(createFormData(row, hasAnteilTrinker));
     setErrorMessage('');
   };
 
@@ -82,14 +80,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults
       }
     }
     if (Number(formData.basis) < 0) return 'Das Basis-Gewicht darf nicht negativ sein.';
-    if (hasGebinde) {
-      const gebindeLiter = Number(formData.gebindeLiter);
-      if (!Number.isFinite(gebindeLiter) || gebindeLiter <= 0) {
-        return 'Bitte eine gültige Gebinde-Größe (Liter) eingeben.';
-      }
-      if (!String(formData.gebindeName || '').trim()) {
-        return 'Bitte eine Gebinde-Bezeichnung eingeben.';
-      }
+    if (hasAnteilTrinker) {
       if (formData.anteilTrinker !== '' && formData.anteilTrinker !== undefined) {
         const anteilTrinker = Number(formData.anteilTrinker);
         if (!Number.isFinite(anteilTrinker) || anteilTrinker <= 0 || anteilTrinker > 1) {
@@ -116,9 +107,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults
       sommer: Number(formData.sommer),
       nachmittag: Number(formData.nachmittag)
     };
-    if (hasGebinde) {
-      payload.gebindeLiter = Number(formData.gebindeLiter);
-      payload.gebindeName = String(formData.gebindeName).trim();
+    if (hasAnteilTrinker) {
       payload.anteilTrinker = formData.anteilTrinker === '' || formData.anteilTrinker === undefined
         ? undefined
         : Number(formData.anteilTrinker);
@@ -155,9 +144,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults
               <th>Winter Δ</th>
               <th>Sommer Δ</th>
               <th>Nachmittag Δ</th>
-              {hasGebinde && <th>Gebinde-Größe (L)</th>}
-              {hasGebinde && <th>Gebinde-Bezeichnung</th>}
-              {hasGebinde && <th>Anteil Trinker</th>}
+              {hasAnteilTrinker && <th>Anteil Trinker</th>}
               <th>Letzte Änderung</th>
               <th>Aktionen</th>
             </tr>
@@ -220,34 +207,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasGebinde, defaults
                       />
                     ) : row.nachmittag}
                   </td>
-                  {hasGebinde && (
-                    <td>
-                      {isEditing ? (
-                        <input
-                          type="number"
-                          step="0.01"
-                          className="drink-weights-inline-input"
-                          aria-label={`Gebinde-Größe für ${row.id}`}
-                          value={formData.gebindeLiter}
-                          onChange={(event) => setFormData((prev) => ({ ...prev, gebindeLiter: event.target.value }))}
-                        />
-                      ) : row.gebindeLiter}
-                    </td>
-                  )}
-                  {hasGebinde && (
-                    <td>
-                      {isEditing ? (
-                        <input
-                          type="text"
-                          className="drink-weights-inline-input"
-                          aria-label={`Gebinde-Bezeichnung für ${row.id}`}
-                          value={formData.gebindeName}
-                          onChange={(event) => setFormData((prev) => ({ ...prev, gebindeName: event.target.value }))}
-                        />
-                      ) : row.gebindeName}
-                    </td>
-                  )}
-                  {hasGebinde && (
+                  {hasAnteilTrinker && (
                     <td>
                       {isEditing ? (
                         <input
@@ -340,9 +300,9 @@ function DrinkWeightsTab({ currentUser }) {
 
         <DrinkWeightMatrixTable
           title="Erwachsene"
-          description="Basis-Gewichte und saisonale Anpassungen je Kategorie, inklusive Gebinde-Metadaten für Einkauf und Verbrauch."
+          description="Basis-Gewichte und saisonale Anpassungen je Kategorie."
           rows={adultsRows}
-          hasGebinde
+          hasAnteilTrinker
           defaults={DEFAULT_DRINK_WEIGHTS}
           onSave={setDrinkWeightEntry}
           currentUser={currentUser}
@@ -352,7 +312,7 @@ function DrinkWeightsTab({ currentUser }) {
           title="Kinder"
           description="Basis-Gewichte und saisonale Anpassungen für den Kinderanteil des Getränkebedarfs. Alkoholische Kategorien bleiben bei 0."
           rows={childrenRows}
-          hasGebinde={false}
+          hasAnteilTrinker={false}
           defaults={DEFAULT_CHILDREN_DRINK_WEIGHTS}
           onSave={setChildrenDrinkWeightEntry}
           currentUser={currentUser}

--- a/src/utils/drinkCategories.js
+++ b/src/utils/drinkCategories.js
@@ -43,7 +43,7 @@ export const PREDEFINED_DRINKS = [
     id: 'predefined_mineralwasser',
     name: 'Mineralwasser',
     kategorie: 'wasser',
-    einheiten: [],
+    einheiten: [{ einheitsgroesse: 1.0, gebindeinheit: 'Flasche', einheitenProGebinde: 1 }],
     predefined: true,
   },
 ];

--- a/src/utils/drinkWeightsDefaults.js
+++ b/src/utils/drinkWeightsDefaults.js
@@ -10,57 +10,52 @@ export const DEFAULT_DRINK_WEIGHTS = {
   bier: {
     parent: null,
     basis: 0.221, winter: -0.016, sommer: 0.010, nachmittag: -0.040,
-    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+    anteilTrinker: 0.5,
   },
   bier_alkoholfrei: {
     parent: 'bier',
     basis: 0.039, winter: -0.002, sommer: 0.004, nachmittag: 0.005,
-    gebindeLiter: 0.5, gebindeName: '0,5L-Flasche', anteilTrinker: 0.5,
+    anteilTrinker: 0.5,
   },
   wein: {
     parent: null,
     basis: 0.137, winter: 0.042, sommer: -0.053, nachmittag: -0.020,
-    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.3,
+    anteilTrinker: 0.3,
   },
   sekt: {
     parent: null,
     basis: 0.015, winter: 0.010, sommer: -0.008, nachmittag: -0.006,
-    gebindeLiter: 0.75, gebindeName: '0,75L-Flasche', anteilTrinker: 0.4,
+    anteilTrinker: 0.4,
   },
   softdrinks: {
     parent: null,
     basis: 0.260, winter: -0.048, sommer: 0.056, nachmittag: 0.020,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
   saft: {
     parent: null,
     basis: 0.025, winter: -0.005, sommer: 0.006, nachmittag: 0.002,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
   spirituosen: {
     parent: null,
     basis: 0.011, winter: 0.007, sommer: -0.010, nachmittag: -0.010,
-    gebindeLiter: 0.7, gebindeName: '0,7L-Flasche', anteilTrinker: 0.25,
+    anteilTrinker: 0.25,
   },
   longdrinks: {
     parent: 'spirituosen',
     basis: 0.017, winter: -0.002, sommer: 0.002, nachmittag: -0.005,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche (Mixer)', anteilTrinker: 0.35,
+    anteilTrinker: 0.35,
   },
   kaffee: {
     parent: null,
     basis: 0.083, winter: 0.046, sommer: -0.039, nachmittag: 0.035,
-    gebindeLiter: 0.0625, gebindeName: 'Tasse (125ml)',
   },
   tee: {
     parent: null,
     basis: 0.037, winter: 0.025, sommer: -0.021, nachmittag: 0.015,
-    gebindeLiter: 0.2, gebindeName: 'Tasse (200ml)',
   },
   wasser: {
     parent: null,
     basis: 0.155, winter: -0.051, sommer: 0.050, nachmittag: 0.000,
-    gebindeLiter: 1.0, gebindeName: '1L-Flasche',
   },
 };
 

--- a/src/utils/drinkWeightsFirestore.js
+++ b/src/utils/drinkWeightsFirestore.js
@@ -75,7 +75,7 @@ export const getChildrenDrinkWeightsOnce = () => getCollectionOnce(CHILDREN_DRIN
 /**
  * Create or update one category entry of the adults drink weight matrix.
  * @param {string} categoryId Category id (document id).
- * @param {Object} data Fields to write (basis, winter, sommer, nachmittag, gebindeLiter, gebindeName, anteilTrinker).
+ * @param {Object} data Fields to write (basis, winter, sommer, nachmittag, anteilTrinker).
  * @param {string} [updatedBy] Optional user name / email for the audit field.
  */
 export const setDrinkWeightEntry = (categoryId, data, updatedBy) =>


### PR DESCRIPTION
## Summary
This PR removes `gebindeLiter` and `gebindeName` fields from the drink weights matrix, consolidating package size information to be sourced exclusively from individual drink definitions rather than category-level defaults.

## Key Changes

- **Removed gebinde metadata from DRINK_WEIGHTS**: Deleted `gebindeLiter` and `gebindeName` fields from all drink categories in `drinkRates.js` and `drinkWeightsDefaults.js`
- **Updated UI component**: Changed `DrinkWeightMatrixTable` to only display and edit `anteilTrinker` (consumer share) when applicable, removing the two gebinde input fields
- **Refactored parameter naming**: Renamed `hasGebinde` to `hasAnteilTrinker` throughout the component to better reflect its actual purpose
- **Updated event calculation**: Modified `calculateEventDrinks.js` to no longer pull gebinde information from the category matrix; package sizes now come exclusively from individual drink `einheiten` definitions
- **Fixed predefined drinks**: Added default unit to `predefined_mineralwasser` with `einheiten: [{einheitsgroesse: 1.0, gebindeinheit: 'Flasche', einheitenProGebinde: 1}]`
- **Simplified consumption tracking**: Updated `submitConsumption.js` to get gebinde sizes only from event calculation results, removing dependency on the rates database for this information
- **Updated tests**: Adjusted test expectations to reflect that category rows no longer provide gebinde data

## Implementation Details

- The change maintains backward compatibility for `anteilTrinker` (consumer share percentage) which remains in the matrix for categories where only a portion of guests consume that drink type
- Package size information is now a property of individual drinks (via their `einheiten` array) rather than a category-level default, allowing for more flexible drink definitions
- The consumption calculation fallback for predefined drinks without units now correctly returns `null` for gebinde fields since the category matrix no longer provides this data

https://claude.ai/code/session_01JuaYVKzdZWuweVZcrbpkWG