### PR TITLE
Fix horizontal overflow revealing gray body background in menu form

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -2,6 +2,7 @@
   max-width: 800px;
   margin: 0 auto;
   padding: 1rem;
+  overflow-x: hidden;
 }
 
 .menu-form-header {
@@ -228,6 +229,8 @@
   margin: 0;
   color: #402C1C;
   font-size: 1.1rem;
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .section-actions {
@@ -324,6 +327,8 @@
 
 .recipe-name {
   flex: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
   font-weight: 500;
   color: #333;
 }


### PR DESCRIPTION
Long section or recipe names without spaces could push flex rows
(.section-header h4, .recipe-name) wider than the viewport since flex
children don't shrink below their content size without min-width: 0.
On iOS Safari this made the light gray body background visible as a
strip on the right edge of the "Menü bearbeiten" screen. Added
overflow-wrap/min-width to let long names wrap, plus overflow-x:
hidden on the form container as a safety net.