### PR TITLE
Fix linked-event deep link getting stuck on "Laden..."

### DIFF
--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -174,13 +174,19 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       if (!event) {
         setSubView('list');
         setOpenedFromMenuLink(false);
-        return;
+      } else {
+        setFallbackEvent(event);
+        setSelectedEventId(event.id);
+        setSubView('detail');
       }
-      setFallbackEvent(event);
-      setSelectedEventId(event.id);
-      setSubView('detail');
+      // Clearing the request (via the parent's state) is deferred until here,
+      // after the fetch has actually resolved. Calling it synchronously above
+      // used to clear pendingEventDetailRequest in the parent immediately,
+      // which re-ran this effect's dependency, triggered this effect's own
+      // cleanup (cancelled = true) before getEvent() had a chance to resolve,
+      // and left the page stuck on "Laden..." forever.
+      onPendingEventDetailRequestHandled?.();
     });
-    onPendingEventDetailRequestHandled?.();
     return () => {
       cancelled = true;
     };

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -160,6 +160,47 @@ describe('EventsPage', () => {
     expect(screen.queryByText('Anderes Event')).toBeNull();
   });
 
+  test('pendingEventDetailRequest still resolves when the parent clears the request immediately (like App.js does), instead of getting stuck on "Laden..."', async () => {
+    const linkedEvent = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+    let resolveGetEvent;
+    mockGetEvent.mockImplementation(() => new Promise((resolve) => { resolveGetEvent = resolve; }));
+
+    // Mirrors App.js: onPendingEventDetailRequestHandled synchronously clears
+    // pendingEventDetailRequest, which changes the prop EventsPage receives.
+    function Wrapper() {
+      const [pendingEventDetailRequest, setPendingEventDetailRequest] = React.useState({ ownerId: 'owner-1', eventId: 'e1' });
+      return (
+        <EventsPage
+          currentUser={currentUser}
+          pendingEventDetailRequest={pendingEventDetailRequest}
+          onPendingEventDetailRequestHandled={() => setPendingEventDetailRequest(null)}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+
+    expect(screen.getByText('Laden...')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveGetEvent(linkedEvent);
+      await Promise.resolve();
+    });
+
+    // Must resolve to the linked event's detail card, not stay stuck on "Laden...".
+    expect(await screen.findByRole('heading', { name: 'Sommerfest' })).toBeInTheDocument();
+    expect(screen.queryByText('Laden...')).toBeNull();
+  });
+
   test('closing an event opened via pendingEventDetailRequest calls onCloseLinkedEventDetail instead of showing the events list', async () => {
     mockSubscribeToEvents.mockImplementation((_uid, cb) => {
       cb([]);


### PR DESCRIPTION
Clicking the "Verknüpftes Event öffnen" button in a menu's Drinks
section navigated to the event detail but never got past the loading
state. The deep-link effect in EventsPage called
onPendingEventDetailRequestHandled() synchronously right after kicking
off getEvent(), which clears pendingEventDetailRequest in App.js. That
prop change re-ran the effect's cleanup (cancelled = true) before the
Firestore fetch resolved, so the .then() callback bailed out and
selectedEvent/subView were never updated, leaving the page stuck on
"Laden..." forever.

Move the onPendingEventDetailRequestHandled() call into the .then()
callback so it only fires after the fetch has actually resolved and
state has been updated.