### PR TITLE
Move linked-event button into the Drinks section and open it directly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -322,6 +322,7 @@ function App() {
   const [menus, setMenus] = useState([]);
   const [selectedMenu, setSelectedMenu] = useState(null);
   const [pendingEventDetailRequest, setPendingEventDetailRequest] = useState(null);
+  const [menuBeforeEventDetail, setMenuBeforeEventDetail] = useState(null);
   const [isMenuFormOpen, setIsMenuFormOpen] = useState(false);
   const [editingMenu, setEditingMenu] = useState(null);
   const [groups, setGroups] = useState([]);
@@ -1296,8 +1297,17 @@ function App() {
 
   const handleOpenMenuEvent = (eventOwnerId, eventId) => {
     if (!eventId) return;
+    setMenuBeforeEventDetail(selectedMenu);
     setPendingEventDetailRequest({ ownerId: eventOwnerId, eventId });
     handleViewChange('events');
+  };
+
+  // Closing the event card that was opened from a menu's Drinks section should
+  // return to that menu instead of the events overview.
+  const handleCloseLinkedEventDetail = () => {
+    if (!menuBeforeEventDetail) return;
+    setSelectedMenu(menuBeforeEventDetail);
+    setMenuBeforeEventDetail(null);
   };
 
   const handleAddMenu = () => {
@@ -2077,6 +2087,7 @@ function App() {
           }}
           pendingEventDetailRequest={pendingEventDetailRequest}
           onPendingEventDetailRequestHandled={() => setPendingEventDetailRequest(null)}
+          onCloseLinkedEventDetail={handleCloseLinkedEventDetail}
         />
         ) : currentView === 'tagesmenu' ? (
         <Tagesmenu

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -91,7 +91,14 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [subView, setSubView] = useState('list'); // list | new | edit | detail | consumption | drinks | guests
+  // Deep links (push notification reminder, menu's "open linked event" button) know their
+  // target subView before the event data has loaded, so start there instead of flashing
+  // the full events overview first.
+  const [subView, setSubView] = useState(() => {
+    if (pendingEventDetailRequest?.eventId) return 'detail';
+    if (pendingEventReminderId) return 'consumption';
+    return 'list';
+  }); // list | new | edit | detail | consumption | drinks | guests
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [fallbackEvent, setFallbackEvent] = useState(null); // used right after calculation, before onSnapshot syncs
 
@@ -133,7 +140,11 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     if (!pendingEventReminderId || !currentUser?.id) return;
     let cancelled = false;
     getEvent(currentUser.id, pendingEventReminderId).then((event) => {
-      if (cancelled || !event) return;
+      if (cancelled) return;
+      if (!event) {
+        setSubView('list');
+        return;
+      }
       setFallbackEvent(event);
       setSelectedEventId(event.id);
       setSubView('consumption');
@@ -155,7 +166,11 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     }
     let cancelled = false;
     getEvent(ownerId, eventId).then((event) => {
-      if (cancelled || !event) return;
+      if (cancelled) return;
+      if (!event) {
+        setSubView('list');
+        return;
+      }
       setFallbackEvent(event);
       setSelectedEventId(event.id);
       setSubView('detail');
@@ -390,6 +405,16 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             )}
           </button>
         )}
+      </div>
+    );
+  }
+
+  // Deep link data (see effects above) hasn't resolved yet: show a lightweight loading
+  // state instead of falling through to the full events overview below.
+  if ((subView === 'detail' || subView === 'consumption') && !selectedEvent) {
+    return (
+      <div className="events-page-container">
+        <div className="events-empty-state">Laden...</div>
       </div>
     );
   }

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -84,7 +84,7 @@ const formatDrinkSummary = (berechnung) => {
     .join(', ');
 };
 
-function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPendingEventReminderHandled, pendingEventDetailRequest, onPendingEventDetailRequestHandled }) {
+function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPendingEventReminderHandled, pendingEventDetailRequest, onPendingEventDetailRequestHandled, onCloseLinkedEventDetail }) {
   const [isMobileView, setIsMobileView] = useState(() => window.innerWidth <= 768);
   const [editFabPressed, setEditFabPressed] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
@@ -99,6 +99,9 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     if (pendingEventReminderId) return 'consumption';
     return 'list';
   }); // list | new | edit | detail | consumption | drinks | guests
