### PR TITLE
Move event status badge below title into the meta row

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -74,9 +74,7 @@
 }
 
 .events-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: block;
   background: white;
   border: 1px solid #ececec;
   border-radius: 10px;
@@ -95,6 +93,13 @@
   margin: 0 0 4px;
   color: #2F5D50;
   font-size: 18px;
+}
+
+.events-card-meta-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
 }
 
 .events-card-meta {

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -415,13 +415,15 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
               <div key={event.id} className="events-card" onClick={() => handleSelectEvent(event)}>
                 <div className="events-card-main">
                   <h3>{event.eventName}</h3>
-                  <p className="events-card-meta">
-                    {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
-                  </p>
+                  <div className="events-card-meta-row">
+                    <p className="events-card-meta">
+                      {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
+                    </p>
+                    <span className={`events-status-badge events-status-${event.status}`}>
+                      {STATUS_LABELS[event.status] || event.status}
+                    </span>
+                  </div>
                 </div>
-                <span className={`events-status-badge events-status-${event.status}`}>
-                  {STATUS_LABELS[event.status] || event.status}
-                </span>
               </div>
             );
           })}


### PR DESCRIPTION
The status badge sat beside the event title, cramping its width. It now
sits on the same line as the date/type metadata instead, letting the
title span the full card width.