### PR TITLE
Hide recipe-linked drinks from Drinks section search to avoid duplicates

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -570,6 +570,10 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
 
     const drinkOptions = allDrinks
       .filter((drink) => !selectedDrinkIds.includes(drink.id))
+      // Drinks linked to a recipe (via "#recipe:id:name") are already
+      // offered as their underlying recipe in recipeOptions above - listing
+      // both would show the same name twice.
+      .filter((drink) => !decodeRecipeLink(drink.name))
       .map((drink) => ({ type: 'drink', id: drink.id, drink, searchLabel: resolveDrinkDisplay(drink, recipes).displayName }));
 
     const combinedOptions = [...recipeOptions, ...drinkOptions];

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -282,6 +282,39 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     expect(mockSaveCustomDrink).not.toHaveBeenCalled();
   });
 
+  test('does not list a drink linked to a recipe separately from that recipe (avoids duplicates)', async () => {
+    const existingLinkedDrink = {
+      id: 'drink-existing-mojito',
+      name: '#recipe:recipe-2:Mojito',
+      kategorie: null,
+      einheiten: [{ einheitsgroesse: 0.3 }],
+    };
+    mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+      callback([...customDrinks, existingLinkedDrink]);
+      return () => {};
+    });
+
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const searchInput = await screen.findByPlaceholderText('Rezept oder Getränk suchen und hinzufügen...');
+    fireEvent.change(searchInput, { target: { value: 'Mojito' } });
+
+    // The recipe "Mojito" and the drink linked to it via "#recipe:..." would
+    // otherwise both match - only the recipe should be listed.
+    expect(await screen.findAllByText('Mojito')).toHaveLength(1);
+  });
+
   test('merged search offers Drinks-category recipes and event drinks, but not other recipes', async () => {
     render(
       <MenuForm


### PR DESCRIPTION
A custom drink created for a drink recipe (via the "#recipe:id:name" link)
was listed in the merged search alongside its underlying recipe, showing
the same name twice. Filter those linked drinks out of the drink options
since the recipe option already covers them.