+  // Tracks whether the current detail view was opened via the deep link from a menu's
+  // Drinks section, so closing it can return to that menu instead of the events list.
+  const [openedFromMenuLink, setOpenedFromMenuLink] = useState(() => !!pendingEventDetailRequest?.eventId);
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [fallbackEvent, setFallbackEvent] = useState(null); // used right after calculation, before onSnapshot syncs
 
@@ -164,11 +167,13 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       onPendingEventDetailRequestHandled?.();
       return;
     }
+    setOpenedFromMenuLink(true);
     let cancelled = false;
     getEvent(ownerId, eventId).then((event) => {
       if (cancelled) return;
       if (!event) {
         setSubView('list');
+        setOpenedFromMenuLink(false);
         return;
       }
       setFallbackEvent(event);
@@ -188,6 +193,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const editEventIcon = getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode);
 
   const handleSelectEvent = (event) => {
+    setOpenedFromMenuLink(false);
     setSelectedEventId(event.id);
     setFallbackEvent(event);
     setSubView('detail');
@@ -285,9 +291,18 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
           <h2>{selectedEvent.eventName}</h2>
           <button
             className="events-close-btn"
-            onClick={() => { setSubView('list'); setSelectedEventId(null); setFallbackEvent(null); }}
-            aria-label="Zurück zur Liste"
-            title="Zurück zur Liste"
+            onClick={() => {
+              if (openedFromMenuLink && onCloseLinkedEventDetail) {
+                setOpenedFromMenuLink(false);
+                onCloseLinkedEventDetail();
+                return;
+              }
+              setSubView('list');
+              setSelectedEventId(null);
+              setFallbackEvent(null);
+            }}
+            aria-label={openedFromMenuLink ? 'Zurück zum Menü' : 'Zurück zur Liste'}
+            title={openedFromMenuLink ? 'Zurück zum Menü' : 'Zurück zur Liste'}
           >
             ×
           </button>

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -160,6 +160,70 @@ describe('EventsPage', () => {
     expect(screen.queryByText('Anderes Event')).toBeNull();
   });
 
+  test('closing an event opened via pendingEventDetailRequest calls onCloseLinkedEventDetail instead of showing the events list', async () => {
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([]);
+      return jest.fn();
+    });
+    const linkedEvent = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    mockGetEvent.mockResolvedValue(linkedEvent);
+    const onCloseLinkedEventDetail = jest.fn();
+
+    render(
+      <EventsPage
+        currentUser={currentUser}
+        pendingEventDetailRequest={{ ownerId: 'owner-1', eventId: 'e1' }}
+        onPendingEventDetailRequestHandled={() => {}}
+        onCloseLinkedEventDetail={onCloseLinkedEventDetail}
+      />
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Sommerfest' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Zurück zum Menü'));
+
+    expect(onCloseLinkedEventDetail).toHaveBeenCalledTimes(1);
+    // The events overview must not appear after closing back to the menu.
+    expect(screen.queryByRole('heading', { name: 'Events' })).toBeNull();
+  });
+
+  test('closing an event opened from the list falls back to the events overview, not onCloseLinkedEventDetail', () => {
+    const event = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([event]);
+      return jest.fn();
+    });
+    const onCloseLinkedEventDetail = jest.fn();
+
+    render(<EventsPage currentUser={currentUser} onCloseLinkedEventDetail={onCloseLinkedEventDetail} />);
+
+    fireEvent.click(screen.getByText('Sommerfest'));
+    expect(screen.getByTitle('Zurück zur Liste')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Zurück zur Liste'));
+
+    expect(onCloseLinkedEventDetail).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
+  });
+
   test('shows mobile edit FAB in detail view and removes inline edit and delete buttons', () => {
     Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 480 });
     window.dispatchEvent(new Event('resize'));

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import EventsPage from './EventsPage';
 
 const mockSubscribeToEvents = jest.fn();
@@ -106,6 +106,58 @@ describe('EventsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Bearbeiten' }));
     expect(screen.getByText('EventForm geöffnet')).toBeInTheDocument();
