### PR TITLE
Fix duplicate drink display in menu detail when recipe is in both Drinks section and linked event

### DIFF
--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -214,6 +214,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
         displayName: display.displayName || drinkId,
         imageUrl: getDrinkImageUrl(display.recipe) || drinksCategoryImage,
         literMitPuffer: null,
+        recipeId: display.recipeId,
       };
     });
   };
@@ -231,6 +232,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
         displayName: display.displayName || drinkId,
         imageUrl: getDrinkImageUrl(display.recipe) || drinksCategoryImage,
         literMitPuffer: ergebnisRow?.literMitPuffer ?? null,
+        recipeId: display.recipeId,
       };
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -658,10 +660,19 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
 
         {displaySections.map((section, index) => {
           const isDrinksSection = section.name?.toLowerCase() === DRINKS_SECTION_NAME.toLowerCase();
+          // Drinks (event-linked or manual) that resolve to a recipe already shown
+          // as its own recipe card in this section are hidden here, so the same
+          // recipe doesn't appear twice (once as a recipe card, once as a drink card).
+          const sectionRecipeIds = new Set(section.recipes.map((recipe) => recipe.id));
           const manualDrinks = isDrinksSection ? resolveManualDrinks(section.drinkIds) : [];
-          const eventDrinkIds = new Set(eventDrinks.map((drink) => drink.id));
-          const dedupedManualDrinks = manualDrinks.filter((drink) => !eventDrinkIds.has(drink.id));
-          const sectionDrinks = isDrinksSection ? [...eventDrinks, ...dedupedManualDrinks] : [];
+          const dedupedEventDrinks = isDrinksSection
+            ? eventDrinks.filter((drink) => !drink.recipeId || !sectionRecipeIds.has(drink.recipeId))
+            : [];
+          const eventDrinkIds = new Set(dedupedEventDrinks.map((drink) => drink.id));
+          const dedupedManualDrinks = manualDrinks.filter((drink) =>
+            !eventDrinkIds.has(drink.id) && (!drink.recipeId || !sectionRecipeIds.has(drink.recipeId))
+          );
+          const sectionDrinks = isDrinksSection ? [...dedupedEventDrinks, ...dedupedManualDrinks] : [];
           const isLoadingDrinks = isDrinksSection && linkedEventLoading;
           const hasCards = section.recipes.length > 0 || sectionDrinks.length > 0;
 
@@ -674,7 +685,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
                 section.itemOrder,
                 [
                   ...section.recipes.map((recipe) => ({ compositeId: `recipe:${recipe.id}`, type: 'recipe', recipe })),
-                  ...eventDrinks.map((drink) => ({ compositeId: `event:${drink.id}`, type: 'drink', drink })),
+                  ...dedupedEventDrinks.map((drink) => ({ compositeId: `event:${drink.id}`, type: 'drink', drink })),
                   ...dedupedManualDrinks.map((drink) => ({ compositeId: `manual:${drink.id}`, type: 'drink', drink })),
                 ],
                 (card) => card.compositeId

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -61,11 +61,16 @@ jest.mock('../utils/categoryImages', () => ({
 }));
 
 const mockGetCustomDrinks = jest.fn(() => Promise.resolve([]));
+// CRA's jest config resets mock implementations (including the one passed to
+// jest.fn()) before every test, so these fall back to a no-op unsubscribe
+// whenever a test hasn't set its own mockImplementation.
+const mockSubscribeToEvent = jest.fn();
+const mockSubscribeToCustomDrinks = jest.fn();
 jest.mock('../utils/eventsFirestore', () => ({
   getEvent: jest.fn(() => Promise.resolve(null)),
   getCustomDrinks: (...args) => mockGetCustomDrinks(...args),
-  subscribeToEvent: () => () => {},
-  subscribeToCustomDrinks: () => () => {},
+  subscribeToEvent: (...args) => mockSubscribeToEvent(...args) || (() => {}),
+  subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args) || (() => {}),
 }));
 
 const mockMenu = {
@@ -463,6 +468,48 @@ describe('MenuDetail - Manually added drinks in the Drinks section', () => {
     );
 
     expect(mockGetCustomDrinks).not.toHaveBeenCalled();
+  });
+});
+
+describe('MenuDetail - Event drink linked to a recipe already in the Drinks section', () => {
+  const mojitoRecipe = { id: 'mojito', title: 'Mojito', ingredients: [] };
+
+  const menuWithRecipeAndLinkedEvent = {
+    id: 'menu-event-drinks',
+    name: 'Menü mit Event',
+    eventId: 'event-1',
+    eventOwnerId: 'user-1',
+    sections: [
+      { name: 'Drinks', recipeIds: ['mojito'] },
+    ],
+  };
+
+  test('shows the recipe only once, not also as a separate event drink card', async () => {
+    mockSubscribeToEvent.mockImplementation((ownerId, eventId, cb) => {
+      cb({ customDrinkIds: ['drink-mojito'], berechnung: { ergebnis: [] } });
+      return () => {};
+    });
+    mockSubscribeToCustomDrinks.mockImplementation((ownerId, cb) => {
+      cb([{ id: 'drink-mojito', name: '#recipe:mojito:Mojito' }]);
+      return () => {};
+    });
+
+    render(
+      <MenuDetail
+        menu={menuWithRecipeAndLinkedEvent}
+        recipes={[mojitoRecipe]}
+        onBack={() => {}}
+        onEdit={() => {}}
+        onDelete={() => {}}
+        onSelectRecipe={() => {}}
+        onToggleMenuFavorite={() => Promise.resolve()}
+        currentUser={currentUser}
+        allUsers={[]}
+      />
+    );
+
+    expect(await screen.findAllByText('Mojito')).toHaveLength(1);
+    expect(screen.getByText('Mojito').closest('.drink-card')).toBeNull();
   });
 });
 


### PR DESCRIPTION
A recipe added directly to a menu's "Drinks" section was shown twice
whenever the linked event also referenced that same recipe as a custom
drink: once as a recipe card, once as the event's drink card. Event and
manually added drinks are now deduped against the section's own recipes
by resolved recipe id, matching the dedup already done in MenuForm.