### PR TITLE
Move linked event drinks from menu edit header into Drinks section

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -725,22 +725,11 @@
   font-weight: 600;
 }
 
-.menu-event-drinks-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.menu-event-drinks-item {
-  padding: 0.5rem 0.75rem;
-  background: #f9f6f3;
-  border-radius: 6px;
-  margin-bottom: 0.5rem;
-  color: #333;
-}
-
-.menu-event-drinks-item:last-child {
-  margin-bottom: 0;
+/* Drinks planned via a linked event, shown read-only in the Drinks section's
+   merged "Ausgewählte Rezepte & Getränke" list (no remove button, unlike
+   manually added drinks). */
+.selected-recipe-item.event-drink-item {
+  background: #f3ede6;
 }
 
 .menu-drinks-link-actions {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -58,7 +58,7 @@ function SortableSection({
   onSearchChange, onAddRecipeToSection, getFilteredRecipes,
   isDrinksSection, drinkSearchQueries, onDrinkSearchChange, onAddDrinkToSection,
   onAddRecipeToDrinksSection, onRemoveDrinkFromSection, getFilteredDrinkSectionOptions,
-  getDrinkDisplayName,
+  getDrinkDisplayName, eventDrinks = [],
 }) {
   const {
     attributes,
@@ -74,6 +74,41 @@ function SortableSection({
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
+
+  // De-duplicate manually added drinks against the event's planned drinks so
+  // the same drink never shows up twice in the merged list below.
+  const eventDrinkIds = eventDrinks.map((drink) => drink.id);
+  const manualDrinkIds = (section.drinkIds || []).filter((drinkId) => !eventDrinkIds.includes(drinkId));
+  const hasSelectedRecipesOrDrinks = section.recipeIds.length > 0 || eventDrinks.length > 0 || manualDrinkIds.length > 0;
+
+  const selectedRecipesList = section.recipeIds.length > 0 && (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={(event) => onDragEndRecipes(sectionIndex, event)}
+    >
+      <SortableContext
+        items={section.recipeIds}
+        strategy={verticalListSortingStrategy}
+      >
+        {section.recipeIds.map(recipeId => {
+          const recipe = recipes.find(r => r.id === recipeId);
+          if (!recipe) return null;
+          const isFavorite = favoriteIds.includes(recipe.id);
+          return (
+            <SortableRecipeItem
+              key={recipe.id}
+              id={recipe.id}
+              recipe={recipe}
+              isFavorite={isFavorite}
+              sectionIndex={sectionIndex}
+              onRemove={onRemoveRecipeFromSection}
+            />
+          );
+        })}
+      </SortableContext>
+    </DndContext>
+  );
 
   return (
     <div ref={setNodeRef} style={style} className={`section-block${isDragging ? ' dragging' : ''}`}>
@@ -104,36 +139,38 @@ function SortableSection({
         </div>
       </div>
       <div className="recipe-selection">
-        {section.recipeIds.length > 0 && (
-          <div className="selected-recipes">
-            <h5>Ausgewählte Rezepte:</h5>
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={(event) => onDragEndRecipes(sectionIndex, event)}
-            >
-              <SortableContext
-                items={section.recipeIds}
-                strategy={verticalListSortingStrategy}
-              >
-                {section.recipeIds.map(recipeId => {
-                  const recipe = recipes.find(r => r.id === recipeId);
-                  if (!recipe) return null;
-                  const isFavorite = favoriteIds.includes(recipe.id);
-                  return (
-                    <SortableRecipeItem
-                      key={recipe.id}
-                      id={recipe.id}
-                      recipe={recipe}
-                      isFavorite={isFavorite}
-                      sectionIndex={sectionIndex}
-                      onRemove={onRemoveRecipeFromSection}
-                    />
-                  );
-                })}
-              </SortableContext>
-            </DndContext>
-          </div>
+        {isDrinksSection ? (
+          hasSelectedRecipesOrDrinks && (
+            <div className="selected-recipes">
+              <h5>Ausgewählte Rezepte & Getränke:</h5>
+              {selectedRecipesList}
+              {eventDrinks.map((drink) => (
+                <div key={`event-drink-${drink.id}`} className="selected-recipe-item event-drink-item">
+                  <span className="recipe-name">{drink.displayName}</span>
+                </div>
+              ))}
+              {manualDrinkIds.map(drinkId => (
+                <div key={drinkId} className="selected-recipe-item">
+                  <span className="recipe-name">{getDrinkDisplayName(drinkId)}</span>
+                  <button
+                    type="button"
+                    className="remove-recipe-button"
+                    onClick={() => onRemoveDrinkFromSection(sectionIndex, drinkId)}
+                    title="Getränk entfernen"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
+          section.recipeIds.length > 0 && (
+            <div className="selected-recipes">
+              <h5>Ausgewählte Rezepte:</h5>
+              {selectedRecipesList}
+            </div>
+          )
         )}
 
         {!isDrinksSection && (
@@ -176,25 +213,6 @@ function SortableSection({
       </div>
       {isDrinksSection && (
         <div className="recipe-selection drink-selection">
-          {(section.drinkIds || []).length > 0 && (
-            <div className="selected-recipes">
-              <h5>Manuell hinzugefügte Getränke:</h5>
-              {(section.drinkIds || []).map(drinkId => (
-                <div key={drinkId} className="selected-recipe-item">
-                  <span className="recipe-name">{getDrinkDisplayName(drinkId)}</span>
-                  <button
-                    type="button"
-                    className="remove-recipe-button"
-                    onClick={() => onRemoveDrinkFromSection(sectionIndex, drinkId)}
-                    title="Getränk entfernen"
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-
           <div className="typeahead-container">
             <input
               type="text"
@@ -243,8 +261,8 @@ function SortableSection({
       )}
       <div className="section-summary">
         {section.recipeIds.length} Rezept{section.recipeIds.length !== 1 ? 'e' : ''}
-        {isDrinksSection && (section.drinkIds || []).length > 0
-          ? `, ${section.drinkIds.length} Getränk${section.drinkIds.length !== 1 ? 'e' : ''}`
+        {isDrinksSection && (eventDrinks.length + manualDrinkIds.length) > 0
+          ? `, ${eventDrinks.length + manualDrinkIds.length} Getränk${(eventDrinks.length + manualDrinkIds.length) !== 1 ? 'e' : ''}`
           : ''}
       </div>
     </div>
@@ -406,17 +424,28 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     };
   }, [eventId, eventOwnerId]);
 
-  // Names of the drinks assigned via the linked event, for a plain-text
-  // list display (no drink tiles here, unlike the menu detail view).
-  const eventDrinkNames = useMemo(() => {
+  // Drinks assigned via the linked event. Shown read-only inside the menu's
+  // "Drinks" section (never in the header) alongside the manually added ones.
+  const eventDrinks = useMemo(() => {
     if (!linkedEvent) return [];
     const allDrinks = mergePredefinedDrinks(linkedEventCustomDrinks);
     const ids = Array.isArray(linkedEvent.customDrinkIds) ? linkedEvent.customDrinkIds : [];
     return ids.map((drinkId) => {
       const drink = allDrinks.find((d) => d.id === drinkId);
-      return resolveDrinkDisplay(drink || drinkId, recipes).displayName || drinkId;
+      return { id: drinkId, displayName: resolveDrinkDisplay(drink || drinkId, recipes).displayName || drinkId };
     });
   }, [linkedEvent, linkedEventCustomDrinks, recipes]);
+
+  // Ensure a "Drinks" section exists once an event is linked, so the event's
+  // planned drinks have somewhere to display within "Abschnitte & Rezepte".
+  useEffect(() => {
+    if (!eventId) return;
+    setSections((prevSections) => {
+      const hasDrinksSection = prevSections.some((s) => s.name?.toLowerCase() === 'drinks');
+      if (hasDrinksSection) return prevSections;
+      return [...prevSections, createMenuSection('Drinks', [])];
+    });
+  }, [eventId]);
 
   // Load the current user's events while the "Event verknüpfen" picker is open.
   useEffect(() => {
@@ -1076,13 +1105,6 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
               <p className="menu-event-linked-name">
                 {linkedEventLoading ? 'Lädt …' : (linkedEvent?.eventName || 'Verknüpftes Event konnte nicht geladen werden.')}
               </p>
-              {eventDrinkNames.length > 0 && (
-                <ul className="menu-event-drinks-list">
-                  {eventDrinkNames.map((drinkName, index) => (
-                    <li key={`${drinkName}-${index}`} className="menu-event-drinks-item">{drinkName}</li>
-                  ))}
-                </ul>
-              )}
               <div className="menu-drinks-link-actions">
                 <button type="button" className="menu-drinks-link-btn" onClick={() => setFormSubView('linkPicker')}>
                   Event ändern
@@ -1220,6 +1242,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   onRemoveDrinkFromSection={handleRemoveDrinkFromSection}
                   getFilteredDrinkSectionOptions={getFilteredDrinkSectionOptions}
                   getDrinkDisplayName={getDrinkDisplayName}
+                  eventDrinks={section.name?.toLowerCase() === 'drinks' ? eventDrinks : []}
                 />
                 {isMobile && (
                   <div className="add-section-gap">

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -146,7 +146,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     const option = await screen.findByText('Cola');
     fireEvent.click(option);
 
-    expect(await screen.findByText('Manuell hinzugefügte Getränke:')).toBeInTheDocument();
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
     expect(screen.getAllByText('Cola').length).toBeGreaterThan(0);
   });
 
@@ -168,12 +168,12 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     fireEvent.change(drinkInput, { target: { value: 'Cola' } });
     fireEvent.click(await screen.findByText('Cola'));
 
-    expect(await screen.findByText('Manuell hinzugefügte Getränke:')).toBeInTheDocument();
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTitle('Getränk entfernen'));
 
     await waitFor(() => {
-      expect(screen.queryByText('Manuell hinzugefügte Getränke:')).not.toBeInTheDocument();
+      expect(screen.queryByText('Ausgewählte Rezepte & Getränke:')).not.toBeInTheDocument();
     });
   });
 
@@ -232,6 +232,35 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     // Selecting the recipe option adds it to the section's recipe list.
     fireEvent.change(searchInput, { target: { value: 'Mojito' } });
     fireEvent.click(await screen.findByText('Mojito'));
-    expect(await screen.findByText('Ausgewählte Rezepte:')).toBeInTheDocument();
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
+  });
+});
+
+describe('MenuForm - linked event drinks display', () => {
+  test('shows the linked event\'s planned drinks in the Drinks section, not in the header', async () => {
+    mockGetEvent.mockResolvedValue({ id: 'event-1', eventName: 'Testparty', customDrinkIds: ['drink-cola'] });
+    mockGetCustomDrinks.mockResolvedValue(customDrinks);
+
+    render(
+      <MenuForm
+        menu={{
+          id: 'menu-1',
+          name: 'Testmenü',
+          sections: [{ name: 'Drinks', recipeIds: [], drinkIds: [] }],
+          eventId: 'event-1',
+          eventOwnerId: 'user-1',
+        }}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    const linkedEventBlock = (await screen.findByText('Testparty')).closest('.menu-event-linked');
+    expect(linkedEventBlock.querySelector('ul')).not.toBeInTheDocument();
+
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
+    expect(screen.getAllByText('Cola').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Event-planned drinks no longer show up under "Event (für Getränke)" in
the menu edit form's header. Instead they're merged into the Drinks
section's recipe/drink list, along with the manually added drinks
which now share a single "Ausgewählte Rezepte & Getränke" list instead
of two separate ones. A "Drinks" section is auto-created when an event
gets linked so the event's drinks always have somewhere to appear.