+  });
+
+  test('pendingEventDetailRequest opens the linked event directly, without flashing the events overview', async () => {
+    const otherEvent = {
+      id: 'other',
+      eventName: 'Anderes Event',
+      date: '2025-08-01',
+      durationHours: 2,
+      eventType: 'party',
+      status: 'geplant',
+      guests: { adults: 1, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+      cb([otherEvent]);
+      return jest.fn();
+    });
+    const linkedEvent = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    let resolveGetEvent;
+    mockGetEvent.mockImplementation(() => new Promise((resolve) => { resolveGetEvent = resolve; }));
+
+    render(
+      <EventsPage
+        currentUser={currentUser}
+        pendingEventDetailRequest={{ ownerId: 'owner-1', eventId: 'e1' }}
+        onPendingEventDetailRequestHandled={() => {}}
+      />
+    );
+
+    // While the linked event is still loading, the full events overview (list of
+    // all events, "Getränke verwalten" links, ...) must not be shown.
+    expect(screen.queryByRole('heading', { name: 'Events' })).toBeNull();
+    expect(screen.queryByText('Getränke verwalten')).toBeNull();
+    expect(screen.queryByText('Anderes Event')).toBeNull();
+
+    await act(async () => {
+      resolveGetEvent(linkedEvent);
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Sommerfest' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Events' })).toBeNull();
+    expect(screen.queryByText('Anderes Event')).toBeNull();
   });
 
   test('shows mobile edit FAB in detail view and removes inline edit and delete buttons', () => {

--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -294,11 +294,24 @@
   border-top: none;
 }
 
+.section-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
 .section-title {
-  margin: 0 0 1.5rem 0;
+  margin: 0;
   color: #402C1C;
   font-size: 1.5rem;
   font-weight: 700;
+}
+
+.section-title-row .open-event-button {
+  width: 40px;
+  height: 40px;
 }
 
 .menu-recipes-section {

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -601,19 +601,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               )}
             </button>
           )}
-          {menu.eventId && menu.eventOwnerId === currentUser?.id && onOpenEvent && (
-            <button
-              className="open-event-button"
-              onClick={() => onOpenEvent(menu.eventOwnerId, menu.eventId)}
-              title="Verknüpftes Event öffnen"
-            >
-              {isBase64Image(openEventIcon) ? (
-                <img src={openEventIcon} alt="Event öffnen" className="open-event-icon-img" />
-              ) : (
-                openEventIcon
-              )}
-            </button>
-          )}
           {!isMobileOrTablet && canEditMenu(currentUser, menu) && onEdit && !showShoppingListModal && !showPortionSelector && (
             <button
               className="menu-edit-button"
@@ -690,7 +677,22 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
 
           return (
             <section key={index} className="menu-section">
-              <h2 className="section-title">{section.name}</h2>
+              <div className="section-title-row">
+                <h2 className="section-title">{section.name}</h2>
+                {isDrinksSection && menu.eventId && menu.eventOwnerId === currentUser?.id && onOpenEvent && (
+                  <button
+                    className="open-event-button"
+                    onClick={() => onOpenEvent(menu.eventOwnerId, menu.eventId)}
+                    title="Verknüpftes Event öffnen"
+                  >
+                    {isBase64Image(openEventIcon) ? (
+                      <img src={openEventIcon} alt="Event öffnen" className="open-event-icon-img" />
+                    ) : (
+                      openEventIcon
+                    )}
+                  </button>
+                )}
+              </div>
               {isLoadingDrinks ? (
                 <p className="no-recipes">Getränke werden geladen …</p>
               ) : hasCards ? (

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -331,6 +331,31 @@ describe('MenuDetail - Open Linked Event Button', () => {
     expect(onOpenEvent).toHaveBeenCalledWith('user-1', 'event-1');
   });
 
+  test('renders next to the Drinks section heading, not in the page header', () => {
+    const menuWithEvent = { ...mockMenu, eventId: 'event-1', eventOwnerId: 'user-1' };
+
+    render(
+      <MenuDetail
+        menu={menuWithEvent}
+        recipes={[]}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+        onSelectRecipe={() => {}}
+        onToggleMenuFavorite={() => Promise.resolve()}
+        onOpenEvent={() => {}}
+        currentUser={currentUser}
+        allUsers={[]}
+      />
+    );
+
+    const button = screen.getByTitle('Verknüpftes Event öffnen');
+    expect(button.closest('.action-buttons')).toBeNull();
+    const titleRow = button.closest('.section-title-row');
+    expect(titleRow).not.toBeNull();
+    expect(titleRow.querySelector('.section-title')).toHaveTextContent('Drinks');
+  });
+
   test('does not render for a non-owner even if the menu has a linked event', () => {
     const menuWithEvent = { ...mockMenu, eventId: 'event-1', eventOwnerId: 'someone-else' };
 


### PR DESCRIPTION
The 📅 button now sits right-aligned next to the "Drinks" section
heading instead of the menu's top header, and only appears there.

Clicking it also no longer flashes the full events overview before
showing the linked event: EventsPage now starts directly in the
target subView for deep links and shows a lightweight loading state
while the event data is still being fetched.