### PR TITLE
Getränke manuell im Drinks-Abschnitt hinzufügen und ins Event übernehmen

### DIFF
--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -70,6 +70,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
   const [linkedEventCustomDrinks, setLinkedEventCustomDrinks] = useState([]);
   const [expandedDrinkId, setExpandedDrinkId] = useState(null);
   const [drinksCategoryImage, setDrinksCategoryImage] = useState(null);
+  const [manualDrinkCatalog, setManualDrinkCatalog] = useState([]);
   const {
     activeId: portionMinusLongPressActiveId,
     triggeredRef: portionMinusLongPressTriggeredRef,
@@ -169,6 +170,44 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
       cancelled = true;
     };
   }, []);
+
+  // Whether any section carries manually added drink-catalog IDs (see MenuForm's
+  // "Drinks" section), independent of whether an event is linked.
+  const hasManualDrinks = useMemo(
+    () => (menu.sections || []).some((section) => Array.isArray(section.drinkIds) && section.drinkIds.length > 0),
+    [menu.sections]
+  );
+
+  // Load the drink catalog needed to resolve manually added drinks, once, only
+  // when the menu actually has any (no live sync, matching the event drinks load).
+  useEffect(() => {
+    if (!hasManualDrinks || !currentUser?.id) {
+      setManualDrinkCatalog([]);
+      return undefined;
+    }
+    let cancelled = false;
+    getCustomDrinks(currentUser.id).then((drinks) => {
+      if (!cancelled) setManualDrinkCatalog(drinks);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [hasManualDrinks, currentUser?.id]);
+
+  const resolveManualDrinks = (drinkIds) => {
+    if (!Array.isArray(drinkIds) || drinkIds.length === 0) return [];
+    const allDrinks = mergePredefinedDrinks(manualDrinkCatalog);
+    return drinkIds.map((drinkId) => {
+      const drink = allDrinks.find((d) => d.id === drinkId);
+      const display = resolveDrinkDisplay(drink || drinkId, recipes);
+      return {
+        id: drinkId,
+        displayName: display.displayName || drinkId,
+        imageUrl: getDrinkImageUrl(display.recipe) || drinksCategoryImage,
+        literMitPuffer: null,
+      };
+    });
+  };
 
   const eventDrinks = useMemo(() => {
     if (!linkedEvent) return [];
@@ -610,7 +649,11 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
 
         {displaySections.map((section, index) => {
           const isDrinksSection = section.name?.toLowerCase() === DRINKS_SECTION_NAME.toLowerCase();
-          const sectionDrinks = isDrinksSection ? eventDrinks : [];
+          const manualDrinks = isDrinksSection ? resolveManualDrinks(section.drinkIds) : [];
+          const eventDrinkIds = new Set(eventDrinks.map((drink) => drink.id));
+          const sectionDrinks = isDrinksSection
+            ? [...eventDrinks, ...manualDrinks.filter((drink) => !eventDrinkIds.has(drink.id))]
+            : [];
           const isLoadingDrinks = isDrinksSection && linkedEventLoading;
           const hasCards = section.recipes.length > 0 || sectionDrinks.length > 0;
 

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -33,9 +33,10 @@ jest.mock('../utils/menuFavorites', () => ({
   getUserMenuFavorites: () => Promise.resolve([]),
 }));
 
-jest.mock('../utils/menuSections', () => ({
-  groupRecipesBySections: () => [],
-}));
+jest.mock('../utils/menuSections', () => {
+  const actual = jest.requireActual('../utils/menuSections');
+  return { ...actual, groupRecipesBySections: actual.groupRecipesBySections };
+});
 
 jest.mock('../utils/customLists', () => ({
   getButtonIcons: () => Promise.resolve({ menuCloseButton: '✕', copyLink: '📋' }),
@@ -57,6 +58,12 @@ jest.mock('../utils/menuFirestore', () => ({
 
 jest.mock('../utils/categoryImages', () => ({
   getImageForCategory: () => Promise.resolve(null),
+}));
+
+const mockGetCustomDrinks = jest.fn(() => Promise.resolve([]));
+jest.mock('../utils/eventsFirestore', () => ({
+  getEvent: jest.fn(() => Promise.resolve(null)),
+  getCustomDrinks: (...args) => mockGetCustomDrinks(...args),
 }));
 
 const mockMenu = {
@@ -303,6 +310,65 @@ describe('MenuDetail - Metadata before Description', () => {
     expect(
       authorDate.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+});
+
+describe('MenuDetail - Manually added drinks in the Drinks section', () => {
+  beforeEach(() => {
+    mockGetCustomDrinks.mockReset();
+  });
+
+  const menuWithManualDrinks = {
+    id: 'menu-drinks',
+    name: 'Menü mit Drinks',
+    sections: [
+      { name: 'Hauptspeise', recipeIds: [] },
+      { name: 'Drinks', recipeIds: [], drinkIds: ['drink-cola'] },
+    ],
+  };
+
+  test('renders a manually added drink as a recipe-style card', async () => {
+    mockGetCustomDrinks.mockResolvedValue([
+      { id: 'drink-cola', name: 'Cola', kategorie: 'softdrinks', einheiten: [{ einheitsgroesse: 0.5 }] },
+    ]);
+
+    render(
+      <MenuDetail
+        menu={menuWithManualDrinks}
+        recipes={[]}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+        onSelectRecipe={() => {}}
+        onToggleMenuFavorite={() => Promise.resolve()}
+        currentUser={currentUser}
+        allUsers={[]}
+      />
+    );
+
+    expect(await screen.findByText('Cola')).toBeInTheDocument();
+    // Uses the same "recipe-card"/"drink-card" classes as the recipe grid - no separate layout/design.
+    const drinkCard = screen.getByText('Cola').closest('.drink-card');
+    expect(drinkCard).toBeInTheDocument();
+    expect(drinkCard.className).toContain('recipe-card');
+  });
+
+  test('does not fetch the drink catalog when no drinks were manually added', () => {
+    render(
+      <MenuDetail
+        menu={mockMenu}
+        recipes={[]}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+        onSelectRecipe={() => {}}
+        onToggleMenuFavorite={() => Promise.resolve()}
+        currentUser={currentUser}
+        allUsers={[]}
+      />
+    );
+
+    expect(mockGetCustomDrinks).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -8,7 +8,7 @@ import { fileToBase64, compressImage, selectMenuGridImages, buildMenuGridImage, 
 import { uploadMenuGridImage, uploadMenuGridImageDark, deleteMenuGridImage, deleteMenuGridImageDark, isStorageUrl } from '../utils/storageUtils';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getButtonIcons } from '../utils/customLists';
 import { getCategoryImages } from '../utils/categoryImages';
-import { getEvent, subscribeToEvents, getCustomDrinks } from '../utils/eventsFirestore';
+import { getEvent, subscribeToEvents, getCustomDrinks, subscribeToCustomDrinks } from '../utils/eventsFirestore';
 import { mergePredefinedDrinks } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import EventForm from './EventForm';
@@ -47,6 +47,8 @@ function SortableSection({
   id, section, sectionIndex, recipes, favoriteIds, searchQueries, sensors, closeIcon,
   onRemoveSection, onDragEndRecipes, onRemoveRecipeFromSection,
   onSearchChange, onAddRecipeToSection, getFilteredRecipes,
+  isDrinksSection, drinkSearchQueries, onDrinkSearchChange, onAddDrinkToSection,
+  onRemoveDrinkFromSection, getFilteredDrinks, getDrinkDisplayName,
 }) {
   const {
     attributes,
@@ -160,8 +162,63 @@ function SortableSection({
           )}
         </div>
       </div>
+      {isDrinksSection && (
+        <div className="recipe-selection drink-selection">
+          {(section.drinkIds || []).length > 0 && (
+            <div className="selected-recipes">
+              <h5>Manuell hinzugefügte Getränke:</h5>
+              {(section.drinkIds || []).map(drinkId => (
+                <div key={drinkId} className="selected-recipe-item">
+                  <span className="recipe-name">{getDrinkDisplayName(drinkId)}</span>
+                  <button
+                    type="button"
+                    className="remove-recipe-button"
+                    onClick={() => onRemoveDrinkFromSection(sectionIndex, drinkId)}
+                    title="Getränk entfernen"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="typeahead-container">
+            <input
+              type="text"
+              className="typeahead-input"
+              placeholder="Getränk aus dem Eventbereich suchen und hinzufügen..."
+              value={drinkSearchQueries[sectionIndex] || ''}
+              onChange={(e) => onDrinkSearchChange(sectionIndex, e.target.value)}
+            />
+
+            {drinkSearchQueries[sectionIndex] && drinkSearchQueries[sectionIndex].trim() && (
+              <div className="typeahead-dropdown">
+                {(() => {
+                  const filteredDrinks = getFilteredDrinks(sectionIndex);
+                  if (filteredDrinks.length === 0) {
+                    return <div className="typeahead-no-results">Keine Getränke gefunden</div>;
+                  }
+                  return filteredDrinks.slice(0, 10).map(drink => (
+                    <div
+                      key={drink.id}
+                      className="typeahead-item"
+                      onClick={() => onAddDrinkToSection(sectionIndex, drink.id)}
+                    >
+                      <span className="recipe-name">{getDrinkDisplayName(drink.id)}</span>
+                    </div>
+                  ));
+                })()}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
       <div className="section-summary">
         {section.recipeIds.length} Rezept{section.recipeIds.length !== 1 ? 'e' : ''}
+        {isDrinksSection && (section.drinkIds || []).length > 0
+          ? `, ${section.drinkIds.length} Getränk${section.drinkIds.length !== 1 ? 'e' : ''}`
+          : ''}
       </div>
     </div>
   );
@@ -244,6 +301,8 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const [linkedEventLoading, setLinkedEventLoading] = useState(false);
   const [linkedEventCustomDrinks, setLinkedEventCustomDrinks] = useState([]);
   const [availableEvents, setAvailableEvents] = useState([]);
+  const [userCustomDrinks, setUserCustomDrinks] = useState([]);
+  const [drinkSearchQueries, setDrinkSearchQueries] = useState({});
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -338,6 +397,79 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     const unsubscribe = subscribeToEvents(currentUser.id, setAvailableEvents);
     return unsubscribe;
   }, [formSubView, currentUser?.id]);
+
+  // Load the current user's drink catalog (custom + predefined) so drinks from
+  // the event area can be manually added to the menu's "Drinks" section.
+  useEffect(() => {
+    if (!currentUser?.id) {
+      setUserCustomDrinks([]);
+      return undefined;
+    }
+    const unsubscribe = subscribeToCustomDrinks(currentUser.id, setUserCustomDrinks);
+    return unsubscribe;
+  }, [currentUser?.id]);
+
+  const allDrinks = useMemo(() => mergePredefinedDrinks(userCustomDrinks), [userCustomDrinks]);
+
+  const getDrinkDisplayName = (drinkId) => {
+    const drink = allDrinks.find((d) => d.id === drinkId);
+    return resolveDrinkDisplay(drink || drinkId, recipes).displayName || drinkId;
+  };
+
+  const handleDrinkSearchChange = (sectionIndex, query) => {
+    setDrinkSearchQueries({
+      ...drinkSearchQueries,
+      [sectionIndex]: query
+    });
+  };
+
+  const handleAddDrinkToSection = (sectionIndex, drinkId) => {
+    setSections((prevSections) => prevSections.map((s, i) => {
+      if (i !== sectionIndex) return s;
+      const existingDrinkIds = s.drinkIds || [];
+      if (existingDrinkIds.includes(drinkId)) return s;
+      return { ...s, drinkIds: [...existingDrinkIds, drinkId] };
+    }));
+    setDrinkSearchQueries({
+      ...drinkSearchQueries,
+      [sectionIndex]: ''
+    });
+  };
+
+  const handleRemoveDrinkFromSection = (sectionIndex, drinkId) => {
+    setSections((prevSections) => prevSections.map((s, i) => {
+      if (i !== sectionIndex) return s;
+      return { ...s, drinkIds: (s.drinkIds || []).filter((id) => id !== drinkId) };
+    }));
+  };
+
+  const getFilteredDrinks = (sectionIndex) => {
+    const query = drinkSearchQueries[sectionIndex] || '';
+    const section = sections[sectionIndex];
+    const selectedDrinkIds = section?.drinkIds || [];
+
+    const availableDrinks = allDrinks.filter((drink) => !selectedDrinkIds.includes(drink.id));
+
+    if (!query.trim()) {
+      return availableDrinks;
+    }
+
+    return fuzzyFilter(availableDrinks, query, (drink) => resolveDrinkDisplay(drink, recipes).displayName);
+  };
+
+  // Manually added drinks in the "Drinks" section, used to pre-fill a newly
+  // created event's drink selection so nothing has to be re-entered there.
+  const drinksSectionManualDrinkIds = useMemo(() => {
+    const ids = [];
+    sections.forEach((s) => {
+      if (s.name?.toLowerCase() === 'drinks') {
+        (s.drinkIds || []).forEach((id) => {
+          if (!ids.includes(id)) ids.push(id);
+        });
+      }
+    });
+    return ids;
+  }, [sections]);
 
   const handleLinkEvent = (id) => {
     setEventId(id);
@@ -463,8 +595,8 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       return;
     }
 
-    if (sections[index].recipeIds.length > 0) {
-      if (!window.confirm('Dieser Abschnitt enthält Rezepte. Wirklich löschen?')) {
+    if (sections[index].recipeIds.length > 0 || (sections[index].drinkIds?.length || 0) > 0) {
+      if (!window.confirm('Dieser Abschnitt enthält Rezepte oder Getränke. Wirklich löschen?')) {
         return;
       }
     }
@@ -540,10 +672,11 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       return;
     }
 
-    // Check if at least one recipe is selected
+    // Check if at least one recipe or manually added drink is selected
     const totalRecipes = sections.reduce((sum, section) => sum + section.recipeIds.length, 0);
-    if (totalRecipes === 0) {
-      alert('Bitte wählen Sie mindestens ein Rezept aus');
+    const totalDrinks = sections.reduce((sum, section) => sum + (section.drinkIds?.length || 0), 0);
+    if (totalRecipes === 0 && totalDrinks === 0) {
+      alert('Bitte wählen Sie mindestens ein Rezept oder Getränk aus');
       return;
     }
 
@@ -756,7 +889,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       <EventForm
         currentUser={currentUser}
         recipes={recipes}
-        initialEvent={{ eventName: name.trim(), date: menuDate }}
+        initialEvent={{ eventName: name.trim(), date: menuDate, customDrinkIds: drinksSectionManualDrinkIds }}
         onCancel={() => setFormSubView('main')}
         onSaved={(newEventId) => {
           setEventId(newEventId);
@@ -1029,6 +1162,13 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   onSearchChange={handleSearchChange}
                   onAddRecipeToSection={handleAddRecipeToSection}
                   getFilteredRecipes={getFilteredRecipes}
+                  isDrinksSection={section.name?.toLowerCase() === 'drinks'}
+                  drinkSearchQueries={drinkSearchQueries}
+                  onDrinkSearchChange={handleDrinkSearchChange}
+                  onAddDrinkToSection={handleAddDrinkToSection}
+                  onRemoveDrinkFromSection={handleRemoveDrinkFromSection}
+                  getFilteredDrinks={getFilteredDrinks}
+                  getDrinkDisplayName={getDrinkDisplayName}
                 />
                 {isMobile && (
                   <div className="add-section-gap">

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MenuForm from './MenuForm';
+
+const mockSubscribeToCustomDrinks = jest.fn();
+const mockSubscribeToEvents = jest.fn();
+const mockGetEvent = jest.fn();
+const mockGetCustomDrinks = jest.fn();
+
+jest.mock('../utils/userFavorites', () => ({
+  getUserFavorites: () => Promise.resolve([]),
+}));
+
+jest.mock('../utils/menuSections', () => {
+  const actual = jest.requireActual('../utils/menuSections');
+  return {
+    ...actual,
+    getSavedSections: () => actual.getDefaultSections(),
+    saveSectionNames: jest.fn(),
+  };
+});
+
+jest.mock('../utils/imageUtils', () => ({
+  fileToBase64: jest.fn(),
+  compressImage: jest.fn(),
+  selectMenuGridImages: jest.fn(() => []),
+  buildMenuGridImage: jest.fn(() => Promise.resolve(null)),
+  isBase64Image: jest.fn(() => false),
+}));
+
+jest.mock('../utils/storageUtils', () => ({
+  uploadMenuGridImage: jest.fn(() => Promise.resolve('')),
+  uploadMenuGridImageDark: jest.fn(() => Promise.resolve('')),
+  deleteMenuGridImage: jest.fn(() => Promise.resolve()),
+  deleteMenuGridImageDark: jest.fn(() => Promise.resolve()),
+  isStorageUrl: jest.fn(() => false),
+}));
+
+jest.mock('../utils/customLists', () => ({
+  DEFAULT_BUTTON_ICONS: {},
+  getEffectiveIcon: (icons, key) => (icons && icons[key]) || '',
+  getDarkModePreference: () => false,
+  getButtonIcons: () => Promise.resolve({}),
+}));
+
+jest.mock('../utils/categoryImages', () => ({
+  getCategoryImages: () => Promise.resolve([]),
+}));
+
+jest.mock('../utils/eventsFirestore', () => ({
+  getEvent: (...args) => mockGetEvent(...args),
+  subscribeToEvents: (...args) => mockSubscribeToEvents(...args),
+  getCustomDrinks: (...args) => mockGetCustomDrinks(...args),
+  subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
+}));
+
+jest.mock('./DrinkManagementPage', () => function MockDrinkManagementPage() {
+  return <div>Getränkeverwaltung</div>;
+});
+
+jest.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }) => <div>{children}</div>,
+  closestCenter: jest.fn(),
+  PointerSensor: jest.fn(),
+  TouchSensor: jest.fn(),
+  KeyboardSensor: jest.fn(),
+  useSensor: jest.fn(),
+  useSensors: jest.fn(() => []),
+}));
+
+jest.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }) => <div>{children}</div>,
+  arrayMove: jest.fn((array, oldIndex, newIndex) => {
+    const newArray = [...array];
+    const [item] = newArray.splice(oldIndex, 1);
+    newArray.splice(newIndex, 0, item);
+    return newArray;
+  }),
+  sortableKeyboardCoordinates: jest.fn(),
+  verticalListSortingStrategy: jest.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: jest.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+
+jest.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: () => '',
+    },
+  },
+}));
+
+let capturedEventFormProps = null;
+jest.mock('./EventForm', () => function MockEventForm(props) {
+  capturedEventFormProps = props;
+  return <div>Neues Event Formular</div>;
+});
+
+const currentUser = { id: 'user-1' };
+
+const customDrinks = [
+  { id: 'drink-cola', name: 'Cola', kategorie: 'softdrinks', einheiten: [{ einheitsgroesse: 0.5 }] },
+  { id: 'drink-apfelsaft', name: 'Apfelsaft', kategorie: 'saft', einheiten: [{ einheitsgroesse: 1 }] },
+];
+
+const recipes = [
+  { id: 'recipe-1', title: 'Nudelsalat', portionen: 4, ingredients: [] },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedEventFormProps = null;
+  mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+    callback(customDrinks);
+    return () => {};
+  });
+  mockSubscribeToEvents.mockImplementation(() => () => {});
+});
+
+describe('MenuForm - Drinks section manual drink selection', () => {
+  test('lets the user add a drink from the event catalog to the "Drinks" section', async () => {
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    // Default section is "Hauptspeise" - switch to a Drinks section via quick-select
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const drinkInput = await screen.findByPlaceholderText('Getränk aus dem Eventbereich suchen und hinzufügen...');
+    fireEvent.change(drinkInput, { target: { value: 'Cola' } });
+
+    const option = await screen.findByText('Cola');
+    fireEvent.click(option);
+
+    expect(await screen.findByText('Manuell hinzugefügte Getränke:')).toBeInTheDocument();
+    expect(screen.getAllByText('Cola').length).toBeGreaterThan(0);
+  });
+
+  test('lets the user remove a manually added drink again', async () => {
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const drinkInput = await screen.findByPlaceholderText('Getränk aus dem Eventbereich suchen und hinzufügen...');
+    fireEvent.change(drinkInput, { target: { value: 'Cola' } });
+    fireEvent.click(await screen.findByText('Cola'));
+
+    expect(await screen.findByText('Manuell hinzugefügte Getränke:')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Getränk entfernen'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Manuell hinzugefügte Getränke:')).not.toBeInTheDocument();
+    });
+  });
+
+  test('carries manually added drinks over to a newly created event', async () => {
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const drinkInput = await screen.findByPlaceholderText('Getränk aus dem Eventbereich suchen und hinzufügen...');
+    fireEvent.change(drinkInput, { target: { value: 'Cola' } });
+    fireEvent.click(await screen.findByText('Cola'));
+
+    fireEvent.click(screen.getByText('Event erstellen'));
+
+    await waitFor(() => {
+      expect(capturedEventFormProps).not.toBeNull();
+    });
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-cola']);
+  });
+});

--- a/src/utils/menuSections.js
+++ b/src/utils/menuSections.js
@@ -75,12 +75,15 @@ export const groupRecipesBySections = (menuSections, allRecipes) => {
   if (!menuSections || !Array.isArray(menuSections) || !allRecipes || !Array.isArray(allRecipes)) {
     return [];
   }
-  
+
   return menuSections.map(section => ({
     name: section.name,
     recipes: (section.recipeIds || [])
       .map(id => allRecipes.find(recipe => recipe.id === id))
-      .filter(Boolean)
+      .filter(Boolean),
+    // Manually added drink-catalog IDs (see the "Drinks" section) aren't recipes,
+    // so they're passed through as-is for the UI to resolve and render separately.
+    ...(Array.isArray(section.drinkIds) ? { drinkIds: section.drinkIds } : {}),
   }));
 };
 
@@ -88,12 +91,14 @@ export const groupRecipesBySections = (menuSections, allRecipes) => {
  * Create a new menu section object
  * @param {string} name - Section name
  * @param {Array} recipeIds - Array of recipe IDs in this section
+ * @param {Array} [drinkIds] - Array of manually added drink-catalog IDs (only meaningful for the "Drinks" section)
  * @returns {Object} Section object
  */
-export const createMenuSection = (name, recipeIds = []) => {
+export const createMenuSection = (name, recipeIds = [], drinkIds = undefined) => {
   return {
     name: name.trim(),
-    recipeIds: recipeIds
+    recipeIds: recipeIds,
+    ...(drinkIds !== undefined ? { drinkIds } : {}),
   };
 };
 

--- a/src/utils/menuSections.test.js
+++ b/src/utils/menuSections.test.js
@@ -106,6 +106,17 @@ describe('menuSections utility functions', () => {
       const section = createMenuSection('  Dessert  ');
       expect(section.name).toBe('Dessert');
     });
+
+    test('does not add a drinkIds key when none is given', () => {
+      const section = createMenuSection('Drinks', ['recipe1']);
+      expect(section).toEqual({ name: 'Drinks', recipeIds: ['recipe1'] });
+      expect('drinkIds' in section).toBe(false);
+    });
+
+    test('includes manually added drink IDs when provided', () => {
+      const section = createMenuSection('Drinks', [], ['drink1', 'drink2']);
+      expect(section).toEqual({ name: 'Drinks', recipeIds: [], drinkIds: ['drink1', 'drink2'] });
+    });
   });
 
   describe('groupRecipesBySections', () => {
@@ -145,6 +156,24 @@ describe('menuSections utility functions', () => {
 
       const grouped = groupRecipesBySections(menuSections, recipes);
       expect(grouped[0].recipes).toHaveLength(0);
+    });
+
+    test('passes through manually added drinkIds on the Drinks section', () => {
+      const menuSections = [
+        { name: 'Drinks', recipeIds: [], drinkIds: ['drink1', 'drink2'] },
+      ];
+
+      const grouped = groupRecipesBySections(menuSections, recipes);
+      expect(grouped[0].drinkIds).toEqual(['drink1', 'drink2']);
+    });
+
+    test('does not add a drinkIds key for sections without manually added drinks', () => {
+      const menuSections = [
+        { name: 'Hauptspeise', recipeIds: ['recipe1'] },
+      ];
+
+      const grouped = groupRecipesBySections(menuSections, recipes);
+      expect('drinkIds' in grouped[0]).toBe(false);
     });
 
     test('preserves recipe order from recipeIds, not from allRecipes order', () => {


### PR DESCRIPTION
- Menü-Formular: im Drinks-Abschnitt lassen sich Getränke aus dem
  Eventbereich (eigene + vordefinierte Getränke) manuell per Typeahead
  hinzufügen/entfernen, gespeichert als section.drinkIds
- Menüdetailansicht: zeigt diese manuell hinzugefügten Getränke als
  designkonsistente Karten im Drinks-Abschnitt, zusammen mit den
  automatisch aus dem verknüpften Event geladenen Getränken
- Beim Erstellen eines neuen Events aus dem Menü-Formular werden alle
  manuell im Drinks-Abschnitt hinzugefügten Getränke als
  customDrinkIds ins neue Event übernommen