### PR TITLE
Remove anteilTrinker (drinker share) field from drink weights

### DIFF
--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -425,8 +425,6 @@ function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_D
       continue;
     }
 
-    const anteilTrinker = entry.anteilTrinker ?? 1.0;
-
     const adultsLiterGesamt = categoryAdultsLiters[cat] || 0;
     const childrenLiterGesamt = childrenTotalRawWeight > 0 ?
         childrenTotalBeverage * ((childrenCategoryRawWeights[cat] || 0) / childrenTotalRawWeight) :
@@ -445,7 +443,7 @@ function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_D
       gebindeGroesseLiter: null,
       anzahlGebinde: null,
       ratenQuelle: entry._nEvents ? 'erfahrungswert' : 'standard-faustwert',
-      anteilTrinkerAngenommen: anteilTrinker !== 1.0 ? anteilTrinker : null,
+      anteilTrinkerAngenommen: null,
       praeferenzFaktor: null,
     });
   }

--- a/functions/drinkRates.js
+++ b/functions/drinkRates.js
@@ -60,12 +60,8 @@ function timeFactor(startTime, hours) {
  * Top-Level-Kategorien) und ist die Referenz-Quelle fuer alle Eltern/Kind-
  * Beziehungen im Getraenke-Modell (siehe getWeightSubcategoryParents(),
  * getParentTotal() sowie DRINK_CATEGORY_PARENTS in calculateEventDrinks.js).
- *
- * `anteilTrinker` beschreibt den angenommenen Anteil der erwachsenen Gaeste,
- * der die Kategorie ueberhaupt konsumiert (fehlt das Feld, wird 1.0
- * angenommen). Gebindegroessen fuer Einkauf/Verbrauch kommen ausschliesslich
- * von den einzelnen Getraenken (deren `einheiten`), nicht mehr aus dieser
- * Matrix.
+ * Gebindegroessen fuer Einkauf/Verbrauch kommen ausschliesslich von den
+ * einzelnen Getraenken (deren `einheiten`), nicht mehr aus dieser Matrix.
  *
  * bier_alkoholfrei (85/15-Split von "bier") und longdrinks (40/60-Split von
  * "spirituosen") sind beides ungeprueft geschaetzte Aufteilungen ohne
