### PR TITLE
Auto-add Mineralwasser to menu and event when creating an event from a menu

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -764,6 +764,24 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       recipeDrinkIds.forEach((id) => {
         if (id && !combinedIds.includes(id)) combinedIds.push(id);
       });
+
+      // Unless the menu already has it, the predefined Mineralwasser drink is
+      // added here to both the new event and this menu's own "Drinks" section.
+      if (!combinedIds.includes('predefined_mineralwasser')) {
+        combinedIds.push('predefined_mineralwasser');
+        setSections((prevSections) => {
+          const drinksSectionIndex = prevSections.findIndex((s) => s.name?.toLowerCase() === 'drinks');
+          if (drinksSectionIndex === -1) {
+            return [...prevSections, createMenuSection('Drinks', [], ['predefined_mineralwasser'])];
+          }
+          return prevSections.map((s, i) => (
+            i === drinksSectionIndex
+              ? { ...s, drinkIds: [...(s.drinkIds || []), 'predefined_mineralwasser'] }
+              : s
+          ));
+        });
+      }
+
       setNewEventDrinkIds(combinedIds);
       setFormSubView('newEvent');
     } finally {

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import MenuForm from './MenuForm';
 
 const mockSubscribeToCustomDrinks = jest.fn();
@@ -209,7 +209,66 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     await waitFor(() => {
       expect(capturedEventFormProps).not.toBeNull();
     });
-    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-cola']);
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-cola', 'predefined_mineralwasser']);
+  });
+
+  test('adds the predefined Mineralwasser drink to both the new event and the menu\'s Drinks section when missing', async () => {
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const drinkInput = await screen.findByPlaceholderText('Rezept oder Getränk suchen und hinzufügen...');
+    fireEvent.change(drinkInput, { target: { value: 'Cola' } });
+    fireEvent.click(await screen.findByText('Cola'));
+
+    fireEvent.click(screen.getByText('Neue Kalkulation erstellen'));
+
+    await waitFor(() => {
+      expect(capturedEventFormProps).not.toBeNull();
+    });
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toContain('predefined_mineralwasser');
+
+    // Also reflected in the menu's own "Drinks" section, not just the event -
+    // back out of the (mocked) EventForm to see the menu's section state.
+    act(() => {
+      capturedEventFormProps.onCancel();
+    });
+    expect(await screen.findAllByText('Mineralwasser')).not.toHaveLength(0);
+  });
+
+  test('does not duplicate the predefined Mineralwasser drink when the menu already has it', async () => {
+    render(
+      <MenuForm
+        menu={null}
+        recipes={recipes}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+        currentUser={currentUser}
+      />
+    );
+
+    fireEvent.click(screen.getByText('+ Abschnitt hinzufügen'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Drinks' }));
+
+    const drinkInput = await screen.findByPlaceholderText('Rezept oder Getränk suchen und hinzufügen...');
+    fireEvent.change(drinkInput, { target: { value: 'Mineralwasser' } });
+    fireEvent.click(await screen.findByText('Mineralwasser'));
+
+    fireEvent.click(screen.getByText('Neue Kalkulation erstellen'));
+
+    await waitFor(() => {
+      expect(capturedEventFormProps).not.toBeNull();
+    });
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['predefined_mineralwasser']);
   });
 
   test('creates a linked drink for a drink recipe without one yet, and carries it over to a new event', async () => {
@@ -243,7 +302,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     await waitFor(() => {
       expect(capturedEventFormProps).not.toBeNull();
     });
-    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-new-mojito']);
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-new-mojito', 'predefined_mineralwasser']);
   });
 
   test('reuses an existing linked drink for a drink recipe instead of creating a duplicate', async () => {
@@ -283,7 +342,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
     await waitFor(() => {
       expect(capturedEventFormProps).not.toBeNull();
     });
-    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-existing-mojito']);
+    expect(capturedEventFormProps.initialEvent.customDrinkIds).toEqual(['drink-existing-mojito', 'predefined_mineralwasser']);
     expect(mockSaveCustomDrink).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- When creating a new event from a menu ("Neue Kalkulation erstellen"), the predefined drink Mineralwasser is now automatically pre-selected for the event unless the menu already has it
- In that case, Mineralwasser is also added to the menu's own "Drinks" section (creating it first if it doesn't exist yet), so it's reflected in the menu itself

## Test plan
- [x] Updated existing `MenuForm.test.js` expectations that assert on `customDrinkIds` for a newly created event
- [x] Added a test verifying Mineralwasser is added to both the new event and the menu's Drinks section when missing
- [x] Added a test verifying Mineralwasser is not duplicated when the menu already has it
- [x] `MenuForm.test.js` (14 tests) and `EventForm.test.js` (30 tests) pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ6gBTmYH1ExMtoUicvFxu)_