### PR TITLE
Move lock button next to Eingekauft/Übrig field label

### DIFF
--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -622,68 +622,81 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
 
               {activeSection === 'einkauf' && (
                 <div className="events-consumption-detail">
-                  {group.rows.map((row) => (
-                    <div className="events-form-row" key={row.kategorie}>
-                      {getRowUnitSubtitle(row) && (
-                        <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
-                      )}
-                      <label className="events-form-field">
-                        <span>Eingekauft</span>
-                        <input
-                          type="text"
-                          inputMode="text"
-                          placeholder="z.B. 1 3/4"
-                          title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
-                          value={values[row.kategorie].eingekauft}
-                          onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
-                          disabled={einkaufGroupLocked}
-                        />
-                      </label>
-                    </div>
-                  ))}
-                  <div className="events-consumption-detail-footer">
-                    <LockToggleButton
-                      locked={einkaufGroupLocked}
-                      onToggle={() => handleToggleEinkaufLock(group)}
-                      lockedLabel="Eingekaufte Menge entsperren"
-                      unlockedLabel="Eingekaufte Menge sperren"
-                      lockedTitle="Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)"
-                      unlockedTitle="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
-                    />
-                  </div>
+                  {group.rows.map((row, idx) => {
+                    const inputId = `${row.kategorie}-eingekauft`;
+                    return (
+                      <div className="events-form-row" key={row.kategorie}>
+                        {getRowUnitSubtitle(row) && (
+                          <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row)}</span>
+                        )}
+                        <div className="events-form-field">
+                          <span className="events-form-field-label-row">
+                            <label htmlFor={inputId}>Eingekauft</label>
+                            {idx === 0 && (
+                              <LockToggleButton
+                                locked={einkaufGroupLocked}
+                                onToggle={() => handleToggleEinkaufLock(group)}
+                                lockedLabel="Eingekaufte Menge entsperren"
+                                unlockedLabel="Eingekaufte Menge sperren"
+                                lockedTitle="Eingekaufte Menge entsperren (wird beim Öffnen wieder neu berechnet)"
+                                unlockedTitle="Eingekaufte Menge sperren (keine automatische Neuberechnung mehr)"
+                              />
+                            )}
+                          </span>
+                          <input
+                            id={inputId}
+                            type="text"
+                            inputMode="text"
+                            placeholder="z.B. 1 3/4"
+                            title="Menge als Bruch (z.B. 1/2 oder 1 3/4) oder Zahl"
+                            value={values[row.kategorie].eingekauft}
+                            onChange={(e) => updateValue(row.kategorie, 'eingekauft', e.target.value)}
+                            disabled={einkaufGroupLocked}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
 
               {activeSection === 'verbrauch' && (
                 <div className="events-consumption-detail">
-                  {group.rows.map((row) => (
-                    <div className="events-form-row" key={row.kategorie}>
-                      {getRowUnitSubtitle(row, getRowConsumptionUnit(row)) && (
-                        <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row, getRowConsumptionUnit(row))}</span>
-                      )}
-                      <label className="events-form-field">
-                        <span>{getRowConsumptionUnit(row) ? `Übrig (${getRowConsumptionUnit(row)})` : 'Übrig'}</span>
-                        <input
-                          type="number"
-                          min="0"
-                          value={values[row.kategorie].uebrig}
-                          onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
-                          disabled={verbrauchGroupLocked}
-                        />
-                      </label>
-                    </div>
-                  ))}
-                  <div className="events-consumption-detail-footer">
-                    <LockToggleButton
-                      locked={verbrauchGroupLocked}
-                      onToggle={() => handleToggleVerbrauchLock(group)}
-                      lockedLabel="Verbrauchte Menge entsperren"
-                      unlockedLabel="Verbrauchte Menge sperren"
-                      lockedTitle="Verbrauchte Menge entsperren (kann wieder bearbeitet werden)"
-                      unlockedTitle="Verbrauchte Menge sperren (keine automatische Änderung mehr)"
-                      disabled={saving}
-                    />
-                  </div>
+                  {group.rows.map((row, idx) => {
+                    const inputId = `${row.kategorie}-uebrig`;
+                    const label = getRowConsumptionUnit(row) ? `Übrig (${getRowConsumptionUnit(row)})` : 'Übrig';
+                    return (
+                      <div className="events-form-row" key={row.kategorie}>
+                        {getRowUnitSubtitle(row, getRowConsumptionUnit(row)) && (
+                          <span className="events-consumption-unit-subtitle">{getRowUnitSubtitle(row, getRowConsumptionUnit(row))}</span>
+                        )}
+                        <div className="events-form-field">
+                          <span className="events-form-field-label-row">
+                            <label htmlFor={inputId}>{label}</label>
+                            {idx === 0 && (
+                              <LockToggleButton
+                                locked={verbrauchGroupLocked}
+                                onToggle={() => handleToggleVerbrauchLock(group)}
+                                lockedLabel="Verbrauchte Menge entsperren"
+                                unlockedLabel="Verbrauchte Menge sperren"
+                                lockedTitle="Verbrauchte Menge entsperren (kann wieder bearbeitet werden)"
+                                unlockedTitle="Verbrauchte Menge sperren (keine automatische Änderung mehr)"
+                                disabled={saving}
+                              />
+                            )}
+                          </span>
+                          <input
+                            id={inputId}
+                            type="number"
+                            min="0"
+                            value={values[row.kategorie].uebrig}
+                            onChange={(e) => updateValue(row.kategorie, 'uebrig', e.target.value)}
+                            disabled={verbrauchGroupLocked}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -454,9 +454,11 @@
   background: #fafaf8;
 }
 
-.events-consumption-detail-footer {
+.events-form-field-label-row {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 .events-consumption-unit-subtitle {


### PR DESCRIPTION
Positions the Sperren-Button inline with the field label,
right-aligned, instead of below the input on the Einkauf &
Verbrauch page.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PaWZZAdR27CdSC5JH3bBuU