### PR TITLE
Resize-Griff der Beschreibungs-Textarea im Menüformular entfernen

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -74,7 +74,7 @@
 }
 
 .form-group textarea {
-  resize: vertical;
+  resize: none;
   min-height: 80px;
 }
 


### PR DESCRIPTION
Das native resize: vertical erzeugte auf iOS/WebKit einen sichtbaren Griff am rechten Rand, der wie ein unklares UI-Element wirkte.