### PR TITLE
Fix light background on shopping list rows in dark mode

### DIFF
--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -1348,12 +1348,62 @@
 }
 
 [data-theme="dark"] .shopping-list-item {
+  background: #2a2a2a;
   color: #e8e8e8;
+  border-color: #3d3d3d;
   border-bottom-color: #3d3d3d;
 }
 
+[data-theme="dark"] .shopping-list-item:hover {
+  background: #333;
+}
+
 [data-theme="dark"] .shopping-list-item.checked {
+  background: #1e1e1e;
+  border-color: #3d3d3d;
   color: #777;
+}
+
+[data-theme="dark"] .shopping-list-item-text {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .shopping-list-item.checked .shopping-list-item-text {
+  color: #777;
+}
+
+[data-theme="dark"] .shopping-list-edit-input {
+  background: #1e1e1e;
+  color: #e8e8e8;
+  border-color: #b07a40;
+}
+
+[data-theme="dark"] .shopping-list-subtitle {
+  color: #aaa;
+  border-bottom-color: #3d3d3d;
+}
+
+[data-theme="dark"] .shopping-list-count {
+  color: #aaa;
+}
+
+[data-theme="dark"] .shopping-list-footer {
+  border-top-color: #3d3d3d;
+}
+
+[data-theme="dark"] .shopping-list-reset-btn {
+  background: #2a2a2a;
+  color: #ccc;
+  border-color: #555;
+}
+
+[data-theme="dark"] .shopping-list-reset-btn:hover {
+  border-color: #b07a40;
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .shopping-list-empty {
+  color: #aaa;
 }
 
 /* ---- Nutrition modal ---- */


### PR DESCRIPTION
.shopping-list-item only had its text color overridden for dark
mode, not its background, hover, or checked-state background, so
rows (and the reset button, edit input, etc.) still rendered with a
light background inside the Einkaufsliste dialog.