### PR TITLE
Fix: Filter-Pillen richten Breite an Text statt an Spaltenbreite aus

### DIFF
--- a/src/components/MobileSearchOverlay.css
+++ b/src/components/MobileSearchOverlay.css
@@ -255,6 +255,7 @@
   flex-direction: column;
   flex-wrap: wrap;
   align-content: flex-start;
+  align-items: flex-start;
   gap: 8px;
   padding: 4px 12px 8px;
   /* Limit to exactly 2 rows; excess pills overflow into a horizontal carousel.


### PR DESCRIPTION
.mobile-search-cuisine-grid nutzt flex-direction: column mit
flex-wrap, wodurch beide Pillen einer Spalte (Speisekategorien- und
Kulinariktyp-Karussell) durch das Standard align-items: stretch auf
die Breite der jeweils breiteren Pille gestreckt wurden. Mit
align-items: flex-start behält jede Pille ihre eigene, am Text
orientierte Breite.