### PR TITLE
Event-Verknüpfung von Menüdetailansicht auf Menü bearbeiten verschieben

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -301,30 +301,6 @@
   max-width: 100%;
 }
 
-.menu-drinks-link-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin-top: 1rem;
-}
-
-.menu-drinks-link-btn {
-  background: #402C1C;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  padding: 0.6rem 1.2rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.menu-drinks-link-btn:hover {
-  background: #2c1f13;
-}
-
 .drink-card-amount {
   margin: 0.75rem 0 0 0;
   color: #666;

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -1,33 +1,21 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useLongPress } from '../utils/useLongPress';
 import './MenuDetail.css';
-import './EventsPage.css';
 import { getUserFavorites } from '../utils/userFavorites';
 import { getUserMenuFavorites } from '../utils/menuFavorites';
 import { groupRecipesBySections } from '../utils/menuSections';
 import { canEditMenu, canDeleteMenu } from '../utils/userManagement';
 import { isBase64Image } from '../utils/imageUtils';
-import { enableMenuSharing, disableMenuSharing, updateMenu } from '../utils/menuFirestore';
+import { enableMenuSharing, disableMenuSharing } from '../utils/menuFirestore';
 import { scaleIngredient, combineIngredients, convertIngredientUnits, isWaterIngredient } from '../utils/ingredientUtils';
 import { decodeRecipeLink } from '../utils/recipeLinks';
 import { getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
-import { getEvent, subscribeToEvents, getCustomDrinks } from '../utils/eventsFirestore';
+import { getEvent, getCustomDrinks } from '../utils/eventsFirestore';
 import { mergePredefinedDrinks } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { getImageForCategory } from '../utils/categoryImages';
 import ShoppingListModal from './ShoppingListModal';
 import RecipeCard from './RecipeCard';
-import EventForm from './EventForm';
-import DrinkManagementPage from './DrinkManagementPage';
-
-const formatEventDate = (dateStr) => {
-  if (!dateStr) return '';
-  try {
-    return new Date(dateStr).toLocaleDateString('de-DE');
-  } catch {
-    return dateStr;
-  }
-};
 
 const formatEventLiter = (value) => {
   const num = Number(value);
@@ -77,12 +65,10 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
   const [linkedPortionCounts, setLinkedPortionCounts] = useState({});
   const [conversionTable, setConversionTable] = useState([]);
   const missingSavedRef = useRef(false);
-  const [drinksSubView, setDrinksSubView] = useState('main'); // main | linkPicker | newEvent | manageDrinks
   const [linkedEvent, setLinkedEvent] = useState(null);
   const [linkedEventLoading, setLinkedEventLoading] = useState(false);
   const [linkedEventCustomDrinks, setLinkedEventCustomDrinks] = useState([]);
   const [expandedDrinkId, setExpandedDrinkId] = useState(null);
-  const [availableEvents, setAvailableEvents] = useState([]);
   const [drinksCategoryImage, setDrinksCategoryImage] = useState(null);
   const {
     activeId: portionMinusLongPressActiveId,
@@ -184,13 +170,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     };
   }, []);
 
