### PR TITLE
Fix photo upload button alignment in menu date row

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -663,7 +663,7 @@
 /* Menu photo upload styles */
 .menu-date-row {
   display: flex;
-  align-items: flex-start;
+  align-items: flex-end;
   gap: 0.75rem;
 }
 
@@ -680,17 +680,7 @@
 
 .menu-photo-upload-wrap {
   display: flex;
-  flex-direction: column;
   flex-shrink: 0;
-}
-
-.menu-photo-upload-spacer {
-  display: block;
-  margin-bottom: 0.5rem;
-  color: #333;
-  font-weight: 600;
-  font-size: 0.95rem;
-  visibility: hidden;
 }
 
 .menu-photo-upload-wrap .menu-photo-upload-btn {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1418,7 +1418,6 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
           </div>
           {!menuImage && (
             <div className="menu-photo-upload-wrap">
-              <span className="menu-photo-upload-spacer" aria-hidden="true">&nbsp;</span>
               <label
                 htmlFor="menuImageFile"
                 className={`menu-photo-upload-btn${uploadingMenuImage ? ' uploading' : ''}`}


### PR DESCRIPTION
The button position relied on an invisible spacer span mimicking the
"Datum" label's height, which drifts from the real label under
different font metrics/text-size adjustments (notably in landscape),
causing the button to sit too low or overlap the date input. Bottom-
align the row instead so the button always lines up with the input
regardless of label height.