### PR TITLE
Getränke-Übergabe an Bring! vereinheitlichen

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -345,14 +345,21 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   }
 
   // Getraenke ohne Rezeptlink: in Gebindeeinheit (falls vorhanden, sonst Einheit) uebernehmen.
+  // Bring! trennt einen uebergebenen Zutaten-Text am ersten Komma: alles davor wird
+  // zum Kachel-Titel, alles danach zum Feld Menge/Beschreibung. Damit der Getraenke-Name
+  // immer vollstaendig im Titel landet und Menge+Einheit immer im Beschreibungsfeld,
+  // wird hier explizit "Name, Menge Einheit" gebaut. Ein Komma im Namen selbst (z.B.
+  // Alkoholgehalt "0,0%") wuerde diesen Split verfaelschen und wird deshalb ersetzt.
   const getOtherDrinkItems = () => {
     const items = [];
     nonRecipeGroups.forEach((group) => {
+      const safeDrinkName = group.drinkName.replace(/,/g, '.');
       group.rows.forEach((row) => {
         const quantityText = (values[row.kategorie]?.eingekauft || '').trim();
         if (!quantityText || !parseFractionQuantity(quantityText)) return;
         const unit = getRowPurchaseUnit(row);
-        items.push(unit ? `${quantityText} ${unit} ${group.drinkName}` : `${quantityText} ${group.drinkName}`);
+        const quantity = unit ? `${quantityText} ${unit}` : quantityText;
+        items.push(`${safeDrinkName}, ${quantity}`);
       });
     });
     return items;

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -160,7 +160,7 @@ describe('ConsumptionForm', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Einkaufsliste erstellen/ }));
 
-    expect(await screen.findByText('1 3/4 Kasten Cola')).toBeInTheDocument();
+    expect(await screen.findByText('Cola, 1 3/4 Kasten')).toBeInTheDocument();
   });
 
   it('übernimmt bei Getränken mit Rezeptlink nur die auf der Getränk-bearbeiten-Karte aktivierten Zutaten', async () => {


### PR DESCRIPTION
Bring! trennt einen übergebenen Zutaten-Text am ersten Komma: alles davor
wird zur Kachel-Titel, alles danach zum Feld Menge/Beschreibung. Bisher
wurde "Menge Einheit Name" ohne Komma übergeben, wodurch Menge/Einheit im
Titel landeten; enthielt der Getränkename selbst ein Komma (z.B. "Bitburger
0,0%"), riss Bring den Namen dort auseinander und schob einen Teil davon
("0%") ins Beschreibungsfeld. Jetzt wird explizit "Name, Menge Einheit"
gebaut und Kommas im Namen selbst werden ersetzt, damit der Split
zuverlässig funktioniert.