### PR TITLE
Gate nutrition button visibility with buttonIconsLoaded

### DIFF
--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -2497,11 +2497,12 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
                 </div>
               )}
 
-              {/* Nutrition icon - always visible */}
+              {/* Nutrition icon */}
               {!isSharedView && (
                 <div className="metadata-item">
                   <button
                     className="nutrition-metadata-btn"
+                    style={{ visibility: buttonIconsLoaded ? 'visible' : 'hidden' }}
                     onClick={handleNutritionButtonClick}
                     disabled={recipe.naehrwerte?.calcPending}
                     title={nutritionButtonTitle}


### PR DESCRIPTION
Keeps the nutrition/kcal button consistent with the other action
buttons in the mobile-action-buttons block, which already hide until
custom button icons finish loading.