### PR TITLE
Add ingredient catalog search to ingredientID selection dropdown

### DIFF
--- a/src/components/AppCallsPage.js
+++ b/src/components/AppCallsPage.js
@@ -34,6 +34,7 @@ import { isBase64Image } from '../utils/imageUtils';
 import { enableRecipeSharing } from '../utils/recipeFirestore';
 import { useNutritionReference } from '../contexts/NutritionReferenceContext';
 import NutritionModal from './NutritionModal';
+import IngredientIDSelect from './IngredientIDSelect';
 import { db, functions } from '../firebase';
 import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
 import {
@@ -2161,30 +2162,14 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
                         </div>
                       </dl>
                     )}
-                    <select
-                      value={ingredientMatchDialog.selections?.[entry.index] || ''}
-                      onChange={(e) => handleIngredientMatchSelectionChange(entry.index, e.target.value)}
-                      aria-label={`ingredientID für ${entry.ingredient}`}
-                    >
-                      <option value="">Bitte auswählen</option>
-                      {entry.suggestions.map((suggestion) => (
-                        <option key={suggestion.ingredientID} value={suggestion.ingredientID}>
-                          {suggestion.displayName || suggestion.ingredientID} ({suggestion.confidencePercent}%)
-                        </option>
-                      ))}
-                      <option value={INGREDIENT_MATCH_CREATE_NEW_OPTION}>Neue Zutat</option>
-                      <option value={INGREDIENT_MATCH_IGNORE_OPTION}>Zutat ignorieren</option>
-                    </select>
-                    {entry.suggestions.length > 0 && (
-                      <label className="ingredient-match-learn-label">
-                        <input
-                          type="checkbox"
-                          checked={ingredientMatchDialog.learnSynonyms?.[entry.index] !== false}
-                          onChange={(e) => handleIngredientMatchLearnChange(entry.index, e.target.checked)}
-                        />
-                        {' '}Synonym lernen
-                      </label>
-                    )}
+                    <IngredientIDSelect
+                      entry={entry}
+                      value={ingredientMatchDialog.selections?.[entry.index]}
+                      onChange={handleIngredientMatchSelectionChange}
+                      nutritionReferenceRows={nutritionReferenceRows}
+                      learnSynonymChecked={ingredientMatchDialog.learnSynonyms?.[entry.index]}
+                      onLearnSynonymChange={handleIngredientMatchLearnChange}
+                    />
                   </li>
                 );
               })}

--- a/src/components/AppCallsPage.test.js
+++ b/src/components/AppCallsPage.test.js
@@ -775,6 +775,65 @@ describe('AppCallsPage – Nährwertberechnungen tab', () => {
     ));
   });
 
