### PR TITLE
Getränk aus Drinks-Abschnitt bei Event-Dopplung beim ersten Klick entfernen

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -540,6 +540,18 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   // once the menu is saved, see handleSubmit.
   const handleRemoveEventDrink = (drinkId) => {
     setRemovedEventDrinkIds((prev) => (prev.includes(drinkId) ? prev : [...prev, drinkId]));
+    // The same drink can also sit in a section's own drinkIds (manualDrinkIds
+    // is deduped by id against the event drinks, so only the merged
+    // event-drink entry was visible). Leaving it there would make it
+    // resurface as its own manual entry - with its own "x" - as soon as this
+    // one is filtered out, needing a second click to actually remove it, and
+    // would re-add it to the event's customDrinkIds on save via
+    // drinksSectionManualDrinkIds. Strip it from every section too.
+    setSections((prevSections) => prevSections.map((s) => (
+      (s.drinkIds || []).includes(drinkId)
+        ? { ...s, drinkIds: s.drinkIds.filter((id) => id !== drinkId) }
+        : s
+    )));
   };
 
   // Merged search results for the Drinks section's single search field:

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -418,4 +418,43 @@ describe('MenuForm - linked event drinks display', () => {
     expect(screen.queryByText('Mojito')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Getränk aus Event entfernen')).not.toBeInTheDocument();
   });
+
+  test('removing a drink that is both manually added and in the linked event removes it in one click, not two', async () => {
+    // The same drinkId ("drink-cola") sits both in the section's own
+    // drinkIds (manually added) and in the linked event's customDrinkIds.
+    // manualDrinkIds dedupes it away by id, so only the merged event-drink
+    // entry (and its "Getränk aus Event entfernen" x) is shown. Clicking it
+    // used to only stage removal from the event, leaving the untouched
+    // section.drinkIds entry to resurface as its own manual entry - with its
+    // own "x" - requiring a second click to fully remove it.
+    mockSubscribeToEvent.mockImplementation((uid, eventId, callback) => {
+      callback({ id: 'event-1', eventName: 'Testparty', customDrinkIds: ['drink-cola'] });
+      return () => {};
+    });
+
+    render(
+      <MenuForm
+        menu={{
+          id: 'menu-1',
+          name: 'Testmenü',
+          sections: [{ name: 'Drinks', recipeIds: [], drinkIds: ['drink-cola'] }],
+          eventId: 'event-1',
+          eventOwnerId: 'user-1',
+        }}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
+    expect(screen.getAllByText('Cola')).toHaveLength(1);
+    expect(screen.queryByTitle('Getränk entfernen')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Getränk aus Event entfernen'));
+
+    expect(screen.queryByText('Cola')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Getränk entfernen')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Ein manuell hinzugefügtes Getränk, dessen Id auch im verlinkten Event
vorkommt, wurde im Abschnitt nur einmal (als Event-Getränk) angezeigt,
da manualDrinkIds per Id gegen die Event-Getränke gededuped wird. Klick
auf dessen "×" entfernte es aber nur aus dem Event - der unveränderte
Eintrag in section.drinkIds tauchte danach als eigenes Getränk mit
eigenem "×" erneut auf und wurde beim Speichern sogar wieder ins Event
zurückgeschrieben. handleRemoveEventDrink entfernt die Id jetzt auch aus
den drinkIds aller Abschnitte.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AqDWAnEjN7WnK5eHgpVN2V