### PR TITLE
Speisekategorie-Filterung im Filterdialog ergänzen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -195,6 +195,16 @@ function matchesCuisineFilter(recipe, selectedCuisines, cuisineGroups) {
   return expanded.includes(recipe.kulinarik);
 }
 
+// Helper function to check if a recipe matches the Speisekategorie filter
+// selected via the Search Overlay's meal category pills.
+function matchesMealCategoryFilter(recipe, selectedCategories) {
+  if (!selectedCategories || selectedCategories.length === 0) return true;
+  if (Array.isArray(recipe.speisekategorie)) {
+    return selectedCategories.some(c => recipe.speisekategorie.includes(c));
+  }
+  return selectedCategories.includes(recipe.speisekategorie);
+}
+
 // Helper function to check if a recipe matches the author filter
 function matchesAuthorFilter(recipe, selectedAuthors) {
   if (!selectedAuthors || selectedAuthors.length === 0) return true;
@@ -351,12 +361,14 @@ function App() {
   const [showSeasonalOnly, setShowSeasonalOnly] = useState(false);
   const [cuisineGroups, setCuisineGroups] = useState([]);
   const [cuisineTypes, setCuisineTypes] = useState([]);
+  const [mealCategories, setMealCategories] = useState([]);
   const [seasonMatrixEntries, setSeasonMatrixEntries] = useState([]);
   const [nutritionReferenceRows, setNutritionReferenceRows] = useState([]);
   const [cookDatesMap, setCookDatesMap] = useState(new Map());
   const [recipeFilters, setRecipeFilters] = useState({
     showDrafts: 'all',
     selectedCuisines: [],
+    selectedCategories: [],
     selectedAuthors: [],
     selectedPrivateLists: [],
     selectedGroup: ''
@@ -507,6 +519,7 @@ function App() {
 
     return selectedGroupUnfilteredRecipes.filter((recipe) =>
       matchesCuisineFilter(recipe, recipeFilters.selectedCuisines, cuisineGroups) &&
+      matchesMealCategoryFilter(recipe, recipeFilters.selectedCategories) &&
       matchesAuthorFilter(recipe, recipeFilters.selectedAuthors) &&
       matchesSeasonalFilter(recipe, showSeasonalOnly, seasonMatrixEntries, nutritionReferenceRows) &&
       (
@@ -514,7 +527,7 @@ function App() {
         matchesPrivateListsFilter(recipe, recipeFilters.selectedPrivateLists, groups)
       )
     );
-  }, [selectedGroupUnfilteredRecipes, selectedGroup, recipeFilters.selectedCuisines, recipeFilters.selectedAuthors, recipeFilters.selectedPrivateLists, cuisineGroups, groups, showSeasonalOnly, seasonMatrixEntries, nutritionReferenceRows]);
+  }, [selectedGroupUnfilteredRecipes, selectedGroup, recipeFilters.selectedCuisines, recipeFilters.selectedCategories, recipeFilters.selectedAuthors, recipeFilters.selectedPrivateLists, cuisineGroups, groups, showSeasonalOnly, seasonMatrixEntries, nutritionReferenceRows]);
 
   // Detect share URL: #share/:shareId or /share/:shareId (pathname)
   const getShareIdFromHash = () => {
@@ -704,9 +717,11 @@ function App() {
     getCustomLists().then(lists => {
       setCuisineGroups(lists.cuisineGroups || []);
       setCuisineTypes(lists.cuisineTypes || []);
+      setMealCategories(lists.mealCategories || []);
     }).catch(() => {
       setCuisineGroups([]);
       setCuisineTypes([]);
+      setMealCategories([]);
     });
   }, []);
 
@@ -1262,6 +1277,7 @@ function App() {
     setRecipeFilters({
       showDrafts: 'all',
       selectedCuisines: [],
+      selectedCategories: [],
       selectedAuthors: [],
       selectedPrivateLists: [],
       selectedGroup: groupId || ''
@@ -1273,6 +1289,7 @@ function App() {
     setRecipeFilters({
       showDrafts: 'all',
       selectedCuisines: [],
+      selectedCategories: [],
       selectedAuthors: [],
       selectedPrivateLists: [],
       selectedGroup: ''
@@ -1759,6 +1776,7 @@ function App() {
     setRecipeFilters({
       showDrafts: 'all',
       selectedCuisines: [],
+      selectedCategories: [],
       selectedAuthors: [],
       selectedPrivateLists: [],
       selectedGroup: ''
@@ -1774,6 +1792,10 @@ function App() {
 
   const handleCuisineFilterChangeFromSearch = (newSelectedCuisines) => {
     setRecipeFilters(prev => ({ ...prev, selectedCuisines: newSelectedCuisines }));
+  };
+
+  const handleMealCategoryFilterChangeFromSearch = (newSelectedCategories) => {
+    setRecipeFilters(prev => ({ ...prev, selectedCategories: newSelectedCategories }));
   };
 
   const handleAuthorFilterChangeFromSearch = (newSelectedAuthors) => {
@@ -1825,6 +1847,21 @@ function App() {
 
     return cuisineTypes.filter((type) => availableTypes.has(type));
   }, [isPrivateListSearchContext, cuisineTypes, overlayRecipes]);
+  const overlayMealCategories = useMemo(() => {
+    if (!isPrivateListSearchContext) return mealCategories;
+
+    const availableCategories = new Set();
+    overlayRecipes.forEach((recipe) => {
+      const speisekategorie = Array.isArray(recipe.speisekategorie)
+        ? recipe.speisekategorie
+        : recipe.speisekategorie
+          ? [recipe.speisekategorie]
+          : [];
+      speisekategorie.forEach((category) => availableCategories.add(category));
+    });
+
+    return mealCategories.filter((category) => availableCategories.has(category));
+  }, [isPrivateListSearchContext, mealCategories, overlayRecipes]);
   const overlayCuisineGroups = useMemo(() => {
     if (!isPrivateListSearchContext) return cuisineGroups;
 
@@ -2171,9 +2208,10 @@ function App() {
         <>
           <RecipeList
             recipes={(isSeasonalRecipesView ? seasonalTaggedRecipes : recipes).filter(recipe => 
-              matchesCategoryFilter(recipe, categoryFilter) && 
+              matchesCategoryFilter(recipe, categoryFilter) &&
               matchesDraftFilter(recipe, recipeFilters.showDrafts) &&
               matchesCuisineFilter(recipe, recipeFilters.selectedCuisines, cuisineGroups) &&
+              matchesMealCategoryFilter(recipe, recipeFilters.selectedCategories) &&
               matchesAuthorFilter(recipe, recipeFilters.selectedAuthors) &&
               matchesGroupFilter(recipe, recipeFilters.selectedGroup, groups) &&
               matchesPrivateListsFilter(recipe, recipeFilters.selectedPrivateLists, groups) &&
@@ -2242,6 +2280,9 @@ function App() {
           cuisineGroups={overlayCuisineGroups}
           onCuisineFilterChange={handleCuisineFilterChangeFromSearch}
           selectedCuisines={recipeFilters.selectedCuisines}
+          mealCategories={overlayMealCategories}
+          onMealCategoryFilterChange={handleMealCategoryFilterChangeFromSearch}
+          selectedCategories={recipeFilters.selectedCategories}
           availableAuthors={overlayAvailableAuthors}
           onAuthorFilterChange={handleAuthorFilterChangeFromSearch}
           selectedAuthors={recipeFilters.selectedAuthors}

--- a/src/components/GroupDetail.js
+++ b/src/components/GroupDetail.js
@@ -256,6 +256,7 @@ function GroupDetail({
   const hasActiveFilters = !!(searchTerm?.trim() || showFavoritesOnly || showSeasonalOnly || (activeFilters && (
     hasSelectedGroup ||
     activeFilters.selectedCuisines?.length > 0 ||
+    activeFilters.selectedCategories?.length > 0 ||
     activeFilters.selectedAuthors?.length > 0
   )));
 

--- a/src/components/MobileSearchOverlay.css
+++ b/src/components/MobileSearchOverlay.css
@@ -248,7 +248,7 @@
   flex-shrink: 0;
 }
 
-/* ─── Kulinariktypen two-row carousel (below favorites filter) ───────────── */
+/* ─── Speisekategorien / Kulinariktypen two-row carousel (below favorites filter) ─ */
 
 .mobile-search-cuisine-grid {
   display: flex;

--- a/src/components/MobileSearchOverlay.js
+++ b/src/components/MobileSearchOverlay.js
@@ -66,7 +66,7 @@ function computeTopCuisineTypes(recipes, cuisineTypes) {
   return computeAllSortedCuisineTypes(recipes, cuisineTypes).slice(0, MAX_CUISINE_TYPE_PILLS);
 }
 
-function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearch, onClearSearch, currentUser, showFavoritesOnly: showFavoritesOnlyProp, showSeasonalOnly: showSeasonalOnlyProp, onFavoritesToggle, onSeasonalToggle, seasonMatrixEntries = [], cuisineTypes, cuisineGroups, onCuisineFilterChange, selectedCuisines: selectedCuisinesProp, availableAuthors, onAuthorFilterChange, selectedAuthors: selectedAuthorsProp, privateLists, onPrivateListFilterChange, selectedPrivateLists: selectedPrivateListsProp, searchTerm: searchTermProp, showPrivateListFilters = true }) {
+function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearch, onClearSearch, currentUser, showFavoritesOnly: showFavoritesOnlyProp, showSeasonalOnly: showSeasonalOnlyProp, onFavoritesToggle, onSeasonalToggle, seasonMatrixEntries = [], cuisineTypes, cuisineGroups, onCuisineFilterChange, selectedCuisines: selectedCuisinesProp, mealCategories, onMealCategoryFilterChange, selectedCategories: selectedCategoriesProp, availableAuthors, onAuthorFilterChange, selectedAuthors: selectedAuthorsProp, privateLists, onPrivateListFilterChange, selectedPrivateLists: selectedPrivateListsProp, searchTerm: searchTermProp, showPrivateListFilters = true }) {
   const { rows: nutritionReferenceRows } = useNutritionReference();
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedTerm, setDebouncedTerm] = useState('');
@@ -74,6 +74,7 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
   const [showSeasonalOnly, setShowSeasonalOnly] = useState(false);
   const [favoriteIds, setFavoriteIds] = useState([]);
   const [selectedCuisines, setSelectedCuisines] = useState([]);
+  const [selectedCategories, setSelectedCategories] = useState([]);
   const [selectedAuthors, setSelectedAuthors] = useState([]);
   const [selectedPrivateLists, setSelectedPrivateLists] = useState([]);
   // panelBottom tracks how far from the bottom of the screen the panel sits
@@ -84,6 +85,8 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
   // it without re-triggering every time the parent filter changes.
   const selectedCuisinesPropRef = useRef(selectedCuisinesProp);
   selectedCuisinesPropRef.current = selectedCuisinesProp;
+  const selectedCategoriesPropRef = useRef(selectedCategoriesProp);
+  selectedCategoriesPropRef.current = selectedCategoriesProp;
   const selectedAuthorsPropRef = useRef(selectedAuthorsProp);
   selectedAuthorsPropRef.current = selectedAuthorsProp;
   const selectedPrivateListsPropRef = useRef(selectedPrivateListsProp);
@@ -111,6 +114,7 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
       setShowFavoritesOnly(showFavoritesOnlyProp ?? false);
       setShowSeasonalOnly(showSeasonalOnlyProp ?? false);
       setSelectedCuisines(selectedCuisinesPropRef.current ?? []);
+      setSelectedCategories(selectedCategoriesPropRef.current ?? []);
       setSelectedAuthors(selectedAuthorsPropRef.current ?? []);
       setSelectedPrivateLists(showPrivateListFilters ? (selectedPrivateListsPropRef.current ?? []) : []);
       const timer = setTimeout(() => {
@@ -180,6 +184,14 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
         return expanded.some((c) => kulinarik.includes(c));
       });
     }
+    if (selectedCategories.length > 0) {
+      list = list.filter((r) => {
+        const speisekategorie = Array.isArray(r.speisekategorie)
+          ? r.speisekategorie
+          : (r.speisekategorie ? [r.speisekategorie] : []);
+        return selectedCategories.some((c) => speisekategorie.includes(c));
+      });
+    }
     if (selectedAuthors.length > 0) {
       list = list.filter((r) => selectedAuthors.includes(r.authorId));
     }
@@ -193,7 +205,7 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
       );
     }
     return list;
-  }, [recipes, showFavoritesOnly, showSeasonalOnly, favoriteIds, selectedCuisines, cuisineGroups, selectedAuthors, selectedPrivateLists, privateLists, showPrivateListFilters, seasonMatrixEntries, nutritionReferenceRows]);
+  }, [recipes, showFavoritesOnly, showSeasonalOnly, favoriteIds, selectedCuisines, cuisineGroups, selectedCategories, selectedAuthors, selectedPrivateLists, privateLists, showPrivateListFilters, seasonMatrixEntries, nutritionReferenceRows]);
 
   const filteredRecipes = fuzzyFilter(
     baseRecipes,
@@ -250,6 +262,17 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
         incrementCuisineUsage(cuisineName);
       }
       onCuisineFilterChange?.(newValue);
+      return newValue;
+    });
+  };
+
+  const handleCategoryPillClick = (categoryName) => {
+    setSelectedCategories((prev) => {
+      const isSelected = prev.includes(categoryName);
+      const newValue = isSelected
+        ? prev.filter((c) => c !== categoryName)
+        : [...prev, categoryName];
+      onMealCategoryFilterChange?.(newValue);
       return newValue;
     });
   };
@@ -339,6 +362,35 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
     return [...active, ...inactive];
   }, [visibleCuisinePills, selectedCuisines]);
 
+  // Speisekategorien with at least one matching recipe
+  const availableCategories = useMemo(() => {
+    if (!mealCategories || mealCategories.length === 0) return [];
+    const recipeList = recipes || [];
+    const recipeCounts = {};
+    recipeList.forEach((recipe) => {
+      const speisekategorie = Array.isArray(recipe.speisekategorie)
+        ? recipe.speisekategorie
+        : (recipe.speisekategorie ? [recipe.speisekategorie] : []);
+      speisekategorie.forEach((c) => {
+        recipeCounts[c] = (recipeCounts[c] || 0) + 1;
+      });
+    });
+    return mealCategories.filter((category) => recipeCounts[category] > 0);
+  }, [recipes, mealCategories]);
+
+  const visibleCategoryPills = useMemo(() => {
+    if (!debouncedTerm) return availableCategories;
+    const lower = debouncedTerm.toLowerCase();
+    return availableCategories.filter((name) => name.toLowerCase().includes(lower));
+  }, [availableCategories, debouncedTerm]);
+
+  // Active (selected) pills are always shown first (leftmost) in the carousel
+  const orderedCategoryPills = useMemo(() => {
+    const active = visibleCategoryPills.filter((name) => selectedCategories.includes(name));
+    const inactive = visibleCategoryPills.filter((name) => !selectedCategories.includes(name));
+    return [...active, ...inactive];
+  }, [visibleCategoryPills, selectedCategories]);
+
   // Author pills: filtered by search term, active (selected) authors shown first
   const orderedAuthorPills = useMemo(() => {
     let authors = availableAuthors || [];
@@ -388,8 +440,8 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
           {!debouncedTerm && filteredRecipes.length === 0 && showFavoritesOnly && (
             <p className="mobile-search-no-results">Keine favorisierten Rezepte</p>
           )}
-          {!debouncedTerm && filteredRecipes.length === 0 && selectedCuisines.length > 0 && !showFavoritesOnly && (
-            <p className="mobile-search-no-results">Keine Rezepte für diesen Kulinariktyp</p>
+          {!debouncedTerm && filteredRecipes.length === 0 && (selectedCuisines.length > 0 || selectedCategories.length > 0) && !showFavoritesOnly && (
+            <p className="mobile-search-no-results">Keine Rezepte für diese Filterauswahl</p>
           )}
           {filteredRecipes.length > 0 && (
             <div className="mobile-search-tiles-grid">
@@ -448,6 +500,24 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
             Saisonal
           </button>
         </div>
+
+        {/* Speisekategorien – two-row horizontal carousel below the favorites filter */}
+        {/* Active (selected) pills are always shown first (leftmost) in the carousel */}
+        {visibleCategoryPills.length > 0 && (
+          <div className="mobile-search-cuisine-grid mobile-search-category-grid">
+            {orderedCategoryPills.map((name) => (
+              <button
+                key={name}
+                className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCategories.includes(name) ? ' active' : ''}`}
+                onClick={() => handleCategoryPillClick(name)}
+                aria-pressed={selectedCategories.includes(name)}
+                title={selectedCategories.includes(name) ? 'Filter aufheben' : `Nach ${name} filtern`}
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+        )}
 
         {/* Kulinariktypen – two-row horizontal carousel below the favorites filter */}
         {/* Active (selected) pills are always shown first (leftmost) in the carousel */}

--- a/src/components/MobileSearchOverlay.test.js
+++ b/src/components/MobileSearchOverlay.test.js
@@ -623,6 +623,91 @@ describe('MobileSearchOverlay – private list carousel', () => {
   });
 });
 
+describe('MobileSearchOverlay – meal category (Speisekategorie) pills', () => {
+  const mockMealCategories = ['Hauptspeisen', 'Desserts', 'Vorspeisen'];
+  const mealCategoryRecipes = [
+    { id: '1', title: 'Sushi', speisekategorie: ['Hauptspeisen'] },
+    { id: '2', title: 'Tiramisu', speisekategorie: ['Desserts'] },
+    { id: '3', title: 'Bruschetta', speisekategorie: ['Vorspeisen'] },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    const { expandCuisineSelection } = require('../utils/customLists');
+    expandCuisineSelection.mockImplementation((selected) => selected);
+  });
+
+  test('shows only meal categories that have at least one matching recipe', () => {
+    renderOverlay({
+      recipes: mealCategoryRecipes,
+      mealCategories: [...mockMealCategories, 'Drinks'],
+    });
+
+    expect(screen.getByText('Hauptspeisen')).toBeInTheDocument();
+    expect(screen.getByText('Desserts')).toBeInTheDocument();
+    expect(screen.getByText('Vorspeisen')).toBeInTheDocument();
+    expect(screen.queryByText('Drinks')).not.toBeInTheDocument();
+  });
+
+  test('clicking a category pill calls onMealCategoryFilterChange and marks it active', () => {
+    const onMealCategoryFilterChange = jest.fn();
+    renderOverlay({
+      recipes: mealCategoryRecipes,
+      mealCategories: mockMealCategories,
+      onMealCategoryFilterChange,
+    });
+
+    fireEvent.click(screen.getByText('Desserts'));
+    expect(onMealCategoryFilterChange).toHaveBeenCalledWith(['Desserts']);
+    expect(screen.getByText('Desserts')).toHaveClass('active');
+  });
+
+  test('supports multi-select and filters the tile results to matching categories', () => {
+    renderOverlay({
+      recipes: mealCategoryRecipes,
+      mealCategories: mockMealCategories,
+    });
+
+    fireEvent.click(screen.getByText('Desserts'));
+    fireEvent.click(screen.getByText('Vorspeisen'));
+
+    expect(screen.getByText('Tiramisu')).toBeInTheDocument();
+    expect(screen.getByText('Bruschetta')).toBeInTheDocument();
+    expect(screen.queryByText('Sushi')).not.toBeInTheDocument();
+  });
+
+  test('clicking an active category pill deselects it', () => {
+    const onMealCategoryFilterChange = jest.fn();
+    renderOverlay({
+      recipes: mealCategoryRecipes,
+      mealCategories: mockMealCategories,
+      onMealCategoryFilterChange,
+    });
+
+    fireEvent.click(screen.getByText('Desserts'));
+    fireEvent.click(screen.getByText('Desserts'));
+
+    expect(onMealCategoryFilterChange).toHaveBeenLastCalledWith([]);
+    expect(screen.getByText('Desserts')).not.toHaveClass('active');
+  });
+
+  test('active category pills are shown before inactive ones', () => {
+    renderOverlay({
+      recipes: mealCategoryRecipes,
+      mealCategories: mockMealCategories,
+    });
+
+    const categoryPill = (name) =>
+      screen.getAllByRole('button', { name: /^(Hauptspeisen|Desserts|Vorspeisen)$/ }).find((btn) => btn.textContent === name);
+
+    fireEvent.click(categoryPill('Vorspeisen'));
+
+    const updatedPills = screen.getAllByRole('button', { name: /^(Hauptspeisen|Desserts|Vorspeisen)$/ });
+    expect(updatedPills[0]).toHaveTextContent('Vorspeisen');
+    expect(updatedPills[0]).toHaveClass('active');
+  });
+});
+
 describe('MobileSearchOverlay – pre-populated search term', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/src/components/RecipeList.js
+++ b/src/components/RecipeList.js
@@ -111,6 +111,7 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
   const hasActiveFilters = !!(searchTerm?.trim() || showFavoritesOnlyProp || showSeasonalOnly || (activeFilters && (
     activeFilters.selectedGroup ||
     activeFilters.selectedCuisines?.length > 0 ||
+    activeFilters.selectedCategories?.length > 0 ||
     activeFilters.selectedAuthors?.length > 0 ||
     activeFilters.selectedPrivateLists?.length > 0
   )));


### PR DESCRIPTION
Die Speisekategorien lassen sich jetzt zusätzlich zum Dropdown-Pfeil
neben der Überschrift auch über den Filterdialog auswählen, analog
zur bestehenden Kulinariktypen-Filterung (Mehrfachauswahl, aktive
Pills zuerst). Die Kategorie-Pills werden zwischen der Favoriten-
/Saisonal-Zeile und den Kulinariktypen-Pills angezeigt.