### PR TITLE
Kalibrierungs-Snapshots sammeln (Phase 1: reines Logging)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -207,6 +207,16 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Kalibrierungs-Snapshots: Ist-Bedarfsdaten pro abgeschlossenem Event, gesammelt
+    // fuer eine spaetere Kalibrierung von DRINK_WEIGHTS/BASE_RATE_PER_PERSON_PER_HOUR
+    // (Phase 1, reines Sammeln -- siehe Konzept "Sammlung von Ist-Bedarfsdaten").
+    // Nur ueber submitConsumption Cloud Function beschreibbar (Admin SDK bypasst
+    // diese Regeln); Lesezugriff ist Admins fuer die spaetere Auswertung vorbehalten.
+    match /kalibrierungsSnapshots/{eventId} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
     // Settings collection
     match /settings/{settingId} {
       // settings/app and settings/images are publicly readable so unauthenticated

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -623,8 +623,15 @@ function calculate(event, ratesDb, customDrinksMap, childrenRatesDb = CHILDREN_D
     dauerStunden: hours,
     saisonFaktor: seasonFactor,
     zeitFaktor: timeFac,
+    dauerFaktor: durFactor,
     eventTyp: event.eventType,
     pufferProzent,
+    // Gesamtbedarf vor Kategorie-Verteilung (ohne Puffer) -- fuer spaetere
+    // Kalibrierungs-Snapshots (siehe submitConsumption.js) explizit
+    // mitgespeichert, damit er nicht aus ggf. spaeter geaenderten Konstanten
+    // (BASE_RATE_PER_PERSON_PER_HOUR etc.) neu abgeleitet werden muss.
+    gesamtbedarfErwachseneLiter: round2(totalBeverage),
+    gesamtbedarfKinderLiter: round2(childrenTotalBeverage),
     ergebnis,
     warnungen,
   };

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -45,6 +45,51 @@ function alleGetraenkeVerbrauchGesperrt(event, verbrauchGesperrt) {
 }
 
 /**
+ * Baut den Ist-Bedarfs-Snapshot fuer die spaetere Kalibrierung von
+ * DRINK_WEIGHTS/BASE_RATE_PER_PERSON_PER_HOUR (Phase 1: reines Sammeln, siehe
+ * Konzept "Sammlung von Ist-Bedarfsdaten fuer spaetere Kalibrierung"). Rahmendaten
+ * und Soll-Werte werden explizit aus dem zum Berechnungszeitpunkt gespeicherten
+ * event.berechnung uebernommen (nicht aus den *aktuellen* Konstanten neu
+ * abgeleitet), damit der Snapshot auch nach spaeteren Aenderungen an den
+ * Kalkulationskonstanten unabhaengig auswertbar bleibt.
+ * @param {object} event Event-Dokument (inkl. berechnung).
+ * @param {object} literGemessen Ist-Verbrauch pro Getraenke-Zeile in Litern (siehe gebindeZuLiter).
+ * @return {object|null} Snapshot-Dokument, oder null, wenn keine Berechnung vorliegt.
+ */
+function buildKalibrierungsSnapshot(event, literGemessen) {
+  const berechnung = event.berechnung;
+  if (!berechnung) return null;
+
+  const kategorien = (berechnung.ergebnis || [])
+      .filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter)
+      .map((row) => ({
+        rowKategorie: row.kategorie,
+        drinkKategorie: row.drinkKategorie || null,
+        sollLiter: row.literOhnePuffer ?? null,
+        istLiter: literGemessen[row.kategorie] ?? null,
+      }));
+
+  const guestPreferencesActive = Array.isArray(event.guestPreferenceMultipliers?.perGuest) &&
+      event.guestPreferenceMultipliers.perGuest.length > 0;
+
+  return {
+    adults: event.guests?.adults ?? null,
+    children: event.guests?.children ?? null,
+    season: event.season ?? null,
+    startTime: event.startTime ?? null,
+    hours: event.durationHours ?? null,
+    eventType: event.eventType ?? null,
+    seasonFactor: berechnung.saisonFaktor ?? null,
+    timeFactor: berechnung.zeitFaktor ?? null,
+    durationFactor: berechnung.dauerFaktor ?? null,
+    guestPreferencesActive,
+    totalBeverageCalculated: berechnung.gesamtbedarfErwachseneLiter ?? null,
+    childrenTotalBeverageCalculated: berechnung.gesamtbedarfKinderLiter ?? null,
+    kategorien,
+  };
+}
+
+/**
  * Callable: submitConsumption({ eventId, gebinde })
  * - eventId: ID des Event-Dokuments (muss existieren und berechnet sein)
  * - gebinde: { kategorie: { eingekauft: <Anzahl>, uebrig: <Anzahl> } }
@@ -90,6 +135,19 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   });
   if (alleGetraenkeVerbrauchGesperrt(event, verbrauchGesperrt)) {
     eventUpdate.status = 'verbrauchErfasst';
+
+    // Phase 1 der Kalibrierung (siehe Konzept): reines Sammeln von
+    // Ist-Bedarfsdaten, keine Rueckwirkung auf DRINK_WEIGHTS/BASE_RATE_PER_PERSON_PER_HOUR.
+    const snapshot = buildKalibrierungsSnapshot({...event, ...eventUpdate}, literGemessen);
+    if (snapshot) {
+      const snapshotRef = db.collection('kalibrierungsSnapshots').doc(eventId);
+      batch.set(snapshotRef, {
+        ...snapshot,
+        eventId,
+        uid,
+        erstelltAm: admin.firestore.FieldValue.serverTimestamp(),
+      });
+    }
   }
   batch.set(eventRef, eventUpdate, {merge: true});
 
@@ -98,4 +156,4 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
   return {eventId};
 });
 
-exports._internal = {gebindeZuLiter, alleGetraenkeVerbrauchGesperrt};
+exports._internal = {gebindeZuLiter, alleGetraenkeVerbrauchGesperrt, buildKalibrierungsSnapshot};

--- a/functions/submitConsumption.test.js
+++ b/functions/submitConsumption.test.js
@@ -49,3 +49,64 @@ test('gebindeZuLiter behandelt fehlenden/negativen Verbrauch als 0', () => {
   const result = _internal.gebindeZuLiter(gebinde, event);
   assert.equal(result.bier, 0);
 });
+
+test('buildKalibrierungsSnapshot liefert null ohne event.berechnung', () => {
+  const result = _internal.buildKalibrierungsSnapshot({}, {});
+  assert.equal(result, null);
+});
+
+test('buildKalibrierungsSnapshot uebernimmt Rahmendaten und Soll-Werte explizit aus event.berechnung', () => {
+  const event = {
+    guests: {adults: 20, children: 3},
+    season: 'sommer',
+    startTime: '16:00',
+    durationHours: 5,
+    eventType: 'grillfest',
+    berechnung: {
+      saisonFaktor: 1.3,
+      zeitFaktor: 0.92,
+      dauerFaktor: 1.0,
+      gesamtbedarfErwachseneLiter: 65,
+      gesamtbedarfKinderLiter: 5.25,
+      ergebnis: [
+        {
+          kategorie: 'bierDrink1', drinkKategorie: 'bier', isCustomDrink: true,
+          gebindeGroesseLiter: 0.5, literOhnePuffer: 20,
+        },
+        // Kategorie-Zeile ohne Gebinde (keine erfasste Ist-Menge) -- darf nicht auftauchen.
+        {kategorie: 'wein', literOhnePuffer: 10},
+      ],
+    },
+  };
+  const literGemessen = {bierDrink1: 18};
+
+  const result = _internal.buildKalibrierungsSnapshot(event, literGemessen);
+
+  assert.deepEqual(result, {
+    adults: 20,
+    children: 3,
+    season: 'sommer',
+    startTime: '16:00',
+    hours: 5,
+    eventType: 'grillfest',
+    seasonFactor: 1.3,
+    timeFactor: 0.92,
+    durationFactor: 1.0,
+    guestPreferencesActive: false,
+    totalBeverageCalculated: 65,
+    childrenTotalBeverageCalculated: 5.25,
+    kategorien: [
+      {rowKategorie: 'bierDrink1', drinkKategorie: 'bier', sollLiter: 20, istLiter: 18},
+    ],
+  });
+});
+
+test('buildKalibrierungsSnapshot setzt guestPreferencesActive, wenn Praeferenz-Multiplikatoren aktiv waren', () => {
+  const event = {
+    guests: {adults: 4, children: 0},
+    guestPreferenceMultipliers: {perGuest: [{preferredCategoryIds: ['bier'], preferenceFactor: 0.6}]},
+    berechnung: {ergebnis: []},
+  };
+  const result = _internal.buildKalibrierungsSnapshot(event, {});
+  assert.equal(result.guestPreferencesActive, true);
+});


### PR DESCRIPTION
Speichert bei Abschluss eines Events (submitConsumption, sobald der letzte
Ist-Verbrauchswert erfasst ist) einen Snapshot aus Rahmendaten, Soll-Werten
und Ist-Verbrauch in kalibrierungsSnapshots/{eventId}. Rahmen- und Soll-Werte
werden explizit aus dem zum Berechnungszeitpunkt gespeicherten
event.berechnung uebernommen, nicht aus den aktuellen Konstanten neu
abgeleitet, damit spaetere Aenderungen an DRINK_WEIGHTS/
BASE_RATE_PER_PERSON_PER_HOUR die Snapshots nicht verfaelschen.

calculateEventDrinks.js liefert dafuer zusaetzlich dauerFaktor sowie den
Gesamtbedarf vor Kategorie-Verteilung (Erwachsene/Kinder) im
Berechnungsergebnis mit.

Keine Rueckwirkung auf die Kalkulationskonstanten und keine automatische
Auswertung -- das ist Phase 2, mit Admin-Review vor jeder Uebernahme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SGG7CKQyb2mciDoJHvhH9G