+  test('allows searching the full ingredient catalog and selecting a match not among the suggestions', async () => {
+    mockNutritionReferenceState = {
+      rows: [
+        { ingredientID: 'tomate', displayName: 'Tomate', synonyms: ['Tomate'] },
+        { ingredientID: 'zitrone', displayName: 'Zitrone', synonyms: ['Zitrone'] },
+      ],
+      loading: false,
+      reload: jest.fn(),
+      lastUpdatedAt: null,
+    };
+    mockGetIngredientIdSuggestions.mockReturnValue([
+      { ingredientID: 'tomate', displayName: 'Tomate', confidencePercent: 39 },
+    ]);
+    const onUpdateRecipe = jest.fn(() => Promise.resolve());
+
+    render(
+      <AppCallsPage
+        onBack={jest.fn()}
+        currentUser={adminUser}
+        recipes={[
+          {
+            id: 'r1',
+            title: 'Gemüsepfanne',
+            ingredients: [{ type: 'ingredient', text: '1 Bio-Zitrone' }],
+            naehrwerte: { calcPending: false, calcCompletedAt: 1720000000000, calcNotIncluded: [{ ingredient: '1 Bio-Zitrone', error: 'Nicht gefunden' }] },
+          },
+        ]}
+        onUpdateRecipe={onUpdateRecipe}
+      />
+    );
+
+    fireEvent.click(await screen.findByText('Nährwertberechnungen'));
+    fireEvent.click(screen.getByRole('button', { name: 'Öffnen' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'IDs prüfen' }));
+    expect(await screen.findByRole('dialog', { name: 'ingredientID-Zuordnung' })).toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'Bestehende Zutaten durchsuchen…' })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('ingredientID für 1 Bio-Zitrone'), {
+      target: { value: '__ingredient_match_search_existing__' },
+    });
+
+    const searchDialog = await screen.findByRole('dialog', { name: 'Bestehende Zutaten durchsuchen' });
+    fireEvent.change(within(searchDialog).getByLabelText('Zutat suchen'), { target: { value: 'zitro' } });
+    fireEvent.click(within(searchDialog).getByRole('button', { name: /Zitrone/ }));
+
+    expect(screen.queryByRole('dialog', { name: 'Bestehende Zutaten durchsuchen' })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('ingredientID für 1 Bio-Zitrone')).toHaveValue('zitrone');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Übernehmen & berechnen' }));
+
+    await waitFor(() => expect(onUpdateRecipe).toHaveBeenCalledWith(
+      'r1',
+      {
+        ingredients: [{ type: 'ingredient', text: '1 Bio-Zitrone', ingredientID: 'zitrone' }],
+      }
+    ));
+  });
+
   test('shows ingredient info panel when info button is clicked', async () => {
     mockNutritionReferenceState = {
       rows: [

--- a/src/components/IngredientCatalogSearchModal.css
+++ b/src/components/IngredientCatalogSearchModal.css
@@ -1,0 +1,114 @@
+.ingredient-search-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 2200;
+}
+
+.ingredient-search-modal {
+  width: min(420px, 100%);
+  max-height: min(70vh, 560px);
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ingredient-search-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0.75rem 0.6rem;
+  border-bottom: 1px solid #eee;
+}
+
+.ingredient-search-modal-input {
+  flex: 1;
+  min-width: 0;
+  min-height: 2.6rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  font-size: 16px;
+}
+
+.ingredient-search-modal-close {
+  border: none;
+  background: transparent;
+  color: #555;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.15rem 0.3rem;
+  flex-shrink: 0;
+}
+
+.ingredient-search-modal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.ingredient-search-modal-item {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  border: none;
+  border-bottom: 1px solid #f0f0f0;
+  background: transparent;
+  padding: 0.75rem 0.9rem;
+  min-height: 3rem;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+.ingredient-search-modal-item:hover,
+.ingredient-search-modal-item:focus-visible {
+  background: #faf3ef;
+  outline: none;
+}
+
+.ingredient-search-modal-item-name {
+  font-size: 0.95rem;
+  color: #222;
+}
+
+.ingredient-search-modal-item-id {
+  font-size: 0.78rem;
+  color: #999;
+}
+
+.ingredient-search-modal-empty {
+  padding: 1.5rem 0.9rem;
+  text-align: center;
+  color: #888;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 480px) {
+  .ingredient-search-modal-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+
+  .ingredient-search-modal {
+    width: 100%;
+    max-height: 85vh;
+    border-radius: 12px 12px 0 0;
+  }
+
+  .ingredient-search-modal-item {
+    min-height: 3.25rem;
+  }
+}

--- a/src/components/IngredientCatalogSearchModal.js
+++ b/src/components/IngredientCatalogSearchModal.js
@@ -1,0 +1,96 @@
+import React, { useMemo, useState } from 'react';
+import './IngredientCatalogSearchModal.css';
+import { normalizeNutritionReferenceId } from '../utils/nutritionReferenceUtils';
+
+function getIngredientRowDisplayName(row) {
+  return String(
+    row?.displayName
+    || row?.Anzeigename
+    || row?.name
+    || (Array.isArray(row?.synonyms) ? row.synonyms[0] : '')
+    || row?.ingredientID
+    || row?.id
+    || ''
+  ).trim();
+}
+
+function IngredientCatalogSearchModal({ nutritionReferenceRows = [], onSelect, onClose }) {
+  const [query, setQuery] = useState('');
+
+  const catalogEntries = useMemo(() => {
+    const seen = new Set();
+    return nutritionReferenceRows
+      .map((row) => {
+        const ingredientID = String(row?.ingredientID || row?.id || '').trim();
+        if (!ingredientID || seen.has(ingredientID)) return null;
+        seen.add(ingredientID);
+        const displayName = getIngredientRowDisplayName(row) || ingredientID;
+        const searchTokens = [displayName, ingredientID, ...(Array.isArray(row?.synonyms) ? row.synonyms : [])]
+          .map((value) => normalizeNutritionReferenceId(value))
+          .filter(Boolean);
+        return { ingredientID, displayName, searchTokens };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.displayName.localeCompare(b.displayName, 'de', { sensitivity: 'base' }));
+  }, [nutritionReferenceRows]);
+
+  const normalizedQuery = normalizeNutritionReferenceId(query);
+  const filteredEntries = normalizedQuery
+    ? catalogEntries.filter((entry) => entry.searchTokens.some((token) => token.includes(normalizedQuery)))
+    : catalogEntries;
+
+  return (
+    <div className="ingredient-search-modal-overlay" onClick={onClose}>
+      <div
+        className="ingredient-search-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Bestehende Zutaten durchsuchen"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ingredient-search-modal-header">
+          <input
+            type="search"
+            className="ingredient-search-modal-input"
+            placeholder="Zutat suchen…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Zutat suchen"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') onClose();
+            }}
+          />
+          <button
+            type="button"
+            className="ingredient-search-modal-close"
+            onClick={onClose}
+            aria-label="Zutatensuche schließen"
+          >
+            ×
+          </button>
+        </div>
+        <ul className="ingredient-search-modal-list">
+          {filteredEntries.length === 0 ? (
+            <li className="ingredient-search-modal-empty">Keine Zutat gefunden.</li>
+          ) : (
+            filteredEntries.map((entry) => (
+              <li key={entry.ingredientID}>
+                <button
+                  type="button"
+                  className="ingredient-search-modal-item"
+                  onClick={() => onSelect(entry.ingredientID)}
+                >
+                  <span className="ingredient-search-modal-item-name">{entry.displayName}</span>
+                  <span className="ingredient-search-modal-item-id">{entry.ingredientID}</span>
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default IngredientCatalogSearchModal;

--- a/src/components/IngredientIDSelect.js
+++ b/src/components/IngredientIDSelect.js
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import {
+  INGREDIENT_MATCH_CREATE_NEW_OPTION,
+  INGREDIENT_MATCH_IGNORE_OPTION,
+  INGREDIENT_MATCH_SEARCH_EXISTING_OPTION,
+} from '../hooks/useIngredientIDMatching';
+import IngredientCatalogSearchModal from './IngredientCatalogSearchModal';
+
+function findRowDisplayName(ingredientID, nutritionReferenceRows) {
+  const row = nutritionReferenceRows.find(
+    (candidate) => String(candidate?.ingredientID || candidate?.id || '').trim() === ingredientID
+  );
+  if (!row) return ingredientID;
+  return String(
+    row.displayName || row.Anzeigename || row.name
+    || (Array.isArray(row.synonyms) ? row.synonyms[0] : '')
+    || ingredientID
+  ).trim() || ingredientID;
+}
+
+function IngredientIDSelect({
+  entry,
+  value,
+  onChange,
+  nutritionReferenceRows = [],
+  learnSynonymChecked,
+  onLearnSynonymChange,
+}) {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+
+  const selectedValue = value || '';
+  const isSuggestedValue = entry.suggestions.some((suggestion) => suggestion.ingredientID === selectedValue);
+  const isSpecialValue = selectedValue === INGREDIENT_MATCH_CREATE_NEW_OPTION
+    || selectedValue === INGREDIENT_MATCH_IGNORE_OPTION;
+  const searchedSelection = selectedValue && !isSuggestedValue && !isSpecialValue
+    ? { ingredientID: selectedValue, displayName: findRowDisplayName(selectedValue, nutritionReferenceRows) }
+    : null;
+
+  const handleSelectChange = (e) => {
+    const nextValue = e.target.value;
+    if (nextValue === INGREDIENT_MATCH_SEARCH_EXISTING_OPTION) {
+      setIsSearchOpen(true);
+      return;
+    }
+    onChange(entry.index, nextValue);
+  };
+
+  return (
+    <>
+      <select
+        value={selectedValue}
+        onChange={handleSelectChange}
+        aria-label={`ingredientID für ${entry.ingredient}`}
+      >
+        <option value="">Bitte auswählen</option>
+        {entry.suggestions.map((suggestion) => (
+          <option key={suggestion.ingredientID} value={suggestion.ingredientID}>
+            {suggestion.displayName || suggestion.ingredientID} ({suggestion.confidencePercent}%)
+          </option>
+        ))}
+        {searchedSelection && (
+          <option value={searchedSelection.ingredientID}>
+            {searchedSelection.displayName}
+          </option>
+        )}
+        <option value={INGREDIENT_MATCH_SEARCH_EXISTING_OPTION}>Bestehende Zutaten durchsuchen…</option>
+        <option value={INGREDIENT_MATCH_CREATE_NEW_OPTION}>Neue Zutat</option>
+        <option value={INGREDIENT_MATCH_IGNORE_OPTION}>Zutat ignorieren</option>
+      </select>
+      {entry.suggestions.length > 0 && (
+        <label className="ingredient-match-learn-label">
+          <input
+            type="checkbox"
+            checked={learnSynonymChecked !== false}
+            onChange={(e) => onLearnSynonymChange(entry.index, e.target.checked)}
+          />
+          {' '}Synonym lernen
+        </label>
+      )}
+      {isSearchOpen && (
+        <IngredientCatalogSearchModal
+          nutritionReferenceRows={nutritionReferenceRows}
+          onSelect={(ingredientID) => {
+            onChange(entry.index, ingredientID);
+            setIsSearchOpen(false);
+          }}
+          onClose={() => setIsSearchOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+export default IngredientIDSelect;

--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -21,6 +21,7 @@ import { db, functions } from '../firebase';
 import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import NutritionModal from './NutritionModal';
+import IngredientIDSelect from './IngredientIDSelect';
 import ShoppingListModal from './ShoppingListModal';
 import RatingModal from './RatingModal';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, DEFAULT_PRINT_FORMATS, selectPrintFormat, mergePrintElementsWithDefaults, getAlarmSoundPreference } from '../utils/customLists';
@@ -2754,30 +2755,14 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
                         </div>
                       </dl>
                     )}
-                    <select
-                      value={ingredientMatchDialog.selections?.[entry.index] || ''}
-                      onChange={(e) => handleIngredientMatchSelectionChange(entry.index, e.target.value)}
-                      aria-label={`ingredientID für ${entry.ingredient}`}
-                    >
-                      <option value="">Bitte auswählen</option>
-                      {entry.suggestions.map((suggestion) => (
-                        <option key={suggestion.ingredientID} value={suggestion.ingredientID}>
-                          {suggestion.displayName || suggestion.ingredientID} ({suggestion.confidencePercent}%)
-                        </option>
-                      ))}
-                      <option value={INGREDIENT_MATCH_CREATE_NEW_OPTION}>Neue Zutat</option>
-                      <option value={INGREDIENT_MATCH_IGNORE_OPTION}>Zutat ignorieren</option>
-                    </select>
-                    {entry.suggestions.length > 0 && (
-                      <label className="ingredient-match-learn-label">
-                        <input
-                          type="checkbox"
-                          checked={ingredientMatchDialog.learnSynonyms?.[entry.index] !== false}
-                          onChange={(e) => handleIngredientMatchLearnChange(entry.index, e.target.checked)}
-                        />
-                        {' '}Synonym lernen
-                      </label>
-                    )}
+                    <IngredientIDSelect
+                      entry={entry}
+                      value={ingredientMatchDialog.selections?.[entry.index]}
+                      onChange={handleIngredientMatchSelectionChange}
+                      nutritionReferenceRows={nutritionReferenceRows}
+                      learnSynonymChecked={ingredientMatchDialog.learnSynonyms?.[entry.index]}
+                      onLearnSynonymChange={handleIngredientMatchLearnChange}
+                    />
                   </li>
                 );
               })}

--- a/src/hooks/useIngredientIDMatching.js
+++ b/src/hooks/useIngredientIDMatching.js
@@ -4,6 +4,7 @@ import { decodeRecipeLink } from '../utils/recipeLinks';
 
 export const INGREDIENT_MATCH_CREATE_NEW_OPTION = '__ingredient_match_create_new__';
 export const INGREDIENT_MATCH_IGNORE_OPTION = '__ingredient_match_ignore__';
+export const INGREDIENT_MATCH_SEARCH_EXISTING_OPTION = '__ingredient_match_search_existing__';
 
 function defaultGetNutritionIngredientSource(recipe) {
   if (!recipe) return { fieldName: 'ingredients', rawIngredients: [] };


### PR DESCRIPTION
Adds a "Bestehende Zutaten durchsuchen…" option to the ingredientID
select used in the Küchenbetrieb match dialogs (RecipeDetail and
AppCallsPage). Picking it opens a mobile-optimized, searchable list of
the full nutritionReferences catalog so users aren't limited to the
fuzzy-matched suggestions when resolving an ingredient.

The select + checkbox markup, previously duplicated in both dialogs,
is now shared via a new IngredientIDSelect component.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nh6gCYdy114B8wf7MQFfX3