### PR TITLE
Getränk aus Drinks-Abschnitt beim ersten Klick vollständig entfernen

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1072,9 +1072,21 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   };
 
   const handleRemoveRecipeFromSection = (sectionIndex, recipeId) => {
-    const newSections = [...sections];
-    newSections[sectionIndex].recipeIds = newSections[sectionIndex].recipeIds.filter(id => id !== recipeId);
-    setSections(newSections);
+    // If this recipe is a drink recipe deduped against a linked event drink
+    // (see the `eventDrinks` useMemo above), removing it here would only
+    // hide the recipe entry - the event drink would then reappear as its
+    // own entry (dedup no longer applies) and need a second click to
+    // actually go away. Stage its removal too so both disappear together.
+    const section = sections[sectionIndex];
+    if (section?.name?.toLowerCase() === 'drinks') {
+      const linkedEventDrink = eventDrinks.find((drink) => drink.recipeId === recipeId);
+      if (linkedEventDrink) {
+        setRemovedEventDrinkIds((prev) => (prev.includes(linkedEventDrink.id) ? prev : [...prev, linkedEventDrink.id]));
+      }
+    }
+    setSections((prevSections) => prevSections.map((s, i) => (
+      i === sectionIndex ? { ...s, recipeIds: s.recipeIds.filter((id) => id !== recipeId) } : s
+    )));
   };
 
   const handleDragEndRecipes = (sectionIndex, event) => {

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -378,4 +378,44 @@ describe('MenuForm - linked event drinks display', () => {
     expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
     expect(screen.getAllByText('Mojito')).toHaveLength(1);
   });
+
+  test('removing a drink recipe deduped against a linked event drink removes it in one click, not two', async () => {
+    // Same setup as above: the recipe's linked drink is deduped away, so
+    // only the recipe's own "x" is shown. Clicking it used to just drop the
+    // recipe, leaving the now-undeduped event drink behind as a second
+    // entry with its own "x" - requiring a second click to fully remove it.
+    const linkedDrink = { id: 'drink-mojito-link', name: '#recipe:recipe-2:Mojito', kategorie: null, einheiten: [{ einheitsgroesse: 0.5 }] };
+    mockSubscribeToEvent.mockImplementation((uid, eventId, callback) => {
+      callback({ id: 'event-1', eventName: 'Testparty', customDrinkIds: [linkedDrink.id] });
+      return () => {};
+    });
+    mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+      callback([linkedDrink]);
+      return () => {};
+    });
+
+    render(
+      <MenuForm
+        menu={{
+          id: 'menu-1',
+          name: 'Testmenü',
+          sections: [{ name: 'Drinks', recipeIds: ['recipe-2'], drinkIds: [] }],
+          eventId: 'event-1',
+          eventOwnerId: 'user-1',
+        }}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
+    expect(screen.queryByTitle('Getränk aus Event entfernen')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Rezept entfernen'));
+
+    expect(screen.queryByText('Mojito')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Getränk aus Event entfernen')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Ein Getränke-Rezept, dessen verlinktes Event-Getränk gegen dieses
Rezept gededuped wurde, zeigte beim Entfernen nur den einen sichtbaren
"×" - der Klick löschte lediglich das Rezept. Das dahinterliegende
Event-Getränk war dadurch nicht mehr gededuped und tauchte als eigener
Eintrag mit eigenem "×" erneut auf, sodass ein zweiter Klick nötig war,
damit das Getränk wirklich verschwindet. handleRemoveRecipeFromSection
staged jetzt zusätzlich die Entfernung des verlinkten Event-Getränks.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N1fQ4Td3356baJs6ZwAjSr