### PR TITLE
Redesign SortCarousel as tap-to-select pill bar

### DIFF
--- a/src/components/RecipeList.css
+++ b/src/components/RecipeList.css
@@ -789,6 +789,11 @@
     width: 100%;
   }
 
+  /* Replaced by the sort carousel on small screens */
+  .recipe-list-heading--replaced-on-mobile {
+    display: none;
+  }
+
   .recipe-grid {
     grid-template-columns: 1fr;
   }

--- a/src/components/RecipeList.js
+++ b/src/components/RecipeList.js
@@ -125,9 +125,7 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
   const [activeSort, setActiveSort] = useState(
     () => sessionStorage.getItem(SORT_STORAGE_KEY) || 'alphabetical'
   );
-  const [carouselExpanded, setCarouselExpanded] = useState(false);
   const handleSortChange = useCallback((sort) => setActiveSort(sort), []);
-  const handleCarouselExpandChange = useCallback((expanded) => setCarouselExpanded(expanded), []);
   const [allUsers, setAllUsers] = useState([]);
   const [favoriteIds, setFavoriteIds] = useState([]);
   const [customLists, setCustomLists] = useState({ mealCategories: [] });
@@ -336,19 +334,15 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
     return author.vorname;
   };
 
-  const targetExpandedWidth = Math.min(window.innerWidth * 0.85, 320);
-  const collapsedWidth = 160; // oder später dynamisch aus dem Carousel ableiten
-  const widthDelta = targetExpandedWidth - collapsedWidth;
-  const filterShift = carouselExpanded ? -(widthDelta / 2) : 0;
-  const filterTransform = `translateX(${filterShift}px)`;
-  const addShift = carouselExpanded ? window.innerWidth : 0;
-
   return (
     <div className="recipe-list-container">
       <div className="recipe-list-header">
         <div className="recipe-list-header-top">
           <div className="recipe-list-title-area">
-            <h2>{getHeading()}</h2>
+            <h2 className={currentUser?.sortCarousel ? 'recipe-list-heading--replaced-on-mobile' : ''}>{getHeading()}</h2>
+            {currentUser?.sortCarousel && (
+              <SortCarousel activeSort={activeSort} onSortChange={handleSortChange} />
+            )}
             {onCategoryFilterChange && (
               <select
                 className="category-filter-arrow"
@@ -369,7 +363,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
               <button 
                   ref={filterButtonRef}
                   className={`filter-button ${hasActiveFilters ? 'has-active-filters' : ''} ${filterPressed ? 'pressed' : ''}`}
-                  style={{ '--filter-transform': filterTransform }}
                   onTouchStart={handleFilterTouchStart}
                   onTouchEnd={handleFilterTouchEnd}
                   onTouchCancel={handleFilterTouchCancel}
@@ -398,7 +391,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
                   {!activePrivateListId && (
                     <button
                       className={`add-icon-button ${addPressed ? 'pressed' : ''}`}
-                      style={{ '--add-shift': `${addShift}px` }}
                       onClick={() => onAddRecipe()}
                       onTouchStart={() => setAddPressed(true)}
                       onTouchEnd={() => setAddPressed(false)}
@@ -419,7 +411,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
                   {activePrivateListId && (
                     <button
                       className={`add-icon-button ${addPressed ? 'pressed' : ''}`}
-                      style={{ '--add-shift': `${addShift}px` }}
                       onClick={() => onAddRecipe(activePrivateListId)}
                       onTouchStart={() => setAddPressed(true)}
                       onTouchEnd={() => setAddPressed(false)}
@@ -440,9 +431,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
                 </>
               )}
             </div>
-            {currentUser?.sortCarousel && (
-              <SortCarousel activeSort={activeSort} onSortChange={handleSortChange} onExpandChange={handleCarouselExpandChange} />
-            )}
           </div>
         </div>
       </div>

--- a/src/components/SortCarousel.css
+++ b/src/components/SortCarousel.css
@@ -1,191 +1,66 @@
 /* ─── SortCarousel ─────────────────────────────────────────────────────────── */
 
-/* Mobile-only: hidden on desktop, visible only at ≤ 480 px */
+/* Mobile-only: hidden on desktop, visible only at ≤ 480 px, where it takes
+   the place of the recipe overview heading. */
 .sort-carousel {
   display: none;
 }
 
 @media (max-width: 480px) {
   .sort-carousel {
-    position: fixed;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
-    isolation: isolate;
-    z-index: 1000;
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    overflow: hidden;
-    /* Collapsed: exactly as wide as one item (set dynamically by JS)
-    max-width: var(--sort-carousel-visible-width); */
-    border-radius: 25px;
-    background: linear-gradient(
-      135deg,
-      rgba(64,44,28,0.85) 0%,
-      rgba(26,26,26,0.85) 100%
-    );
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-    user-select: none;
-    /* Allow vertical page-scroll while JS handles horizontal swipes */
-    touch-action: pan-y;
-    -webkit-tap-highlight-color: transparent;
-    outline: none;
-    /* Transitions deaktiviert bis zur ersten Messung, um Flash zu vermeiden */
-    transition: none;
+    gap: 0.5rem;
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    -webkit-overflow-scrolling: touch;
+    padding: 0.15rem 0.05rem;
   }
 
-  /* Transitions erst aktivieren, nachdem JS die Item-Breite gemessen hat */
-  .sort-carousel.sort-carousel--measured {
-    transition: box-shadow 0.25s ease;
+  .sort-carousel::-webkit-scrollbar {
+    display: none;
   }
-
-  .sort-carousel:focus-visible {
-    box-shadow: 0 0 0 3px rgba(223, 122, 0, 0.5), 0 2px 4px rgba(0, 0, 0, 0.15);
-  }
-
-  /* Expanded: reveal neighbours on both sides; take full touch control */
-  .sort-carousel--expanded {
-    /* --sort-carousel-visible-width: calc(var(--sort-item-width, 160px) * 3 + 2rem);
-    max-width: var(--sort-carousel-visible-width); */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-    touch-action: pan-x;
-  }
-}
-
-/* ─── Track ─────────────────────────────────────────────────────────────────── */
-
-.sort-carousel-track {
-  display: flex;
-  /* Items don't shrink; track can scroll freely */
-  flex-wrap: nowrap;
-  will-change: transform;
-  /* Transitions deaktiviert bis zur ersten Messung */
-  transition: none;
-}
-
-/* Smooth track transition nur nach Messung und wenn nicht gedraggt wird */
-.sort-carousel--measured .sort-carousel-track {
-  transition: none;
-}
-
-/* While dragging, disable the CSS transition so the track follows the finger instantly */
-.sort-carousel--dragging .sort-carousel-track {
-  transition: none;
 }
 
 /* ─── Items ─────────────────────────────────────────────────────────────────── */
 
 .sort-carousel-item {
   flex: 0 0 auto;
-  width: auto;
-  min-width: max-content;
-  padding: 0.6rem 1rem;
-  text-align: center;
-  font-size: 0.9rem;
+  scroll-snap-align: center;
+
+  appearance: none;
+  -webkit-appearance: none;
+  background: white;
+  color: #666;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
-  color: #ffffff;
   white-space: nowrap;
-  border-radius: 25px;
-  transition: color 0.25s ease, transform 0.25s ease;
-  pointer-events: none;
+
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
 }
 
-/* Subtle scale-up for the active item when expanded */
-.sort-carousel--expanded .sort-carousel-item--active {
-  transform: scale(1.02);
+.sort-carousel-item:active {
+  transform: scale(0.96);
 }
 
-/* Non-active items are invisible in collapsed state (they're clipped anyway) */
-.sort-carousel:not(.sort-carousel--expanded) .sort-carousel-item:not(.sort-carousel-item--active) {
-  color: rgba(255, 255, 255, 0);
+.sort-carousel-item--active {
+  background: linear-gradient(135deg, #DF7A00 0%, #c46900 100%);
+  color: white;
+  border-color: #DF7A00;
 }
 
-/* ─── Collapsed pill ─────────────────────────────────────────────────────────── */
-
-@media (max-width: 480px) {
-  /* Transparent inner pill with silver border + glow, always visible */
-  .sort-carousel::after {
-      content: '';
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: min(calc(var(--sort-max-item-width, 160px) - 12px), calc(100% - 12px));
-      height: calc(100% - 8px);
-      border-radius: 25px;
-      pointer-events: none;
-      z-index: 2;
-    
-      /* sehr dezente Innenfläche */
-      background: rgba(255, 255, 255, 0.02);
-    
-      /* Apple-artiger Grundglow */
-      box-shadow:
-        inset 0 0 0 1px rgba(255,255,255,0.08),
-        0 0 10px rgba(255,255,255,0.06);
-    }  
-  
-    .sort-carousel::before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: min(calc(var(--sort-max-item-width, 160px) - 12px), calc(100% - 12px));
-    height: calc(100% - 8px);
-    border-radius: 25px;
-    pointer-events: none;
-    z-index: 3;
-    padding: 1.25px;
-  
-    background:
-      conic-gradient(
-        from 225deg,
-        transparent 0deg,
-        transparent 28deg,
-  
-        rgba(255,255,255,0.10) 40deg,
-        rgba(255,255,255,0.75) 62deg,
-        rgba(255,255,255,0.95) 82deg,
-        rgba(255,255,255,0.55) 102deg,
-        rgba(255,255,255,0.12) 118deg,
-  
-        transparent 132deg,
-        transparent 208deg,
-  
-        rgba(255,255,255,0.10) 222deg,
-        rgba(255,255,255,0.55) 242deg,
-        rgba(255,255,255,0.95) 262deg,
-        rgba(255,255,255,0.75) 282deg,
-        rgba(255,255,255,0.10) 300deg,
-  
-        transparent 314deg,
-        transparent 360deg
-      );
-  
-    -webkit-mask:
-      linear-gradient(#000 0 0) content-box,
-      linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-  
-    filter: drop-shadow(0 0 4px rgba(255,255,255,0.18))
-            drop-shadow(0 0 8px rgba(255,255,255,0.10));
-  }  
-
-  .sort-carousel--expanded::before {
-    filter: drop-shadow(0 0 5px rgba(255,255,255,0.22))
-            drop-shadow(0 0 10px rgba(255,255,255,0.12));
-    animation: cameraGlowPulse 1.8s ease-in-out infinite;
-  }
-  
-  @keyframes cameraGlowPulse {
-    0%, 100% {
-      opacity: 0.92;
-    }
-    50% {
-      opacity: 1;
-    }
-  }
+.sort-carousel-item:focus-visible {
+  outline: 2px solid #DF7A00;
+  outline-offset: 2px;
 }
-

--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useRef,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-} from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import './SortCarousel.css';
 
 export const SORT_OPTIONS = [
@@ -15,437 +9,62 @@ export const SORT_OPTIONS = [
   { id: 'index', label: 'Nach Relevanz' },
 ];
 
-const LONG_PRESS_DELAY = 300;
-const HORIZONTAL_SWIPE_MIN = 10;
-const SWIPE_THRESHOLD = 12;
-const FALLBACK_ITEM_WIDTH = 160;
-
-function clampLoop(index, length) {
-  return ((index % length) + length) % length;
-}
-
-function velocityToSteps(velocity) {
-  if (velocity >= 0.8) return Math.min(Math.round(velocity * 3), 4);
-  if (velocity >= 0.3) return 2;
-  return 1;
-}
-
-function SortCarousel({ activeSort = 'alphabetical', onSortChange, onExpandChange }) {
-  const carouselRef = useRef(null);
-  const trackRef = useRef(null);
+// Simple tap-to-select pill bar with native horizontal scrolling/snapping.
+// Replaces the previous long-press + drag gesture carousel, whose custom
+// touch-velocity math reacted unpredictably.
+function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   const itemRefs = useRef([]);
-  const itemMetricsRef = useRef([]);
-  const gestureViewportWidthRef = useRef(null);
-
-  const [expanded, setExpanded] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragOffset, setDragOffset] = useState(0);
-  const [isMeasured, setIsMeasured] = useState(false);
-  const [freezeViewportWidth, setFreezeViewportWidth] = useState(null);
-
-  const onExpandChangeRef = useRef(onExpandChange);
-
-  const gestureRef = useRef({
-    startX: null,
-    startY: null,
-    dragStartX: null,
-    startTime: null,
-    longPressTimer: null,
-    isExpanded: false,
-    isDragging: false,
-  });
 
   const activeIndex = SORT_OPTIONS.findIndex((o) => o.id === activeSort);
   const safeIndex = activeIndex >= 0 ? activeIndex : 0;
 
   useEffect(() => {
-    onExpandChangeRef.current = onExpandChange;
-  }, [onExpandChange]);
+    itemRefs.current[safeIndex]?.scrollIntoView?.({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'center',
+    });
+  }, [safeIndex]);
 
-  useEffect(() => {
-    onExpandChangeRef.current?.(expanded);
-  }, [expanded]);
-
-  // --- Wiederverwendbare Helfer ---
-
-  const clearLongPressTimer = useCallback(() => {
-    if (gestureRef.current.longPressTimer) {
-      clearTimeout(gestureRef.current.longPressTimer);
-      gestureRef.current.longPressTimer = null;
-    }
-  }, []);
-
-  const resetGesture = useCallback(() => {
-    clearLongPressTimer();
-    gestureRef.current.startX = null;
-    gestureRef.current.startY = null;
-    gestureRef.current.dragStartX = null;
-    gestureRef.current.startTime = null;
-    gestureRef.current.isDragging = false;
-  }, [clearLongPressTimer]);
-
-  const collapse = useCallback(() => {
-    resetGesture();
-    gestureRef.current.isExpanded = false;
-    gestureViewportWidthRef.current = null;
-    setFreezeViewportWidth(null);
-    setExpanded(false);
-    setIsDragging(false);
-    setDragOffset(0);
-  }, [resetGesture]);
-
-  const selectIndex = useCallback(
-    (idx) => {
-      const nextIndex = clampLoop(idx, SORT_OPTIONS.length);
-      onSortChange?.(SORT_OPTIONS[nextIndex].id);
-      collapse();
+  const handleSelect = useCallback(
+    (id) => {
+      if (id !== activeSort) onSortChange?.(id);
     },
-    [collapse, onSortChange]
+    [activeSort, onSortChange]
   );
-
-  // --- Messung ---  
-  const applyMeasurementsToDom = useCallback(() => {
-    const carouselEl = carouselRef.current;
-    const trackEl = trackRef.current;
-    if (!carouselEl || !trackEl) return;
-
-    const items = itemRefs.current.filter(Boolean);
-    if (!items.length) return;
-
-    const trackRect = trackEl.getBoundingClientRect();
-
-  const metrics = items.map((item) => {
-    const rect = item.getBoundingClientRect();
-    const width = rect.width || item.scrollWidth || FALLBACK_ITEM_WIDTH;
-    const left = rect.left - trackRect.left;
-    const center = left + width / 2;
-  
-    return {
-      width,
-      left,
-      center,
-    };
-  });
-  
-  const maxWidth = Math.max(...metrics.map(m => m.width));
-  
-  carouselEl.style.setProperty('--sort-max-item-width', `${maxWidth}px`);
-
-    itemMetricsRef.current = metrics;
-    setIsMeasured(true);
-  }, []);
-  
-  useLayoutEffect(() => {
-    applyMeasurementsToDom();
-
-    const carouselEl = carouselRef.current;
-    if (!carouselEl) return;
-
-    if (typeof ResizeObserver !== 'undefined') {
-      const resizeObserver = new ResizeObserver(() => {
-        applyMeasurementsToDom();
-      });
-
-      resizeObserver.observe(carouselEl);
-
-      return () => {
-        resizeObserver.disconnect();
-      };
-    }
-  }, [applyMeasurementsToDom]);
-
-  // --- Keyboard ---
 
   const onKeyDown = useCallback(
     (e) => {
-      if (!expanded) {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          gestureRef.current.isExpanded = true;
-          setExpanded(true);
-        }
-        return;
-      }
-
-      if (e.key === 'ArrowLeft') {
-        e.preventDefault();
-        selectIndex(safeIndex - 1);
-      } else if (e.key === 'ArrowRight') {
-        e.preventDefault();
-        selectIndex(safeIndex + 1);
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        collapse();
-      } else if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        collapse();
-      }
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+      e.preventDefault();
+      const delta = e.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (safeIndex + delta + SORT_OPTIONS.length) % SORT_OPTIONS.length;
+      handleSelect(SORT_OPTIONS[nextIndex].id);
+      itemRefs.current[nextIndex]?.focus();
     },
-    [collapse, expanded, safeIndex, selectIndex]
+    [safeIndex, handleSelect]
   );
 
-  const activeMetric = itemMetricsRef.current?.[safeIndex];
-  const activeWidth = activeMetric?.width ?? FALLBACK_ITEM_WIDTH;
-
-  const expandWithFrozenViewport = useCallback(() => {
-    const currentWidth =
-      carouselRef.current?.getBoundingClientRect().width || activeWidth;
-  
-    setFreezeViewportWidth(currentWidth);
-    gestureViewportWidthRef.current = currentWidth;
-  
-    setExpanded(true);
-  
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setFreezeViewportWidth(null);
-        gestureViewportWidthRef.current = null;
-      });
-    });
-  }, [activeWidth]);
-
-  // --- Touch-Gesten ---
-
-  const beginExpandedDrag = useCallback((clientX) => {
-    gestureRef.current.isExpanded = true;
-    gestureRef.current.isDragging = true;
-    gestureRef.current.dragStartX = clientX;
-  
-    if (!expanded) {
-      expandWithFrozenViewport();
-    }
-  
-    setIsDragging(true);
-    setDragOffset(0);
-  }, [expanded, expandWithFrozenViewport]);
-
-  const onTouchStart = useCallback(
-    (e) => {
-      const touch = e.touches[0];
-      if (!touch) return;
-
-      gestureRef.current.startX = touch.clientX;
-      gestureRef.current.startY = touch.clientY;
-      gestureRef.current.startTime = Date.now();
-
-      if (!gestureRef.current.isExpanded) {
-          gestureRef.current.longPressTimer = setTimeout(() => {
-            gestureRef.current.longPressTimer = null;
-            gestureRef.current.isExpanded = true;
-            setExpanded(true);
-          }, LONG_PRESS_DELAY);
-        
-      } else {
-        beginExpandedDrag(touch.clientX);
-      }
-    },
-    [beginExpandedDrag]
-  );
-
-  const onTouchMove = useCallback(
-    (e) => {
-      const touch = e.touches[0];
-      if (!touch) return;
-      if (gestureRef.current.startX === null || gestureRef.current.startY === null) return;
-
-      const deltaX = touch.clientX - gestureRef.current.startX;
-      const deltaY = touch.clientY - gestureRef.current.startY;
-
-      if (!gestureRef.current.isExpanded) {
-        const isHorizontalIntent =
-          Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > HORIZONTAL_SWIPE_MIN;
-
-        if (isHorizontalIntent) {
-          clearLongPressTimer();
-          beginExpandedDrag(touch.clientX);
-        }
-        return;
-      }
-
-      if (!gestureRef.current.isDragging) {
-        gestureRef.current.isDragging = true;
-        gestureRef.current.dragStartX = touch.clientX;
-
-        gestureViewportWidthRef.current =
-          carouselRef.current?.getBoundingClientRect().width || null;
-        
-        setIsDragging(true);
-        return;
-      }
-
-      setDragOffset(touch.clientX - gestureRef.current.dragStartX);
-    },
-    [beginExpandedDrag, clearLongPressTimer]
-  );
-
-  const onTouchEnd = useCallback(
-    (e) => {
-      clearLongPressTimer();
-
-      const touch = e.changedTouches[0];
-      if (!touch || gestureRef.current.startX === null) {
-        resetGesture();
-        return;
-      }
-
-      const wasExpanded = gestureRef.current.isExpanded;
-      const effectiveStartX =
-        gestureRef.current.dragStartX ?? gestureRef.current.startX;
-      const delta = touch.clientX - effectiveStartX;
-      const gestureStartTime = gestureRef.current.startTime;
-
-      resetGesture();
-      gestureRef.current.isExpanded = false;
-      setIsDragging(false);
-
-      if (!wasExpanded) {
-        setDragOffset(0);
-        return;
-      }
-
-      const elapsed = Date.now() - (gestureStartTime ?? Date.now());
-      const velocity = elapsed > 0 ? Math.abs(delta) / elapsed : 0;
-
-      if (Math.abs(delta) > SWIPE_THRESHOLD && velocity >= 0.3) {
-        const steps = velocityToSteps(velocity);
-        selectIndex(delta < 0 ? safeIndex + steps : safeIndex - steps);
-        return;
-      }
-
-      // Erst präziser visueller Snap, dann Fallback über Delta
-      const carouselEl = carouselRef.current;
-      const trackEl = trackRef.current;
-
-      if (carouselEl && trackEl) {
-        const carouselRect = carouselEl.getBoundingClientRect();
-
-        if (carouselRect.width > 0) {
-          const carouselCenter = carouselRect.left + carouselRect.width / 2;
-          const items = trackEl.querySelectorAll('.sort-carousel-item');
-
-          let closestIndex = -1;
-          let closestDist = Infinity;
-
-          items.forEach((item, idx) => {
-            const rect = item.getBoundingClientRect();
-            const itemCenter = rect.left + rect.width / 2;
-            const dist = Math.abs(itemCenter - carouselCenter);
-
-            if (dist < closestDist) {
-              closestDist = dist;
-              closestIndex = idx;
-            }
-          });
-
-          if (closestIndex >= 0) {
-            selectIndex(closestIndex);
-            return;
-          }
-        }
-      }
-
-      // Fallback, falls Rects z. B. in Tests unbrauchbar sind
-      
-      const currentMetric = itemMetricsRef.current[safeIndex];
-      const referenceWidth = currentMetric?.width || FALLBACK_ITEM_WIDTH;
-
-      if (delta < -SWIPE_THRESHOLD) {
-        const steps = Math.max(1, Math.round(-delta / referenceWidth));
-        selectIndex(safeIndex + steps);
-        return;
-      }
-
-      if (delta > SWIPE_THRESHOLD) {
-        const steps = Math.max(1, Math.round(delta / referenceWidth));
-        selectIndex(safeIndex - steps);
-        return;
-      }
-
-      collapse();
-    },
-    [clearLongPressTimer, collapse, resetGesture, safeIndex, selectIndex]
-  );
-  
-  const targetExpandedWidth = Math.min(window.innerWidth * 0.85, 320);
-  const effectiveCarouselWidth =
-    freezeViewportWidth ?? (expanded ? targetExpandedWidth : activeWidth);
-  
-  const carouselStyle = {
-    width: `${effectiveCarouselWidth}px`,
-  };
-  
-  /*const liveViewportWidth =
-    freezeViewportWidth ||
-    carouselRef.current?.getBoundingClientRect().width ||
-    effectiveCarouselWidth; */
-  
-  const currentViewportWidth =
-    isDragging && gestureViewportWidthRef.current
-      ? gestureViewportWidthRef.current
-      : effectiveCarouselWidth;
-  
-  const viewportCenter = currentViewportWidth / 2;
-  
-  const activeCenter =
-    activeMetric?.center ??
-    (safeIndex * activeWidth + activeWidth / 2);
-  
-  const trackStyle = {
-    transform: `translate3d(${viewportCenter - activeCenter + dragOffset}px, 0, 0)`,
-  };
-  
   return (
-    <>
-      <div
-        ref={carouselRef}
-        style={carouselStyle}
-        className={[
-          'sort-carousel',
-          expanded && 'sort-carousel--expanded',
-          isDragging && 'sort-carousel--dragging',
-          isMeasured && 'sort-carousel--measured',
-        ]
-          .filter(Boolean)
-          .join(' ')}
-        role="listbox"
-        aria-label="Sortierung"
-        aria-expanded={expanded}
-        tabIndex={0}
-        onKeyDown={onKeyDown}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-      >
-        <div
-          ref={trackRef}
-          className="sort-carousel-track"
-          style={trackStyle}
+    <div className="sort-carousel" role="tablist" aria-label="Sortierung">
+      {SORT_OPTIONS.map((option, idx) => (
+        <button
+          key={option.id}
+          ref={(el) => {
+            itemRefs.current[idx] = el;
+          }}
+          type="button"
+          role="tab"
+          aria-selected={idx === safeIndex}
+          tabIndex={idx === safeIndex ? 0 : -1}
+          className={`sort-carousel-item${idx === safeIndex ? ' sort-carousel-item--active' : ''}`}
+          onClick={() => handleSelect(option.id)}
+          onKeyDown={onKeyDown}
         >
-          {SORT_OPTIONS.map((option, idx) => (
-            <div
-              key={option.id}
-              ref={(el) => {
-                itemRefs.current[idx] = el;
-              }}
-              className={`sort-carousel-item${idx === safeIndex ? ' sort-carousel-item--active' : ''}`}
-              role="option"
-              aria-selected={idx === safeIndex}
-          >
-              {option.label}
-            </div>
-        ))}
-        </div>
-      </div>
-
-      <div className="sort-carousel-indicator" aria-hidden="true">
-        {SORT_OPTIONS.map((option, idx) => (
-          <span
-            key={option.id}
-            className={`sort-carousel-dot${idx === safeIndex ? ' sort-carousel-dot--active' : ''}`}
-          />
-        ))}
-      </div>
-    </>
+          {option.label}
+        </button>
+      ))}
+    </div>
   );
 }
 

--- a/src/components/SortCarousel.test.js
+++ b/src/components/SortCarousel.test.js
@@ -1,55 +1,13 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import SortCarousel, { SORT_OPTIONS } from './SortCarousel';
 
-// JSDOM does not implement ResizeObserver — provide a no-op mock so the component
-// can register/unregister observers without throwing.
-global.ResizeObserver = class ResizeObserver {
-  constructor(cb) { this.cb = cb; }
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
-
-// Helper: fire a complete touch gesture (touchStart → [expand step] → touchMove → touchEnd).
-// For swipes larger than 10 px, one intermediate touchMove is fired at startX ± 11 px to
-// trigger expansion and simultaneously start drag tracking (sets dragStartX).
-function simulateTouchSwipe(element, startX, endX, startY = 100, endY = 100) {
-  fireEvent.touchStart(element, { touches: [{ clientX: startX, clientY: startY }] });
-  if (Math.abs(endX - startX) > 10) {
-    const expandX = endX < startX ? startX - 11 : startX + 11;
-    // Intermediate: triggers expansion and starts drag tracking simultaneously
-    fireEvent.touchMove(element, { touches: [{ clientX: expandX, clientY: startY }] });
-  }
-  fireEvent.touchMove(element, { touches: [{ clientX: endX, clientY: endY }] });
-  fireEvent.touchEnd(element, { changedTouches: [{ clientX: endX, clientY: endY }] });
-}
-
-// Helper: mock the first carousel item's getBoundingClientRect to return a known width
-function mockItemWidth(container, width) {
-  const items = container.firstChild
-    .querySelector('.sort-carousel-track')
-    .querySelectorAll('.sort-carousel-item');
-  jest.spyOn(items[0], 'getBoundingClientRect').mockReturnValue({
-    width, height: 40, top: 0, left: 0, right: width, bottom: 40,
-  });
-}
+// JSDOM does not implement scrollIntoView — provide a no-op mock.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
 
 describe('SortCarousel', () => {
-  // Freeze Date.now so all non-velocity tests see elapsed=0 → velocity=0 → old paths.
-  let nowSpy;
-  beforeEach(() => {
-    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
-  });
-  afterEach(() => {
-    nowSpy.mockRestore();
-  });
-
-  test('renders the active option label', () => {
-    render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
-    expect(screen.getByText('Alphabetisch')).toBeInTheDocument();
-  });
-
   test('renders all option labels', () => {
     render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
     SORT_OPTIONS.forEach(opt => {
@@ -57,199 +15,65 @@ describe('SortCarousel', () => {
     });
   });
 
-  test('starts collapsed (no expanded class)', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-  });
-
-  test('expands on long press', () => {
-    jest.useFakeTimers();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    fireEvent.touchStart(container.firstChild, { touches: [{ clientX: 100, clientY: 100 }] });
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-    act(() => { jest.advanceTimersByTime(300); });
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-    jest.useRealTimers();
-  });
-
-  test('expands immediately on horizontal swipe', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    fireEvent.touchStart(container.firstChild, { touches: [{ clientX: 100, clientY: 100 }] });
-    fireEvent.touchMove(container.firstChild, { touches: [{ clientX: 115, clientY: 100 }] });
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-  });
-
-  test('sets dragging class while finger is moving', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    fireEvent.touchStart(container.firstChild, { touches: [{ clientX: 200, clientY: 100 }] });
-    // First move crosses HORIZONTAL_SWIPE_MIN: expands AND starts dragging immediately
-    fireEvent.touchMove(container.firstChild, { touches: [{ clientX: 215, clientY: 100 }] });
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-    expect(container.firstChild).toHaveClass('sort-carousel--dragging');
-  });
-
-  test('selects next sort option via swipe left and collapses', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    simulateTouchSwipe(container.firstChild, 200, 100); // -100 px > threshold
-    expect(handleChange).toHaveBeenCalledWith('trending');
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-  });
-
-  test('selects previous sort option via swipe right', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="trending" onSortChange={handleChange} />
-    );
-    simulateTouchSwipe(container.firstChild, 100, 200); // +100 px > threshold
-    expect(handleChange).toHaveBeenCalledWith('alphabetical');
-  });
-
-  test('multi-step swipe left skips multiple options based on item width', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    // swipe left ~500 px from drag origin (after expansion step): 489/160 ≈ 3.06 → 3 steps from 'alphabetical' → 'rating'
-    simulateTouchSwipe(container.firstChild, 600, 100);
-    expect(handleChange).toHaveBeenCalledWith('rating');
-  });
-
-  test('multi-step swipe right skips multiple options based on item width', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="rating" onSortChange={handleChange} />
-    );
-    // swipe right ~500 px from drag origin (after expansion step): 489/160 ≈ 3.06 → 3 steps back → index 0 → 'alphabetical'
-    simulateTouchSwipe(container.firstChild, 100, 600);
-    expect(handleChange).toHaveBeenCalledWith('alphabetical');
-  });
-
-  test('short swipe collapses without changing sort', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    // 20 px: expands (> 10 px) but below the 30 px sort threshold
-    simulateTouchSwipe(container.firstChild, 200, 220);
-    expect(handleChange).not.toHaveBeenCalled();
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-  });
-
-  test('very short tap (< 10 px) does not expand', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    simulateTouchSwipe(container.firstChild, 200, 205); // 5 px — below expand threshold
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-  });
-
-  test('initial dragOffset on expansion is 0 (no visual jump)', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    const track = container.firstChild.querySelector('.sort-carousel-track');
-    const transformBefore = track.style.transform;
-    // Trigger expansion via horizontal swipe (deltaX = 15 > 10 px threshold)
-    fireEvent.touchStart(container.firstChild, { touches: [{ clientX: 100, clientY: 100 }] });
-    fireEvent.touchMove(container.firstChild, { touches: [{ clientX: 115, clientY: 100 }] });
-    // Carousel should be expanded…
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-    // …but the track transform must not have shifted (dragOffset = 0, no visual jump)
-    expect(track.style.transform).toBe(transformBefore);
-  });
-
-  test('keyboard: Enter expands the carousel', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' });
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-  });
-
-  test('keyboard: Escape collapses the carousel', () => {
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={() => {}} />
-    );
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' });
-    expect(container.firstChild).toHaveClass('sort-carousel--expanded');
-    fireEvent.keyDown(container.firstChild, { key: 'Escape' });
-    expect(container.firstChild).not.toHaveClass('sort-carousel--expanded');
-  });
-
-  test('keyboard: ArrowRight advances to next option', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' }); // expand
-    fireEvent.keyDown(container.firstChild, { key: 'ArrowRight' });
-    expect(handleChange).toHaveBeenCalledWith('trending');
-  });
-
-  test('keyboard: ArrowLeft wraps around to last option', () => {
-    const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    fireEvent.keyDown(container.firstChild, { key: 'Enter' }); // expand
-    fireEvent.keyDown(container.firstChild, { key: 'ArrowLeft' });
-    // 'alphabetical' is index 0, wrapping back goes to last item
-    expect(handleChange).toHaveBeenCalledWith(SORT_OPTIONS[SORT_OPTIONS.length - 1].id);
-  });
-
   test('active item has aria-selected=true', () => {
     render(<SortCarousel activeSort="newest" onSortChange={() => {}} />);
-    const activeItem = screen.getByRole('option', { name: 'Neue Rezepte' });
+    const activeItem = screen.getByRole('tab', { name: 'Neue Rezepte' });
     expect(activeItem).toHaveAttribute('aria-selected', 'true');
+    expect(activeItem).toHaveClass('sort-carousel-item--active');
   });
 
   test('non-active items have aria-selected=false', () => {
     render(<SortCarousel activeSort="newest" onSortChange={() => {}} />);
-    const inactiveItem = screen.getByRole('option', { name: 'Alphabetisch' });
+    const inactiveItem = screen.getByRole('tab', { name: 'Alphabetisch' });
     expect(inactiveItem).toHaveAttribute('aria-selected', 'false');
+    expect(inactiveItem).not.toHaveClass('sort-carousel-item--active');
   });
 
