### PR TITLE
Drivers cover their full budget with non-alcoholic drinks

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -130,8 +130,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   );
 
   const guestPreferenceMultipliers = useMemo(
-    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks)),
-    [selectedGuests, customDrinks],
+    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks), driverGuestIds),
+    [selectedGuests, customDrinks, driverGuestIds],
   );
 
   useEffect(() => {

--- a/src/components/EventForm.test.js
+++ b/src/components/EventForm.test.js
@@ -50,7 +50,7 @@ describe('EventForm', () => {
           id: 'g1',
           vorname: 'Anna',
           nachname: 'Beispiel',
-          alkoholischeGetränke: false,
+          alkoholischeGetränke: true,
           bevorzugteGetränke: ['custom-wasser'],
           präferenzFaktor: 1,
         },

--- a/src/utils/guestPreferences.js
+++ b/src/utils/guestPreferences.js
@@ -60,10 +60,13 @@ const isDrinkAlcoholic = (drinkId, drinkKategorie) => {
  *
  * @param {Array} selectedGuests - Array of guest objects with preference properties.
  * @param {Array} drinks - Array of drink objects or IDs (used to resolve preferred drink categories).
+ * @param {Array} driverGuestIds - IDs of guests marked as drivers for this event; drivers always
+ *   cover their full budget with non-alcoholic drinks, regardless of their alcohol preference.
  * @returns {{ perGuest: Array }} Per-guest preference profiles for adult guests.
  */
-export const computeGuestPreferenceMultipliers = (selectedGuests, drinks) => {
+export const computeGuestPreferenceMultipliers = (selectedGuests, drinks, driverGuestIds) => {
   const allDrinks = Array.isArray(drinks) ? drinks : [];
+  const driverIds = Array.isArray(driverGuestIds) ? driverGuestIds : [];
   if (!Array.isArray(selectedGuests) || selectedGuests.length === 0) {
     return { perGuest: [] };
   }
@@ -84,7 +87,8 @@ export const computeGuestPreferenceMultipliers = (selectedGuests, drinks) => {
       ? [...new Set(guest.bevorzugteKategorien.filter((id) => typeof id === 'string' && id.trim()))]
       : [];
     const preferenceFactor = normalizePreferenceFactor(guest?.präferenzFaktor);
-    const allowsAlcohol = guest?.alkoholischeGetränke !== false;
+    const isDriver = guest?.id !== undefined && driverIds.includes(guest.id);
+    const allowsAlcohol = guest?.alkoholischeGetränke !== false && !isDriver;
 
     // Resolve categories for specifically preferred drink IDs
     const preferredCategoryIdsFromDrinks = preferredDrinkIds.flatMap((drinkId) => {

--- a/src/utils/guestPreferences.test.js
+++ b/src/utils/guestPreferences.test.js
@@ -110,6 +110,33 @@ describe('guestPreferences', () => {
     expect(result.perGuest[0].preferredCategoryIds).toContain('wein_rotwein');
   });
 
+  test('drivers are forced to allowsAlcohol=false even if their preference allows alcohol', () => {
+    const result = computeGuestPreferenceMultipliers(
+      [
+        {
+          id: 'g1',
+          alkoholischeGetränke: true,
+          bevorzugteGetränke: [],
+          präferenzFaktor: 0,
+        },
+        {
+          id: 'g2',
+          alkoholischeGetränke: true,
+          bevorzugteGetränke: [],
+          präferenzFaktor: 0,
+        },
+      ],
+      [
+        { id: 'bier-1', kategorie: 'bier' },
+      ],
+      ['g1'],
+    );
+
+    expect(result.perGuest).toHaveLength(2);
+    expect(result.perGuest[0].allowsAlcohol).toBe(false);
+    expect(result.perGuest[1].allowsAlcohol).toBe(true);
+  });
+
   test('children are excluded from perGuest array', () => {
     const result = computeGuestPreferenceMultipliers(
       [


### PR DESCRIPTION
Pass driverGuestIds into computeGuestPreferenceMultipliers so guests
marked as a driver always get allowsAlcohol=false, overriding their
personal alcohol preference, and their entire drink budget is
distributed across non-alcoholic categories.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L2v1fKQGtYcvgBVn3UsueY