### PR TITLE
Privatflag in Menüdetailansicht unter dem Menünamen anzeigen

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -215,6 +215,10 @@
   flex: 1;
 }
 
+.menu-private-row {
+  margin-bottom: 1rem;
+}
+
 .private-indicator {
   background: #402C1C;
   color: white;

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -637,7 +637,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
       <div className="menu-detail-content">
         <div className="menu-title-row">
           <h1 className="menu-title">{menu.name}</h1>
-          {menu.privat && <span className="private-indicator">Privat</span>}
           <button className="close-button" onClick={onBack} title="Schließen">
             {isBase64Image(closeButtonIcon) ? (
               <img src={closeButtonIcon} alt="Schließen" className="close-button-icon-img" />
@@ -646,7 +645,13 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
             )}
           </button>
         </div>
-        
+
+        {menu.privat && (
+          <div className="menu-private-row">
+            <span className="private-indicator">Privat</span>
+          </div>
+        )}
+
         {(formattedMenuDate || authorName) && (
           <div className="menu-author-date">
             {authorName && <span className="menu-author"><span className="menu-author-label">Autor:</span> {authorName}</span>}


### PR DESCRIPTION
## Summary
- Der "Privat"-Badge in der Menüdetailansicht stand bisher in derselben Zeile wie der Menüname und der Schließen-Button
- Er erscheint jetzt in einer eigenen Zeile direkt unterhalb des Menünamens (`src/components/MenuDetail.js:637-651`, CSS-Ergänzung `.menu-private-row` in `MenuDetail.css`)

## Test plan
- [x] Bestehende MenuDetail-Tests laufen weiterhin durch (2 vorbestehende, unabhängige Fehlschläge bei Bruch-vs-Dezimal-Formatierung in der Einkaufsliste, nicht durch diese Änderung verursacht)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ktWvU3DA21RpHNupvaDwo)_