-  test('fast swipe left uses velocity-based steps', () => {
+  test('clicking an option selects it directly', () => {
     const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="alphabetical" onSortChange={handleChange} />
-    );
-    // Override frozen clock: 1st call (touchStart) → 1000, rest (touchEnd) → 1200
-    let nowCallCount = 0;
-    nowSpy.mockImplementation(() => nowCallCount++ === 0 ? 1000 : 1200);
+    render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
 
-    // Swipe left: dragStartX = 300-11=289, endX=100 → delta=-189 px, elapsed=200 ms
-    // velocity = 189/200 = 0.945 px/ms → steps = min(round(0.945*3), 4) = 3
-    // selectIndex(0 + 3) → 'rating'
-    simulateTouchSwipe(container.firstChild, 300, 100);
+    fireEvent.click(screen.getByRole('tab', { name: 'Im Trend' }));
 
-    expect(handleChange).toHaveBeenCalledWith('rating');
+    expect(handleChange).toHaveBeenCalledWith('trending');
   });
 
-  test('fast swipe right uses velocity-based steps', () => {
+  test('clicking the already-active option does not call onSortChange', () => {
     const handleChange = jest.fn();
-    const { container } = render(
-      <SortCarousel activeSort="rating" onSortChange={handleChange} />
-    );
-    let nowCallCount = 0;
-    nowSpy.mockImplementation(() => nowCallCount++ === 0 ? 1000 : 1200);
+    render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
 
-    // Swipe right: dragStartX = 100+11=111, endX=300 → delta=189 px, elapsed=200 ms
-    // velocity = 189/200 = 0.945 px/ms → steps = 3
-    // selectIndex(3 - 3) → 'alphabetical'
-    simulateTouchSwipe(container.firstChild, 100, 300);
+    fireEvent.click(screen.getByRole('tab', { name: 'Alphabetisch' }));
 
-    expect(handleChange).toHaveBeenCalledWith('alphabetical');
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  test('only the active option is reachable via Tab (roving tabindex)', () => {
+    render(<SortCarousel activeSort="rating" onSortChange={() => {}} />);
+
+    expect(screen.getByRole('tab', { name: 'Nach Bewertung' })).toHaveAttribute('tabIndex', '0');
+    expect(screen.getByRole('tab', { name: 'Alphabetisch' })).toHaveAttribute('tabIndex', '-1');
+  });
+
+  test('keyboard: ArrowRight selects the next option', () => {
+    const handleChange = jest.fn();
+    render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Alphabetisch' }), { key: 'ArrowRight' });
+
+    expect(handleChange).toHaveBeenCalledWith('trending');
+  });
+
+  test('keyboard: ArrowLeft wraps around to the last option', () => {
+    const handleChange = jest.fn();
+    render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
+
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Alphabetisch' }), { key: 'ArrowLeft' });
+
+    expect(handleChange).toHaveBeenCalledWith(SORT_OPTIONS[SORT_OPTIONS.length - 1].id);
+  });
+
+  test('has an accessible tablist role', () => {
+    render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
+    expect(screen.getByRole('tablist', { name: 'Sortierung' })).toBeInTheDocument();
   });
 });

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3027,6 +3027,18 @@
   border-color: #555;
 }
 
+[data-theme="dark"] .sort-carousel-item {
+  background: #2a2a2a;
+  color: #aaa;
+  border-color: #555;
+}
+
+[data-theme="dark"] .sort-carousel-item--active {
+  background: linear-gradient(135deg, #DF7A00 0%, #c46900 100%);
+  color: white;
+  border-color: #DF7A00;
+}
+
 [data-theme="dark"] .recipe-image {
   background: #2a2a2a;
 }


### PR DESCRIPTION
Replace the long-press + drag gesture carousel with simple tap-to-select
pills using native horizontal scroll/snap, since the custom touch-velocity
gestures reacted unpredictably. On mobile (≤480px), the carousel now sits
above the recipe grid in place of the "Kochbuch"/list/category heading;
larger screens are unchanged. Styling follows the app's existing pill-button
language (rounded chips, orange gradient active state, dark-mode variants).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018MuwwKL461Yc2fXFcWcwti