### PR TITLE
Synchronisiere Getränke zwischen Menü und verknüpftem Event

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -7,6 +7,7 @@ import {
   subscribeToCustomDrinks,
   subscribeToGuestProfiles,
 } from '../utils/eventsFirestore';
+import { getMenusByEventId, updateMenu } from '../utils/menuFirestore';
 import { getDrinkParentCategoryId, categoryHasOwnBudget, PREDEFINED_DRINKS, mergePredefinedDrinks } from '../utils/drinkCategories';
 import {
   computeGuestPreferenceMultipliers,
@@ -198,6 +199,34 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         pufferProzent: Number(pufferProzent),
       };
       const result = await calculateEventDrinks(event, isEditing ? initialEvent.id : undefined);
+
+      // Drinks removed here should disappear from any menu they were also
+      // added to, so the menu stays in sync with this event's Getränke.
+      // Drinks added here need no extra propagation: a linked menu reads the
+      // event live and already merges its drinks into the "Drinks" section.
+      const removedDrinkIds = (initialEvent?.customDrinkIds ?? []).filter(
+        (id) => !customDrinkIds.includes(id)
+      );
+      if (removedDrinkIds.length > 0 && currentUser?.id) {
+        try {
+          const linkedMenus = await getMenusByEventId(currentUser.id, result.eventId);
+          await Promise.all(linkedMenus.map((linkedMenu) => {
+            let changed = false;
+            const nextSections = (linkedMenu.sections || []).map((section) => {
+              if (!Array.isArray(section.drinkIds) || section.drinkIds.length === 0) return section;
+              const filteredDrinkIds = section.drinkIds.filter((id) => !removedDrinkIds.includes(id));
+              if (filteredDrinkIds.length === section.drinkIds.length) return section;
+              changed = true;
+              return { ...section, drinkIds: filteredDrinkIds };
+            });
+            if (!changed) return null;
+            return updateMenu(linkedMenu.id, { sections: nextSections });
+          }));
+        } catch (err) {
+          console.error('Error syncing removed drinks to linked menus:', err);
+        }
+      }
+
       onSaved(result.eventId);
     } catch (err) {
       console.error('Error calculating event drinks:', err);

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -10,7 +10,7 @@ import { enableMenuSharing, disableMenuSharing } from '../utils/menuFirestore';
 import { scaleIngredient, combineIngredients, convertIngredientUnits, isWaterIngredient } from '../utils/ingredientUtils';
 import { decodeRecipeLink } from '../utils/recipeLinks';
 import { getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
-import { getEvent, getCustomDrinks } from '../utils/eventsFirestore';
+import { subscribeToEvent, subscribeToCustomDrinks, getCustomDrinks } from '../utils/eventsFirestore';
 import { mergePredefinedDrinks } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { getImageForCategory } from '../utils/categoryImages';
@@ -135,27 +135,34 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     loadFavorites();
   }, [currentUser?.id]);
 
