### PR TITLE
Send plural unit to Bring except when quantity is exactly 1

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -48,6 +48,25 @@ function getRowPurchaseUnit(row) {
   return row.gebinde || '';
 }
 
+// Loest die Pluralform einer (als Singular gespeicherten) Gebinde-/Getraenkeeinheit auf,
+// indem die Einheit anhand ihres Singulars in den Gebinde-/Getraenkeeinheiten-Listen
+// gesucht wird. Ohne Treffer (z.B. Freitext-Einheit) wird die Einheit unveraendert
+// zurueckgegeben.
+function getPluralUnit(unitSingular, packageUnits, drinkUnits) {
+  if (!unitSingular) return unitSingular;
+  const match = [...packageUnits, ...drinkUnits].find((u) => u.singular === unitSingular);
+  return match ? match.plural : unitSingular;
+}
+
+// Waehlt Singular oder Plural einer Einheit passend zur Menge: nur bei Menge = 1
+// wird der Singular verwendet, bei allen anderen Mengen (0,5, 1/4, 1 1/4, 2, ...) der Plural.
+function getUnitForQuantity(unitSingular, quantity, packageUnits, drinkUnits) {
+  if (!unitSingular) return unitSingular;
+  const EPSILON = 1e-9;
+  if (Number.isFinite(quantity) && Math.abs(quantity - 1) < EPSILON) return unitSingular;
+  return getPluralUnit(unitSingular, packageUnits, drinkUnits);
+}
+
 // Einzel-Einheit (z.B. Flasche) fuer den Verbrauch -- im Unterschied zur
 // Gebindeeinheit (z.B. Kasten) beim Einkauf.
 function getRowConsumptionUnit(row) {
@@ -289,6 +308,8 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [conversionTable, setConversionTable] = useState([]);
+  const [packageUnits, setPackageUnits] = useState([]);
+  const [drinkUnits, setDrinkUnits] = useState([]);
   const [bringButtonIcon, setBringButtonIcon] = useState('Bring');
   const [shoppingListIcon, setShoppingListIcon] = useState('Einkauf');
   const [buttonIcons, setButtonIcons] = useState(DEFAULT_BUTTON_ICONS);
@@ -313,6 +334,8 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     const loadShoppingListSettings = async () => {
       const [icons, lists] = await Promise.all([getButtonIcons(), getCustomLists()]);
       setConversionTable(lists.conversionTable || []);
+      setPackageUnits(lists.packageUnits || []);
+      setDrinkUnits(lists.drinkUnits || []);
       setBringButtonIcon(getEffectiveIcon(icons, 'bringButton', getDarkModePreference()) || 'Bring');
       setShoppingListIcon(getEffectiveIcon(icons, 'shoppingList', getDarkModePreference()) || 'Einkauf');
       setButtonIcons(icons);
@@ -356,8 +379,10 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
       const safeDrinkName = group.drinkName.replace(/,/g, '.');
       group.rows.forEach((row) => {
         const quantityText = (values[row.kategorie]?.eingekauft || '').trim();
-        if (!quantityText || !parseFractionQuantity(quantityText)) return;
-        const unit = getRowPurchaseUnit(row);
+        const parsedQuantity = parseFractionQuantity(quantityText);
+        if (!quantityText || !parsedQuantity) return;
+        const unitSingular = getRowPurchaseUnit(row);
+        const unit = getUnitForQuantity(unitSingular, parsedQuantity, packageUnits, drinkUnits);
         const quantity = unit ? `${quantityText} ${unit}` : quantityText;
         items.push(`${safeDrinkName}, ${quantity}`);
       });

--- a/src/components/ConsumptionForm.test.js
+++ b/src/components/ConsumptionForm.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import ConsumptionForm from './ConsumptionForm';
 import { encodeRecipeLink } from '../utils/recipeLinks';
 
@@ -9,6 +9,7 @@ const mockUnlockEinkaufMengen = jest.fn(() => Promise.resolve());
 const mockLockVerbrauchMengen = jest.fn(() => Promise.resolve());
 const mockUnlockVerbrauchMengen = jest.fn(() => Promise.resolve());
 const mockSetEventStatus = jest.fn(() => Promise.resolve());
+const mockGetCustomLists = jest.fn();
 
 jest.mock('../utils/eventsFirestore', () => ({
   submitConsumption: (...args) => mockSubmitConsumption(...args),
@@ -18,6 +19,14 @@ jest.mock('../utils/eventsFirestore', () => ({
   unlockVerbrauchMengen: (...args) => mockUnlockVerbrauchMengen(...args),
   setEventStatus: (...args) => mockSetEventStatus(...args),
 }));
+
+jest.mock('../utils/customLists', () => {
+  const actual = jest.requireActual('../utils/customLists');
+  return {
+    ...actual,
+    getCustomLists: (...args) => mockGetCustomLists(...args),
+  };
+});
 
 jest.mock('./EventForm', () => ({
   CATEGORY_LABELS: { wasser: 'Wasser' },
@@ -43,6 +52,7 @@ describe('ConsumptionForm', () => {
     // (siehe handleToggleVerbrauchLock) -- Standard-Resolve, damit Tests, die das nur
     // beilaeufig ausloesen, nicht an einem unbehandelten Promise-Fehler scheitern.
     mockSubmitConsumption.mockResolvedValue({ eventId: 'event1' });
+    mockGetCustomLists.mockResolvedValue({ conversionTable: [], packageUnits: [], drinkUnits: [] });
   });
 
   it('befüllt Fass und Flasche kaskadierend aus dem kalkulierten Bedarf (Fass=1, Flasche=1,75)', () => {
@@ -161,6 +171,76 @@ describe('ConsumptionForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /Einkaufsliste erstellen/ }));
 
     expect(await screen.findByText('Cola, 1 3/4 Kasten')).toBeInTheDocument();
+  });
+
+  it('übergibt an Bring nur bei Menge = 1 den Singular der Gebindeeinheit, sonst den Plural', async () => {
+    mockGetCustomLists.mockResolvedValue({
+      conversionTable: [],
+      packageUnits: [{ id: 'kasten', singular: 'Kasten', plural: 'Kästen' }],
+      drinkUnits: [],
+    });
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+    await waitFor(() => expect(mockGetCustomLists).toHaveBeenCalled());
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+    const eingekauftInput = screen.getByLabelText('Eingekauft');
+    fireEvent.change(eingekauftInput, { target: { value: '1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Einkaufsliste erstellen' }));
+
+    expect(await screen.findByText('Cola, 1 Kasten')).toBeInTheDocument();
+  });
+
+  it('übergibt an Bring bei Menge 2 den Plural der Gebindeeinheit', async () => {
+    mockGetCustomLists.mockResolvedValue({
+      conversionTable: [],
+      packageUnits: [{ id: 'kasten', singular: 'Kasten', plural: 'Kästen' }],
+      drinkUnits: [],
+    });
+    const einheiten = [
+      { einheitsgroesse: 0.33, einheit: 'Flasche', gebindeinheit: 'Kasten', einheitenProGebinde: 24 },
+    ];
+    const ergebnis = [
+      {
+        kategorie: 'drink2:0',
+        drinkId: 'drink2',
+        drinkLabel: 'Cola',
+        isCustomDrink: true,
+        einheitIdx: 0,
+        literMitPuffer: 12.7,
+        gebinde: 'Kasten',
+        gebindeGroesseLiter: 0.33,
+        einheiten,
+      },
+    ];
+
+    render(<ConsumptionForm event={makeEvent(ergebnis)} recipes={[]} onDone={jest.fn()} onCancel={jest.fn()} />);
+    await waitFor(() => expect(mockGetCustomLists).toHaveBeenCalled());
+    await act(async () => {});
+
+    fireEvent.click(screen.getByRole('button', { name: 'Einkauf bearbeiten' }));
+    const eingekauftInput = screen.getByLabelText('Eingekauft');
+    fireEvent.change(eingekauftInput, { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Einkaufsliste erstellen' }));
+
+    expect(await screen.findByText('Cola, 2 Kästen')).toBeInTheDocument();
   });
 
   it('übernimmt bei Getränken mit Rezeptlink nur die auf der Getränk-bearbeiten-Karte aktivierten Zutaten', async () => {


### PR DESCRIPTION
Gebinde-/Getraenkeeinheiten fuer Getraenke ohne Rezeptlink wurden beim
Bring!-Export immer im Singular uebergeben, unabhaengig von der Menge
(z.B. "2 Kasten" statt "2 Kaesten"). Die Einheit wird jetzt anhand der
eingegebenen Menge aufgeloest: Singular nur bei Menge = 1, sonst Plural
(0,5, 1/4, 1 1/4, 2, ...), passend zu den in den Einstellungen
hinterlegten Singular-/Pluralformen der Gebinde- und Getraenkeeinheiten.