### PR TITLE
Menüdetail: Buttonleiste linksbündig, Teilen/Link-Button rechtsbündig, einzeilig

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -40,9 +40,10 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.5rem;
-  flex-wrap: nowrap;
-  align-items: center;
+  width: 100%;
+  overflow-x: auto;
 }
 
 .favorite-button {
@@ -93,6 +94,15 @@
   transition: all 0.3s ease;
   width: 1.5rem;
   height: 1.5rem;
+  flex-shrink: 0;
+}
+
+/* Teilen- bzw. Share-Link-kopieren-Button ist immer rechtsbündig in der Buttonleiste */
+.share-button,
+.share-copy-url-button {
+  margin-left: auto;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .shopping-list-trigger-button:hover,
@@ -154,6 +164,7 @@
   cursor: pointer;
   transition: background 0.2s ease;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .publish-menu-button:hover {
@@ -170,6 +181,8 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .menu-edit-button {

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -563,6 +563,34 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               shoppingListIcon
             )}
           </button>
+          {!isMobileOrTablet && canEditMenu(currentUser, menu) && onEdit && !showShoppingListModal && !showPortionSelector && (
+            <button
+              className="menu-edit-button"
+              onClick={() => onEdit(menu)}
+              title="Menü bearbeiten"
+            >
+              Bearbeiten
+            </button>
+          )}
+          {!isMobileOrTablet && menu.privat && canEditMenu(currentUser, menu) && onPublish && (
+            <button
+              className="publish-menu-button"
+              onClick={handlePublish}
+              disabled={publishLoading}
+              title="Menü veröffentlichen"
+            >
+              {publishLoading ? '…' : 'Veröffentlichen'}
+            </button>
+          )}
+          {!isMobileOrTablet && canDeleteMenu(currentUser, menu) && onDelete && (
+            <button
+              className="menu-delete-button"
+              onClick={handleDelete}
+              title="Menü löschen"
+            >
+              Löschen
+            </button>
+          )}
           {canEditMenu(currentUser, menu) && !menu.shareId && (
             <button
               className="share-button"
@@ -601,34 +629,6 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
                   copyLinkIcon
                 )
               )}
-            </button>
-          )}
-          {!isMobileOrTablet && canEditMenu(currentUser, menu) && onEdit && !showShoppingListModal && !showPortionSelector && (
-            <button
-              className="menu-edit-button"
-              onClick={() => onEdit(menu)}
-              title="Menü bearbeiten"
-            >
-              Bearbeiten
-            </button>
-          )}
-          {!isMobileOrTablet && menu.privat && canEditMenu(currentUser, menu) && onPublish && (
-            <button
-              className="publish-menu-button"
-              onClick={handlePublish}
-              disabled={publishLoading}
-              title="Menü veröffentlichen"
-            >
-              {publishLoading ? '…' : 'Veröffentlichen'}
-            </button>
-          )}
-          {!isMobileOrTablet && canDeleteMenu(currentUser, menu) && onDelete && (
-            <button
-              className="menu-delete-button"
-              onClick={handleDelete}
-              title="Menü löschen"
-            >
-              Löschen
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Der Teilen- bzw. Share-Link-kopieren-Button wird ans Ende der Buttonleiste im Kopf der Menüdetailansicht verschoben und per `margin-left: auto` rechtsbündig ausgerichtet
- Alle übrigen Buttons (Favorit, Einkaufsliste, Bearbeiten, Veröffentlichen, Löschen) bleiben in ursprünglicher Reihenfolge linksbündig (`justify-content: flex-start`)
- Die Leiste bleibt garantiert einzeilig: `flex-wrap: nowrap` plus `overflow-x: auto` auf `.action-buttons`, sowie `flex-shrink: 0` und `white-space: nowrap` auf allen Buttons, damit bei wenig Platz seitlich gescrollt statt umgebrochen oder der Text gequetscht wird

## Test plan
- [ ] Änderung konnte in der Ursprungs-Session mangels installierter `node_modules` nicht per `npm test`/Browser verifiziert werden — bitte visuell in der Menüdetailansicht auf verschiedenen Breiten gegenprüfen

---
_Generated by [Claude Code](https://claude.ai/code/session_016ktWvU3DA21RpHNupvaDwo)_