### PR TITLE
Filter orphaned recipeIds from menu section's sortable items

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -105,19 +105,26 @@ function SortableSection({
   const manualDrinkIds = (section.drinkIds || []).filter((drinkId) => !eventDrinkIds.includes(drinkId));
   const hasSelectedRecipesOrDrinks = section.recipeIds.length > 0 || dedupedEventDrinks.length > 0 || manualDrinkIds.length > 0;
 
-  const selectedRecipesList = section.recipeIds.length > 0 && (
+  // section.recipeIds can contain ids of recipes that no longer resolve (e.g.
+  // deleted or no longer visible to this user); those are skipped below and
+  // render nothing. SortableContext's `items` must match the actually
+  // rendered nodes exactly, or dnd-kit's items.indexOf(id) lookups go out of
+  // sync with real DOM order and every handle after the gap gets a wrong,
+  // displaced transform even at rest.
+  const renderableRecipeIds = section.recipeIds.filter(recipeId => recipes.some(r => r.id === recipeId));
+
+  const selectedRecipesList = renderableRecipeIds.length > 0 && (
     <DndContext
       sensors={recipeSensors}
       collisionDetection={closestCenter}
       onDragEnd={(event) => onDragEndRecipes(sectionIndex, event)}
     >
       <SortableContext
-        items={section.recipeIds}
+        items={renderableRecipeIds}
         strategy={verticalListSortingStrategy}
       >
-        {section.recipeIds.map(recipeId => {
+        {renderableRecipeIds.map(recipeId => {
           const recipe = recipes.find(r => r.id === recipeId);
-          if (!recipe) return null;
           const isFavorite = favoriteIds.includes(recipe.id);
           return (
             <SortableRecipeItem

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -70,8 +70,12 @@ jest.mock('@dnd-kit/core', () => ({
   useSensors: jest.fn(() => []),
 }));
 
+const mockSortableContextItemsCalls = [];
 jest.mock('@dnd-kit/sortable', () => ({
-  SortableContext: ({ children }) => <div>{children}</div>,
+  SortableContext: ({ children, items }) => {
+    mockSortableContextItemsCalls.push(items);
+    return <div>{children}</div>;
+  },
   arrayMove: jest.fn((array, oldIndex, newIndex) => {
     const newArray = [...array];
     const [item] = newArray.splice(oldIndex, 1);
@@ -118,6 +122,7 @@ const recipes = [
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockSortableContextItemsCalls.length = 0;
   capturedEventFormProps = null;
   mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
     callback(customDrinks);
@@ -489,5 +494,30 @@ describe('MenuForm - linked event drinks display', () => {
 
     expect(screen.queryByText('Cola')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Getränk entfernen')).not.toBeInTheDocument();
+  });
+});
+
+describe('MenuForm - recipe drag-and-drop items', () => {
+  test('excludes recipeIds with no matching recipe from the sortable items list, so dnd-kit\'s index lookups stay aligned with the rendered handles', async () => {
+    render(
+      <MenuForm
+        menu={{
+          id: 'menu-1',
+          name: 'Testmenü',
+          sections: [{ name: 'Hauptspeise', recipeIds: ['recipe-1', 'recipe-deleted'] }],
+        }}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    await screen.findByText('Nudelsalat');
+
+    const recipeItemsCall = mockSortableContextItemsCalls.find(
+      (items) => Array.isArray(items) && items.includes('recipe-1')
+    );
+    expect(recipeItemsCall).toEqual(['recipe-1']);
   });
 });


### PR DESCRIPTION
The previous fix for the "Abschnitt/Rezept verschieben" displaced-handle
bug gave each nested DndContext its own sensor instances, but that never
addressed the actual root cause: SortableContext's `items` prop must
match the rendered DOM order exactly, since dnd-kit computes each
useSortable's index via items.indexOf(id). section.recipeIds can contain
ids of recipes no longer present in the `recipes` prop (deleted, no
longer visible, or not yet loaded), which were skipped during render but
still included in `items` - a mismatch that permanently miscalculates
the transform of every handle after the gap, even at rest.

Filter recipeIds down to ones that actually resolve to a recipe before
passing them to SortableContext and rendering, so items always matches
the DOM 1:1.