-  // Load the linked event's drinks once when the menu is opened (no live sync).
+  // Live-track the linked event's drinks, so changes made on the event side
+  // (or synced back from another menu edit) show up immediately here too.
   useEffect(() => {
     if (!menu.eventId || !menu.eventOwnerId) {
       setLinkedEvent(null);
       setLinkedEventCustomDrinks([]);
       return undefined;
     }
-    let cancelled = false;
     setLinkedEventLoading(true);
-    Promise.all([
-      getEvent(menu.eventOwnerId, menu.eventId),
-      getCustomDrinks(menu.eventOwnerId),
-    ]).then(([event, customDrinks]) => {
-      if (cancelled) return;
+    let firstEventSnapshot = true;
+    let firstDrinksSnapshot = true;
+    const unsubEvent = subscribeToEvent(menu.eventOwnerId, menu.eventId, (event) => {
       setLinkedEvent(event);
-      setLinkedEventCustomDrinks(customDrinks);
-    }).finally(() => {
-      if (!cancelled) setLinkedEventLoading(false);
+      if (firstEventSnapshot) {
+        firstEventSnapshot = false;
+        if (!firstDrinksSnapshot) setLinkedEventLoading(false);
+      }
+    });
+    const unsubDrinks = subscribeToCustomDrinks(menu.eventOwnerId, (drinks) => {
+      setLinkedEventCustomDrinks(drinks);
+      if (firstDrinksSnapshot) {
+        firstDrinksSnapshot = false;
+        if (!firstEventSnapshot) setLinkedEventLoading(false);
+      }
     });
     return () => {
-      cancelled = true;
+      unsubEvent();
+      unsubDrinks();
     };
   }, [menu.eventId, menu.eventOwnerId]);
 

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -730,9 +730,10 @@
   font-weight: 600;
 }
 
-/* Drinks planned via a linked event, shown read-only in the Drinks section's
-   merged "Ausgewählte Rezepte & Getränke" list (no remove button, unlike
-   manually added drinks). */
+/* Drinks planned via a linked event, shown in the Drinks section's merged
+   "Ausgewählte Rezepte & Getränke" list. Removing one here also removes it
+   from the linked event's customDrinkIds (and recalculates its
+   Getränkeverteilung) once the menu is saved. */
 .selected-recipe-item.event-drink-item {
   background: #f3ede6;
 }

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -8,8 +8,8 @@ import { fileToBase64, compressImage, selectMenuGridImages, buildMenuGridImage, 
 import { uploadMenuGridImage, uploadMenuGridImageDark, deleteMenuGridImage, deleteMenuGridImageDark, isStorageUrl } from '../utils/storageUtils';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getButtonIcons } from '../utils/customLists';
 import { getCategoryImages } from '../utils/categoryImages';
-import { getEvent, subscribeToEvents, getCustomDrinks, subscribeToCustomDrinks, saveCustomDrink } from '../utils/eventsFirestore';
-import { mergePredefinedDrinks } from '../utils/drinkCategories';
+import { subscribeToEvent, subscribeToEvents, subscribeToCustomDrinks, saveCustomDrink, calculateEventDrinks } from '../utils/eventsFirestore';
+import { mergePredefinedDrinks, getDrinkParentCategoryId, categoryHasOwnBudget } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { encodeRecipeLink, decodeRecipeLink } from '../utils/recipeLinks';
 import EventForm from './EventForm';
@@ -59,7 +59,7 @@ function SortableSection({
   onSearchChange, onAddRecipeToSection, getFilteredRecipes,
   isDrinksSection, drinkSearchQueries, onDrinkSearchChange, onAddDrinkToSection,
   onAddRecipeToDrinksSection, onRemoveDrinkFromSection, getFilteredDrinkSectionOptions,
-  getDrinkDisplayName, eventDrinks = [],
+  getDrinkDisplayName, eventDrinks = [], onRemoveEventDrink,
 }) {
   const {
     attributes,
@@ -152,6 +152,14 @@ function SortableSection({
               {dedupedEventDrinks.map((drink) => (
                 <div key={`event-drink-${drink.id}`} className="selected-recipe-item event-drink-item">
                   <span className="recipe-name">{drink.displayName}</span>
+                  <button
+                    type="button"
+                    className="remove-recipe-button"
+                    onClick={() => onRemoveEventDrink(drink.id)}
+                    title="Getränk aus Event entfernen"
+                  >
+                    ×
+                  </button>
                 </div>
               ))}
               {manualDrinkIds.map(drinkId => (
@@ -350,6 +358,9 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const [linkedEvent, setLinkedEvent] = useState(null);
   const [linkedEventLoading, setLinkedEventLoading] = useState(false);
   const [linkedEventCustomDrinks, setLinkedEventCustomDrinks] = useState([]);
+  // Drinks the user removed from the linked event via this menu's "Drinks"
+  // section, staged locally until the menu is saved (see handleSubmit).
+  const [removedEventDrinkIds, setRemovedEventDrinkIds] = useState([]);
   const [availableEvents, setAvailableEvents] = useState([]);
   const [userCustomDrinks, setUserCustomDrinks] = useState([]);
   const [drinkSearchQueries, setDrinkSearchQueries] = useState({});
@@ -407,29 +418,43 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  // Load the name and drinks of the currently linked event, if any.
+  // Live-track the name and drinks of the currently linked event, so any
+  // change made on the event side (add/remove drink, recalculation) shows up
+  // here immediately without having to reopen the menu.
   useEffect(() => {
     if (!eventId || !eventOwnerId) {
       setLinkedEvent(null);
       setLinkedEventCustomDrinks([]);
       return undefined;
     }
-    let cancelled = false;
     setLinkedEventLoading(true);
-    Promise.all([
-      getEvent(eventOwnerId, eventId),
-      getCustomDrinks(eventOwnerId),
-    ]).then(([event, customDrinks]) => {
-      if (cancelled) return;
+    let firstEventSnapshot = true;
+    let firstDrinksSnapshot = true;
+    const unsubEvent = subscribeToEvent(eventOwnerId, eventId, (event) => {
       setLinkedEvent(event);
-      setLinkedEventCustomDrinks(customDrinks);
-    }).finally(() => {
-      if (!cancelled) setLinkedEventLoading(false);
+      if (firstEventSnapshot) {
+        firstEventSnapshot = false;
+        if (!firstDrinksSnapshot) setLinkedEventLoading(false);
+      }
+    });
+    const unsubDrinks = subscribeToCustomDrinks(eventOwnerId, (drinks) => {
+      setLinkedEventCustomDrinks(drinks);
+      if (firstDrinksSnapshot) {
+        firstDrinksSnapshot = false;
+        if (!firstEventSnapshot) setLinkedEventLoading(false);
+      }
     });
     return () => {
-      cancelled = true;
+      unsubEvent();
+      unsubDrinks();
     };
   }, [eventId, eventOwnerId]);
+
+  // Discard any pending "remove drink from event" staging when switching to a
+  // different (or no) linked event.
+  useEffect(() => {
+    setRemovedEventDrinkIds([]);
+  }, [eventId]);
 
   // Drinks assigned via the linked event. Shown read-only inside the menu's
   // "Drinks" section (never in the header) alongside the manually added ones.
@@ -498,6 +523,9 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       ...drinkSearchQueries,
       [sectionIndex]: ''
     });
+    // Re-adding a drink that was staged for removal from the event cancels
+    // that removal.
+    setRemovedEventDrinkIds((prev) => prev.filter((id) => id !== drinkId));
   };
 
   const handleRemoveDrinkFromSection = (sectionIndex, drinkId) => {
@@ -505,6 +533,13 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       if (i !== sectionIndex) return s;
       return { ...s, drinkIds: (s.drinkIds || []).filter((id) => id !== drinkId) };
     }));
+  };
+
+  // Stages the removal of one of the linked event's drinks; it's actually
+  // removed from the event (and the event's Getränkeverteilung recalculated)
+  // once the menu is saved, see handleSubmit.
+  const handleRemoveEventDrink = (drinkId) => {
+    setRemovedEventDrinkIds((prev) => (prev.includes(drinkId) ? prev : [...prev, drinkId]));
   };
 
   // Merged search results for the Drinks section's single search field:
@@ -534,8 +569,9 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     return fuzzyFilter(combinedOptions, query, (option) => option.searchLabel);
   };
 
-  // Manually added drinks in the "Drinks" section, used to pre-fill a newly
-  // created event's drink selection so nothing has to be re-entered there.
+  // Manually added drinks in the "Drinks" section. Used both to pre-fill a
+  // newly created event's drink selection and, on every save, to sync this
+  // menu's drinks into an already-linked event (see handleSubmit).
   const drinksSectionManualDrinkIds = useMemo(() => {
     const ids = [];
     sections.forEach((s) => {
@@ -549,8 +585,9 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   }, [sections]);
 
   // Drink recipes (recipes tagged with the "Drinks" Speisekategorie) added to
-  // the "Drinks" section, used to pre-fill a newly created event's drink
-  // selection alongside the manually added drinks above.
+  // the "Drinks" section. Used to pre-fill a newly created event's drink
+  // selection alongside the manually added drinks above, and (via
+  // ensureDrinkForRecipe) synced into an already-linked event on every save.
   const drinksSectionRecipeIds = useMemo(() => {
     const ids = [];
     sections.forEach((s) => {
@@ -946,6 +983,60 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
         sectionsCount: menuData.sections.length,
         recipeIdsCount: menuData.recipeIds.length,
       });
+
+      // Keep the linked event's drinks in sync with this menu's "Drinks"
+      // section: every manually added/removed drink (and every drink recipe)
+      // here is mirrored into the event's customDrinkIds, and its
+      // Getränkeverteilung is recalculated to match. Drinks that live only on
+      // the event side (never touched from the menu) are left untouched.
+      // Only possible when the current user owns the linked event, since the
+      // calculateEventDrinks Cloud Function only ever writes to the caller's
+      // own events collection.
+      if (eventId && linkedEvent && eventOwnerId === currentUser?.id) {
+        try {
+          const recipeDrinkIds = await Promise.all(drinksSectionRecipeIds.map(ensureDrinkForRecipe));
+          const existingEventDrinkIds = Array.isArray(linkedEvent.customDrinkIds) ? linkedEvent.customDrinkIds : [];
+          const targetDrinkIds = existingEventDrinkIds.filter((id) => !removedEventDrinkIds.includes(id));
+          [...drinksSectionManualDrinkIds, ...recipeDrinkIds].forEach((id) => {
+            if (id && !targetDrinkIds.includes(id)) targetDrinkIds.push(id);
+          });
+
+          const drinksChanged =
+            targetDrinkIds.length !== existingEventDrinkIds.length ||
+            targetDrinkIds.some((id) => !existingEventDrinkIds.includes(id));
+
+          if (drinksChanged) {
+            const drinkDistributionFactors = { ...(linkedEvent.drinkDistributionFactors || {}) };
+            const drinkSelectedEinheiten = { ...(linkedEvent.drinkSelectedEinheiten || {}) };
+            Object.keys(drinkDistributionFactors).forEach((id) => {
+              if (!targetDrinkIds.includes(id)) delete drinkDistributionFactors[id];
+            });
+            Object.keys(drinkSelectedEinheiten).forEach((id) => {
+              if (!targetDrinkIds.includes(id)) delete drinkSelectedEinheiten[id];
+            });
+
+            const { id: _linkedEventId, berechnung: _berechnung, ...eventFields } = linkedEvent;
+            const allEventDrinks = mergePredefinedDrinks(linkedEventCustomDrinks);
+            const categories = [...new Set(
+              targetDrinkIds
+                .map((drinkId) => allEventDrinks.find((d) => d.id === drinkId)?.kategorie)
+                .filter(Boolean)
+                .map((categoryId) => (categoryHasOwnBudget(categoryId) ? categoryId : getDrinkParentCategoryId(categoryId) || categoryId))
+            )];
+            console.log('[MenuForm:handleSubmit] Syncing drinks to linked event and recalculating Getränkeverteilung:', targetDrinkIds);
+            await calculateEventDrinks({
+              ...eventFields,
+              customDrinkIds: targetDrinkIds,
+              drinkDistributionFactors,
+              drinkSelectedEinheiten,
+              categories,
+            }, eventId);
+          }
+        } catch (err) {
+          console.error('[MenuForm:handleSubmit] Fehler beim Synchronisieren der Event-Getränke:', err);
+        }
+      }
+
       console.log('=== [MenuForm:handleSubmit] END (%.1fms) ===', performance.now() - t0);
 
       onSave(menuData);
@@ -1303,7 +1394,10 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   onRemoveDrinkFromSection={handleRemoveDrinkFromSection}
                   getFilteredDrinkSectionOptions={getFilteredDrinkSectionOptions}
                   getDrinkDisplayName={getDrinkDisplayName}
-                  eventDrinks={section.name?.toLowerCase() === 'drinks' ? eventDrinks : []}
+                  eventDrinks={section.name?.toLowerCase() === 'drinks'
+                    ? eventDrinks.filter((drink) => !removedEventDrinkIds.includes(drink.id))
+                    : []}
+                  onRemoveEventDrink={handleRemoveEventDrink}
                 />
                 {isMobile && (
                   <div className="add-section-gap">

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -4,9 +4,9 @@ import MenuForm from './MenuForm';
 
 const mockSubscribeToCustomDrinks = jest.fn();
 const mockSubscribeToEvents = jest.fn();
-const mockGetEvent = jest.fn();
-const mockGetCustomDrinks = jest.fn();
+const mockSubscribeToEvent = jest.fn();
 const mockSaveCustomDrink = jest.fn();
+const mockCalculateEventDrinks = jest.fn();
 
 jest.mock('../utils/userFavorites', () => ({
   getUserFavorites: () => Promise.resolve([]),
@@ -49,11 +49,11 @@ jest.mock('../utils/categoryImages', () => ({
 }));
 
 jest.mock('../utils/eventsFirestore', () => ({
-  getEvent: (...args) => mockGetEvent(...args),
+  subscribeToEvent: (...args) => mockSubscribeToEvent(...args),
   subscribeToEvents: (...args) => mockSubscribeToEvents(...args),
-  getCustomDrinks: (...args) => mockGetCustomDrinks(...args),
   subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
   saveCustomDrink: (...args) => mockSaveCustomDrink(...args),
+  calculateEventDrinks: (...args) => mockCalculateEventDrinks(...args),
 }));
 
 jest.mock('./DrinkManagementPage', () => function MockDrinkManagementPage() {
@@ -124,6 +124,7 @@ beforeEach(() => {
     return () => {};
   });
   mockSubscribeToEvents.mockImplementation(() => () => {});
+  mockSubscribeToEvent.mockImplementation(() => () => {});
   mockSaveCustomDrink.mockResolvedValue('drink-new-mojito');
 });
 
@@ -316,8 +317,10 @@ describe('MenuForm - Drinks section manual drink selection', () => {
 
 describe('MenuForm - linked event drinks display', () => {
   test('shows the linked event\'s planned drinks in the Drinks section, not in the header', async () => {
-    mockGetEvent.mockResolvedValue({ id: 'event-1', eventName: 'Testparty', customDrinkIds: ['drink-cola'] });
-    mockGetCustomDrinks.mockResolvedValue(customDrinks);
+    mockSubscribeToEvent.mockImplementation((uid, eventId, callback) => {
+      callback({ id: 'event-1', eventName: 'Testparty', customDrinkIds: ['drink-cola'] });
+      return () => {};
+    });
 
     render(
       <MenuForm
@@ -347,8 +350,14 @@ describe('MenuForm - linked event drinks display', () => {
     // a drink recipe already in the "Drinks" section gets a matching custom
     // drink (linked via "#recipe:id:name") added to the event's customDrinkIds.
     const linkedDrink = { id: 'drink-mojito-link', name: '#recipe:recipe-2:Mojito', kategorie: null, einheiten: [{ einheitsgroesse: 0.5 }] };
-    mockGetEvent.mockResolvedValue({ id: 'event-1', eventName: 'Testparty', customDrinkIds: [linkedDrink.id] });
-    mockGetCustomDrinks.mockResolvedValue([linkedDrink]);
+    mockSubscribeToEvent.mockImplementation((uid, eventId, callback) => {
+      callback({ id: 'event-1', eventName: 'Testparty', customDrinkIds: [linkedDrink.id] });
+      return () => {};
+    });
+    mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+      callback([linkedDrink]);
+      return () => {};
+    });
 
     render(
       <MenuForm

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -65,6 +65,24 @@ export const subscribeToEvents = (uid, callback) => {
 };
 
 /**
+ * Set up a real-time listener for a single event, so callers (e.g. a linked
+ * menu) always see the event's current drinks and Getränkeverteilung.
+ * @param {string} uid - Owner of the event
+ * @param {string} eventId - ID of the event
+ * @param {Function} callback - Receives the event ({ id, ...data }) or null if it doesn't exist
+ * @returns {Function} Unsubscribe function
+ */
+export const subscribeToEvent = (uid, eventId, callback) => {
+  const eventRef = doc(db, 'users', uid, 'events', eventId);
+  return onSnapshot(eventRef, (snap) => {
+    callback(snap.exists() ? { id: snap.id, ...snap.data() } : null);
+  }, (error) => {
+    console.error('Error subscribing to event:', error);
+    callback(null);
+  });
+};
+
+/**
  * Get a single event by ID (one-time fetch).
  * @param {string} uid - Current user ID
  * @param {string} eventId - ID of the event

--- a/src/utils/menuFirestore.js
+++ b/src/utils/menuFirestore.js
@@ -183,6 +183,24 @@ export const deleteMenu = async (menuId) => {
 };
 
 /**
+ * Get all menus linked to a given event (one-time fetch).
+ * @param {string} eventOwnerId - uid of the event's owner (menu.eventOwnerId)
+ * @param {string} eventId - ID of the linked event (menu.eventId)
+ * @returns {Promise<Array>} Promise resolving to the linked menus
+ */
+export const getMenusByEventId = async (eventOwnerId, eventId) => {
+  try {
+    const menusRef = collection(db, 'menus');
+    const q = query(menusRef, where('eventId', '==', eventId), where('eventOwnerId', '==', eventOwnerId));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+  } catch (error) {
+    console.error('Error getting menus by eventId:', error);
+    return [];
+  }
+};
+
+/**
  * Get a menu by its shareId (public access, no authentication required)
  * @param {string} shareId - The shareId of the menu
  * @returns {Promise<Object|null>} Promise resolving to the menu or null if not found


### PR DESCRIPTION
Fügt man am Menü im "Drinks"-Abschnitt ein Getränk hinzu oder entfernt
eines (manuell oder als Getränke-Rezept), wird beim Speichern des Menüs
das verknüpfte Event aktualisiert und dessen Getränkeverteilung über
calculateEventDrinks neu berechnet. Entfernt man umgekehrt ein Getränk
am Event, verschwindet es auch aus dem/den verknüpften Menü(s).

Menü und Event zeigen jetzt außerdem live den aktuellen Stand des
jeweils anderen (subscribeToEvent statt einmaligem getEvent-Fetch), so
dass Änderungen ohne erneutes Öffnen sichtbar werden.