@@ -79,7 +75,6 @@ const DRINK_WEIGHTS = {
     winter: -0.016,
     sommer: 0.010,
     nachmittag: -0.040,
-    anteilTrinker: 0.5,
   },
   bier_alkoholfrei: {
     parent: 'bier',
@@ -87,7 +82,6 @@ const DRINK_WEIGHTS = {
     winter: -0.002,
     sommer: 0.004,
     nachmittag: 0.005,
-    anteilTrinker: 0.5,
   },
   wein: {
     parent: null,
@@ -95,7 +89,6 @@ const DRINK_WEIGHTS = {
     winter: 0.042,
     sommer: -0.053,
     nachmittag: -0.020,
-    anteilTrinker: 0.3,
   },
   sekt: {
     parent: null,
@@ -103,7 +96,6 @@ const DRINK_WEIGHTS = {
     winter: 0.010,
     sommer: -0.008,
     nachmittag: -0.006,
-    anteilTrinker: 0.4,
   },
   softdrinks: {
     parent: null,
@@ -125,7 +117,6 @@ const DRINK_WEIGHTS = {
     winter: 0.007,
     sommer: -0.010,
     nachmittag: -0.010,
-    anteilTrinker: 0.25,
   },
   longdrinks: {
     parent: 'spirituosen',
@@ -133,7 +124,6 @@ const DRINK_WEIGHTS = {
     winter: -0.002,
     sommer: 0.002,
     nachmittag: -0.005,
-    anteilTrinker: 0.35,
   },
   kaffee: {
     parent: null,

--- a/src/components/DrinkWeightsTab.js
+++ b/src/components/DrinkWeightsTab.js
@@ -12,14 +12,11 @@ import { canManageDrinkWeights } from '../utils/userManagement';
 
 const NUMBER_FIELDS = ['basis', 'winter', 'sommer', 'nachmittag'];
 
-const createFormData = (row, hasAnteilTrinker) => ({
+const createFormData = (row) => ({
   basis: row.basis,
   winter: row.winter,
   sommer: row.sommer,
-  nachmittag: row.nachmittag,
-  ...(hasAnteilTrinker ? {
-    anteilTrinker: row.anteilTrinker ?? ''
-  } : {})
+  nachmittag: row.nachmittag
 });
 
 const formatGermanDate = (timestamp) => {
@@ -42,7 +39,7 @@ const buildRows = (defaults, overrides) =>
     ...(overrides[id] || {})
   }));
 
-function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, defaults, onSave, currentUser }) {
+function DrinkWeightMatrixTable({ title, description, rows, defaults, onSave, currentUser }) {
   const [editingId, setEditingId] = useState(null);
   const [formData, setFormData] = useState({});
   const [isSaving, setIsSaving] = useState(false);
@@ -52,7 +49,7 @@ function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, de
 
   const handleEdit = (row) => {
     setEditingId(row.id);
-    setFormData(createFormData(row, hasAnteilTrinker));
+    setFormData(createFormData(row));
     setErrorMessage('');
   };
 
@@ -80,14 +77,6 @@ function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, de
       }
     }
     if (Number(formData.basis) < 0) return 'Das Basis-Gewicht darf nicht negativ sein.';
-    if (hasAnteilTrinker) {
-      if (formData.anteilTrinker !== '' && formData.anteilTrinker !== undefined) {
-        const anteilTrinker = Number(formData.anteilTrinker);
-        if (!Number.isFinite(anteilTrinker) || anteilTrinker <= 0 || anteilTrinker > 1) {
-          return 'Der Anteil Trinker muss zwischen 0 (exklusiv) und 1 liegen.';
-        }
-      }
-    }
     return '';
   };
 
@@ -107,11 +96,6 @@ function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, de
       sommer: Number(formData.sommer),
       nachmittag: Number(formData.nachmittag)
     };
-    if (hasAnteilTrinker) {
-      payload.anteilTrinker = formData.anteilTrinker === '' || formData.anteilTrinker === undefined
-        ? undefined
-        : Number(formData.anteilTrinker);
-    }
 
     try {
       await onSave(editingId, payload, resolveUpdatedBy(currentUser));
@@ -144,7 +128,6 @@ function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, de
               <th>Winter Δ</th>
               <th>Sommer Δ</th>
               <th>Nachmittag Δ</th>
-              {hasAnteilTrinker && <th>Anteil Trinker</th>}
               <th>Letzte Änderung</th>
               <th>Aktionen</th>
             </tr>
@@ -207,23 +190,6 @@ function DrinkWeightMatrixTable({ title, description, rows, hasAnteilTrinker, de
                       />
                     ) : row.nachmittag}
                   </td>
-                  {hasAnteilTrinker && (
-                    <td>
-                      {isEditing ? (
-                        <input
-                          type="number"
-                          step="0.01"
-                          min="0"
-                          max="1"
-                          className="drink-weights-inline-input"
-                          aria-label={`Anteil Trinker für ${row.id}`}
-                          placeholder="1.0"
-                          value={formData.anteilTrinker}
-                          onChange={(event) => setFormData((prev) => ({ ...prev, anteilTrinker: event.target.value }))}
-                        />
-                      ) : (row.anteilTrinker ?? '—')}
-                    </td>
-                  )}
                   <td>{formatGermanDate(row.updatedAt)}</td>
                   <td>
                     <div className="drink-weights-actions">
@@ -302,7 +268,6 @@ function DrinkWeightsTab({ currentUser }) {
           title="Erwachsene"
           description="Basis-Gewichte und saisonale Anpassungen je Kategorie."
           rows={adultsRows}
-          hasAnteilTrinker
           defaults={DEFAULT_DRINK_WEIGHTS}
           onSave={setDrinkWeightEntry}
           currentUser={currentUser}
@@ -312,7 +277,6 @@ function DrinkWeightsTab({ currentUser }) {
           title="Kinder"
           description="Basis-Gewichte und saisonale Anpassungen für den Kinderanteil des Getränkebedarfs. Alkoholische Kategorien bleiben bei 0."
           rows={childrenRows}
-          hasAnteilTrinker={false}
           defaults={DEFAULT_CHILDREN_DRINK_WEIGHTS}
           onSave={setChildrenDrinkWeightEntry}
           currentUser={currentUser}

--- a/src/utils/drinkWeightsDefaults.js
+++ b/src/utils/drinkWeightsDefaults.js
@@ -10,22 +10,18 @@ export const DEFAULT_DRINK_WEIGHTS = {
   bier: {
     parent: null,
     basis: 0.221, winter: -0.016, sommer: 0.010, nachmittag: -0.040,
-    anteilTrinker: 0.5,
   },
   bier_alkoholfrei: {
     parent: 'bier',
     basis: 0.039, winter: -0.002, sommer: 0.004, nachmittag: 0.005,
-    anteilTrinker: 0.5,
   },
   wein: {
     parent: null,
     basis: 0.137, winter: 0.042, sommer: -0.053, nachmittag: -0.020,
-    anteilTrinker: 0.3,
   },
   sekt: {
     parent: null,
     basis: 0.015, winter: 0.010, sommer: -0.008, nachmittag: -0.006,
-    anteilTrinker: 0.4,
   },
   softdrinks: {
     parent: null,
@@ -38,12 +34,10 @@ export const DEFAULT_DRINK_WEIGHTS = {
   spirituosen: {
     parent: null,
     basis: 0.011, winter: 0.007, sommer: -0.010, nachmittag: -0.010,
-    anteilTrinker: 0.25,
   },
   longdrinks: {
     parent: 'spirituosen',
     basis: 0.017, winter: -0.002, sommer: 0.002, nachmittag: -0.005,
-    anteilTrinker: 0.35,
   },
   kaffee: {
     parent: null,

--- a/src/utils/drinkWeightsFirestore.js
+++ b/src/utils/drinkWeightsFirestore.js
@@ -75,7 +75,7 @@ export const getChildrenDrinkWeightsOnce = () => getCollectionOnce(CHILDREN_DRIN
 /**
  * Create or update one category entry of the adults drink weight matrix.
  * @param {string} categoryId Category id (document id).
- * @param {Object} data Fields to write (basis, winter, sommer, nachmittag, anteilTrinker).
+ * @param {Object} data Fields to write (basis, winter, sommer, nachmittag).
  * @param {string} [updatedBy] Optional user name / email for the audit field.
  */
 export const setDrinkWeightEntry = (categoryId, data, updatedBy) =>


### PR DESCRIPTION
## Summary
This PR removes the `anteilTrinker` (drinker share) field from the drink weights system across the codebase. This field was used to represent the assumed proportion of adult guests consuming each beverage category, but is no longer needed for the drink calculation logic.

## Key Changes
- **DrinkWeightsTab.js**: Removed `hasAnteilTrinker` prop and all related UI logic for editing/displaying the anteilTrinker field
  - Simplified `createFormData()` function to only handle basis, winter, sommer, and nachmittag fields
  - Removed validation logic for anteilTrinker values
  - Removed table column and input field for anteilTrinker
  - Removed anteilTrinker from payload sent to `onSave()`

- **drinkRates.js**: Removed `anteilTrinker` field from all DRINK_WEIGHTS entries and updated documentation
  - Removed anteilTrinker values from bier, bier_alkoholfrei, wein, sekt, spirituosen, and longdrinks
  - Updated JSDoc comments to remove references to anteilTrinker

- **drinkWeightsDefaults.js**: Removed `anteilTrinker` field from DEFAULT_DRINK_WEIGHTS entries

- **calculateEventDrinks.js**: Removed anteilTrinker calculation and usage
  - Removed the line that read `anteilTrinker` from entry with fallback to 1.0
  - Changed `anteilTrinkerAngenommen` output to always be `null` instead of conditionally setting it

- **drinkWeightsFirestore.js**: Updated JSDoc to reflect that anteilTrinker is no longer a valid field

## Implementation Details
The removal is comprehensive and consistent across all layers:
- UI layer: No longer accepts or displays the field
- Data layer: Field is removed from all default configurations
- Calculation layer: No longer reads or uses the field in drink calculations
- Documentation: Updated to reflect the removal

This simplifies the drink weights system by removing a feature that is no longer part of the calculation logic.

https://claude.ai/code/session_017c6Dj7T2zFPdsXiKZUDqKm