-  // Load the current user's events while the "Event verknüpfen" picker is open.
-  useEffect(() => {
-    if (drinksSubView !== 'linkPicker' || !currentUser?.id) return undefined;
-    const unsubscribe = subscribeToEvents(currentUser.id, setAvailableEvents);
-    return unsubscribe;
-  }, [drinksSubView, currentUser?.id]);
-
   const eventDrinks = useMemo(() => {
     if (!linkedEvent) return [];
     const allDrinks = mergePredefinedDrinks(linkedEventCustomDrinks);
@@ -208,12 +187,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linkedEvent, linkedEventCustomDrinks, recipes, drinksCategoryImage]);
-
-  const handleLinkEvent = async (eventId) => {
-    await updateMenu(menu.id, { eventId, eventOwnerId: currentUser.id });
-    setMenu((prev) => ({ ...prev, eventId, eventOwnerId: currentUser.id }));
-    setDrinksSubView('main');
-  };
 
   const authorName = useMemo(() => {
     if (!menu.authorId || !allUsers || allUsers.length === 0) return null;
@@ -505,66 +478,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     return combineIngredients(converted);
   };
 
-  if (drinksSubView === 'newEvent') {
-    return (
-      <EventForm
-        currentUser={currentUser}
-        recipes={recipes}
-        onCancel={() => setDrinksSubView('main')}
-        onSaved={async (eventId) => {
-          await updateMenu(menu.id, { eventId, eventOwnerId: currentUser.id });
-          setMenu((prev) => ({ ...prev, eventId, eventOwnerId: currentUser.id }));
-          setDrinksSubView('main');
-        }}
-        onManageDrinks={() => setDrinksSubView('manageDrinks')}
-      />
-    );
-  }
-
-  if (drinksSubView === 'manageDrinks') {
-    return (
-      <DrinkManagementPage
-        onBack={() => setDrinksSubView('newEvent')}
-        currentUser={currentUser}
-        recipes={recipes}
-      />
-    );
-  }
-
-  if (drinksSubView === 'linkPicker') {
-    return (
-      <div className="events-page-container">
-        <div className="events-page-header">
-          <h2>Event verknüpfen</h2>
-          <button
-            className="events-close-btn"
-            onClick={() => setDrinksSubView('main')}
-            aria-label="Abbrechen"
-            title="Abbrechen"
-          >
-            ×
-          </button>
-        </div>
-        {availableEvents.length === 0 ? (
-          <div className="events-empty-state">
-            <p>Noch keine Events vorhanden.</p>
-          </div>
-        ) : (
-          <div className="events-list">
-            {availableEvents.map((event) => (
-              <div key={event.id} className="events-card" onClick={() => handleLinkEvent(event.id)}>
-                <div className="events-card-main">
-                  <h3>{event.eventName}</h3>
-                  <p className="events-card-meta">{formatEventDate(event.date)}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-
   return (
     <div className="menu-detail-container">
       <div className="menu-detail-header">
@@ -703,7 +616,9 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
 
           let emptyText = 'Keine Rezepte in diesem Abschnitt';
           if (isDrinksSection && !menu.eventId) {
-            emptyText = 'Noch kein Event verknüpft.';
+            emptyText = canEditMenu(currentUser, menu)
+              ? 'Noch kein Event verknüpft. Event über "Menü bearbeiten" verknüpfen oder erstellen.'
+              : 'Noch kein Event verknüpft.';
           } else if (isDrinksSection && menu.eventId && !linkedEventLoading && !linkedEvent) {
             emptyText = 'Verknüpftes Event konnte nicht geladen werden.';
           }
@@ -758,16 +673,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
                 </div>
               ) : (
                 <p className="no-recipes">{emptyText}</p>
-              )}
-              {isDrinksSection && !menu.eventId && canEditMenu(currentUser, menu) && (
-                <div className="menu-drinks-link-actions">
-                  <button type="button" className="menu-drinks-link-btn" onClick={() => setDrinksSubView('linkPicker')}>
-                    Event verknüpfen
-                  </button>
-                  <button type="button" className="menu-drinks-link-btn" onClick={() => setDrinksSubView('newEvent')}>
-                    Event erstellen
-                  </button>
-                </div>
               )}
             </section>
           );

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -714,6 +714,39 @@
   color: white;
 }
 
+.menu-event-linked {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu-event-linked-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.menu-drinks-link-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.menu-drinks-link-btn {
+  background: #402C1C;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.menu-drinks-link-btn:hover {
+  background: #2c1f13;
+}
+
 .menu-image-remove-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -725,6 +725,24 @@
   font-weight: 600;
 }
 
+.menu-event-drinks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.menu-event-drinks-item {
+  padding: 0.5rem 0.75rem;
+  background: #f9f6f3;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.menu-event-drinks-item:last-child {
+  margin-bottom: 0;
+}
+
 .menu-drinks-link-actions {
   display: flex;
   gap: 0.75rem;

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './MenuForm.css';
+import './EventsPage.css';
 import { getUserFavorites } from '../utils/userFavorites';
 import { getSavedSections, saveSectionNames, createMenuSection } from '../utils/menuSections';
 import { fuzzyFilter } from '../utils/fuzzySearch';
@@ -7,6 +8,9 @@ import { fileToBase64, compressImage, selectMenuGridImages, buildMenuGridImage, 
 import { uploadMenuGridImage, uploadMenuGridImageDark, deleteMenuGridImage, deleteMenuGridImageDark, isStorageUrl } from '../utils/storageUtils';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getButtonIcons } from '../utils/customLists';
 import { getCategoryImages } from '../utils/categoryImages';
+import { getEvent, subscribeToEvents } from '../utils/eventsFirestore';
+import EventForm from './EventForm';
+import DrinkManagementPage from './DrinkManagementPage';
 import {
   DndContext,
   closestCenter,
@@ -26,6 +30,15 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 
 const MOBILE_BREAKPOINT = 768;
+
+const formatEventDate = (dateStr) => {
+  if (!dateStr) return '';
+  try {
+    return new Date(dateStr).toLocaleDateString('de-DE');
+  } catch {
+    return dateStr;
+  }
+};
 
 // Sortable Section Component for drag & drop reordering of menu sections
 function SortableSection({
@@ -222,6 +235,12 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const [addSectionIcon, setAddSectionIcon] = useState('+');
   const [addSectionFabPressedIndex, setAddSectionFabPressedIndex] = useState(null);
   const [insertSectionAtIndex, setInsertSectionAtIndex] = useState(null);
+  const [eventId, setEventId] = useState(null);
+  const [eventOwnerId, setEventOwnerId] = useState(null);
+  const [formSubView, setFormSubView] = useState('main'); // main | linkPicker | newEvent | manageDrinks
+  const [linkedEvent, setLinkedEvent] = useState(null);
+  const [linkedEventLoading, setLinkedEventLoading] = useState(false);
+  const [availableEvents, setAvailableEvents] = useState([]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -274,6 +293,42 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  // Load the name of the currently linked event, if any.
+  useEffect(() => {
+    if (!eventId || !eventOwnerId) {
+      setLinkedEvent(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setLinkedEventLoading(true);
+    getEvent(eventOwnerId, eventId).then((event) => {
+      if (!cancelled) setLinkedEvent(event);
+    }).finally(() => {
+      if (!cancelled) setLinkedEventLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId, eventOwnerId]);
+
+  // Load the current user's events while the "Event verknüpfen" picker is open.
+  useEffect(() => {
+    if (formSubView !== 'linkPicker' || !currentUser?.id) return undefined;
+    const unsubscribe = subscribeToEvents(currentUser.id, setAvailableEvents);
+    return unsubscribe;
+  }, [formSubView, currentUser?.id]);
+
+  const handleLinkEvent = (id) => {
+    setEventId(id);
+    setEventOwnerId(currentUser.id);
+    setFormSubView('main');
+  };
+
+  const handleUnlinkEvent = () => {
+    setEventId(null);
+    setEventOwnerId(null);
+  };
+
   useEffect(() => {
     // Load available section names
     setAvailableSections(getSavedSections());
@@ -282,6 +337,8 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       setName(menu.name || '');
       setDescription(menu.description || '');
       setMenuImage(menu.image || '');
+      setEventId(menu.eventId || null);
+      setEventOwnerId(menu.eventOwnerId || null);
       // Initialize menuDate: use existing menuDate, or fall back to createdAt, or today
       if (menu.menuDate) {
         setMenuDate(menu.menuDate);
@@ -318,6 +375,8 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       // New menu - create default section
       setSections([createMenuSection('Hauptspeise', [])]);
       setMenuDate(new Date().toISOString().slice(0, 10));
+      setEventId(null);
+      setEventOwnerId(null);
     }
   }, [menu]);
 
@@ -594,7 +653,9 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
         gridImageDark: gridImageDark || null,
         createdBy: menu?.createdBy || currentUser?.id,
         sections: sections,
-        recipeIds: allRecipeIds // Keep for backward compatibility
+        recipeIds: allRecipeIds, // Keep for backward compatibility
+        eventId: eventId || null,
+        eventOwnerId: eventId ? eventOwnerId : null,
       };
 
       console.log('[MenuForm:handleSubmit] Final menuData:', {
@@ -669,6 +730,66 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const handleAddSectionFabPressStart = (index) => setAddSectionFabPressedIndex(index);
   const handleAddSectionFabPressEnd = () => setAddSectionFabPressedIndex(null);
 
+  if (formSubView === 'newEvent') {
+    return (
+      <EventForm
+        currentUser={currentUser}
+        recipes={recipes}
+        onCancel={() => setFormSubView('main')}
+        onSaved={(newEventId) => {
+          setEventId(newEventId);
+          setEventOwnerId(currentUser.id);
+          setFormSubView('main');
+        }}
+        onManageDrinks={() => setFormSubView('manageDrinks')}
+      />
+    );
+  }
+
+  if (formSubView === 'manageDrinks') {
+    return (
+      <DrinkManagementPage
+        onBack={() => setFormSubView('newEvent')}
+        currentUser={currentUser}
+        recipes={recipes}
+      />
+    );
+  }
+
+  if (formSubView === 'linkPicker') {
+    return (
+      <div className="events-page-container">
+        <div className="events-page-header">
+          <h2>Event verknüpfen</h2>
+          <button
+            className="events-close-btn"
+            onClick={() => setFormSubView('main')}
+            aria-label="Abbrechen"
+            title="Abbrechen"
+          >
+            ×
+          </button>
+        </div>
+        {availableEvents.length === 0 ? (
+          <div className="events-empty-state">
+            <p>Noch keine Events vorhanden.</p>
+          </div>
+        ) : (
+          <div className="events-list">
+            {availableEvents.map((event) => (
+              <div key={event.id} className="events-card" onClick={() => handleLinkEvent(event.id)}>
+                <div className="events-card-main">
+                  <h3>{event.eventName}</h3>
+                  <p className="events-card-meta">{formatEventDate(event.date)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="menu-form-container">
       <div className="menu-form-header">
@@ -741,6 +862,34 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
             style={{ display: 'none' }}
             disabled={uploadingMenuImage}
           />
+        </div>
+
+        <div className="form-group">
+          <label>Event (für Getränke)</label>
+          {eventId ? (
+            <div className="menu-event-linked">
+              <p className="menu-event-linked-name">
+                {linkedEventLoading ? 'Lädt …' : (linkedEvent?.eventName || 'Verknüpftes Event konnte nicht geladen werden.')}
+              </p>
+              <div className="menu-drinks-link-actions">
+                <button type="button" className="menu-drinks-link-btn" onClick={() => setFormSubView('linkPicker')}>
+                  Event ändern
+                </button>
+                <button type="button" className="menu-drinks-link-btn" onClick={handleUnlinkEvent}>
+                  Verknüpfung entfernen
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="menu-drinks-link-actions">
+              <button type="button" className="menu-drinks-link-btn" onClick={() => setFormSubView('linkPicker')}>
+                Event verknüpfen
+              </button>
+              <button type="button" className="menu-drinks-link-btn" onClick={() => setFormSubView('newEvent')}>
+                Event erstellen
+              </button>
+            </div>
+          )}
         </div>
 
         <div className="form-section sections-management">

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import './MenuForm.css';
 import './EventsPage.css';
 import { getUserFavorites } from '../utils/userFavorites';
@@ -8,7 +8,9 @@ import { fileToBase64, compressImage, selectMenuGridImages, buildMenuGridImage, 
 import { uploadMenuGridImage, uploadMenuGridImageDark, deleteMenuGridImage, deleteMenuGridImageDark, isStorageUrl } from '../utils/storageUtils';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getButtonIcons } from '../utils/customLists';
 import { getCategoryImages } from '../utils/categoryImages';
-import { getEvent, subscribeToEvents } from '../utils/eventsFirestore';
+import { getEvent, subscribeToEvents, getCustomDrinks } from '../utils/eventsFirestore';
+import { mergePredefinedDrinks } from '../utils/drinkCategories';
+import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import EventForm from './EventForm';
 import DrinkManagementPage from './DrinkManagementPage';
 import {
@@ -240,6 +242,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const [formSubView, setFormSubView] = useState('main'); // main | linkPicker | newEvent | manageDrinks
   const [linkedEvent, setLinkedEvent] = useState(null);
   const [linkedEventLoading, setLinkedEventLoading] = useState(false);
+  const [linkedEventCustomDrinks, setLinkedEventCustomDrinks] = useState([]);
   const [availableEvents, setAvailableEvents] = useState([]);
 
   const sensors = useSensors(
@@ -293,16 +296,22 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // Load the name of the currently linked event, if any.
+  // Load the name and drinks of the currently linked event, if any.
   useEffect(() => {
     if (!eventId || !eventOwnerId) {
       setLinkedEvent(null);
+      setLinkedEventCustomDrinks([]);
       return undefined;
     }
     let cancelled = false;
     setLinkedEventLoading(true);
-    getEvent(eventOwnerId, eventId).then((event) => {
-      if (!cancelled) setLinkedEvent(event);
+    Promise.all([
+      getEvent(eventOwnerId, eventId),
+      getCustomDrinks(eventOwnerId),
+    ]).then(([event, customDrinks]) => {
+      if (cancelled) return;
+      setLinkedEvent(event);
+      setLinkedEventCustomDrinks(customDrinks);
     }).finally(() => {
       if (!cancelled) setLinkedEventLoading(false);
     });
@@ -310,6 +319,18 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       cancelled = true;
     };
   }, [eventId, eventOwnerId]);
+
+  // Names of the drinks assigned via the linked event, for a plain-text
+  // list display (no drink tiles here, unlike the menu detail view).
+  const eventDrinkNames = useMemo(() => {
+    if (!linkedEvent) return [];
+    const allDrinks = mergePredefinedDrinks(linkedEventCustomDrinks);
+    const ids = Array.isArray(linkedEvent.customDrinkIds) ? linkedEvent.customDrinkIds : [];
+    return ids.map((drinkId) => {
+      const drink = allDrinks.find((d) => d.id === drinkId);
+      return resolveDrinkDisplay(drink || drinkId, recipes).displayName || drinkId;
+    });
+  }, [linkedEvent, linkedEventCustomDrinks, recipes]);
 
   // Load the current user's events while the "Event verknüpfen" picker is open.
   useEffect(() => {
@@ -735,6 +756,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       <EventForm
         currentUser={currentUser}
         recipes={recipes}
+        initialEvent={{ eventName: name.trim(), date: menuDate }}
         onCancel={() => setFormSubView('main')}
         onSaved={(newEventId) => {
           setEventId(newEventId);
@@ -871,6 +893,13 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
               <p className="menu-event-linked-name">
                 {linkedEventLoading ? 'Lädt …' : (linkedEvent?.eventName || 'Verknüpftes Event konnte nicht geladen werden.')}
               </p>
+              {eventDrinkNames.length > 0 && (
+                <ul className="menu-event-drinks-list">
+                  {eventDrinkNames.map((drinkName, index) => (
+                    <li key={`${drinkName}-${index}`} className="menu-event-drinks-item">{drinkName}</li>
+                  ))}
+                </ul>
+              )}
               <div className="menu-drinks-link-actions">
                 <button type="button" className="menu-drinks-link-btn" onClick={() => setFormSubView('linkPicker')}>
                   Event ändern


### PR DESCRIPTION
Die Buttons "Event verknüpfen" und "Event erstellen" samt zugehöriger
Unteransichten (Event-Picker, EventForm, DrinkManagementPage) wurden aus
MenuDetail entfernt und stattdessen in MenuForm eingebaut, wo sie beim
Erstellen oder Bearbeiten eines Menüs verfügbar sind. Die Detailansicht
zeigt weiterhin die Getränke des verknüpften Events an, erlaubt aber
keine Verknüpfung/Erstellung mehr.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012JHujGJz4YvEfccr3r4Hdf