### PR TITLE
Remove category filter arrow from recipe overview heading

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -71,14 +71,6 @@ test('recipe form has default values for new fields', () => {
   expect(filledStars).toHaveLength(3);
 });
 
-test('category filter is displayed in header', () => {
-  setupLoggedInUser();
-  render(<App />);
-  const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-  expect(categoryFilter).toBeInTheDocument();
-  expect(categoryFilter).toHaveValue('');
-});
-
 test('favorites filter button is displayed in header', () => {
   setupLoggedInUser();
   render(<App />);
@@ -86,176 +78,14 @@ test('favorites filter button is displayed in header', () => {
   expect(favoritesButton).toBeInTheDocument();
 });
 
-test('category filter shows only recipes of selected category', () => {
-  setupLoggedInUser();
-  render(<App />);
-  
-  // Initially should show all 3 sample recipes
-  expect(screen.getByText('Spaghetti Carbonara')).toBeInTheDocument();
-  expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument();
-  expect(screen.getByText('Chocolate Chip Cookies')).toBeInTheDocument();
-  
-  // Filter by Dessert
-  const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-  fireEvent.change(categoryFilter, { target: { value: 'Dessert' } });
-  
-  // Should only show Dessert recipes
-  expect(screen.queryByText('Spaghetti Carbonara')).not.toBeInTheDocument();
-  expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument();
-  expect(screen.getByText('Chocolate Chip Cookies')).toBeInTheDocument();
-});
-
-test('heading changes to category name when category filter is selected', () => {
-  setupLoggedInUser();
-  render(<App />);
-  
-  // Initially should show "Rezepte" as heading (not button text)
-  const initialHeading = screen.getByRole('heading', { name: /^Rezepte$/, level: 2 });
-  expect(initialHeading).toBeInTheDocument();
-  
-  // Change category filter
-  const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-  fireEvent.change(categoryFilter, { target: { value: 'Dessert' } });
-  
-  // Heading should now show "Dessert"
-  const newHeading = screen.getByRole('heading', { name: /^Dessert$/, level: 2 });
-  expect(newHeading).toBeInTheDocument();
-  expect(screen.queryByRole('heading', { name: /^Rezepte$/, level: 2 })).not.toBeInTheDocument();
-});
-
 test('heading shows "Meine Rezepte" when favorites filter is active with no category', () => {
   setupLoggedInUser();
   render(<App />);
-  
+
   // Click favorites filter
   const favoritesButton = screen.getByRole('button', { name: /Favoriten/i });
   fireEvent.click(favoritesButton);
-  
+
   // Heading should show "Meine Rezepte"
   expect(screen.getByText('Meine Rezepte')).toBeInTheDocument();
-});
-
-test('heading shows "Meine" + category when both filters are active', () => {
-  setupLoggedInUser();
-  render(<App />);
-  
-  // Select category
-  const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-  fireEvent.change(categoryFilter, { target: { value: 'Main Course' } });
-  
-  // Click favorites filter
-  const favoritesButton = screen.getByRole('button', { name: /Favoriten/i });
-  fireEvent.click(favoritesButton);
-  
-  // Heading should show "Meine Main Course"
-  expect(screen.getByText('Meine Main Course')).toBeInTheDocument();
-});
-
-describe('Multi-category filtering', () => {
-  test('recipe with multiple categories appears when filtering by any of its categories', () => {
-    setupLoggedInUser();
-    
-    // Add custom categories to match our test recipes
-    const customLists = {
-      cuisineTypes: ['Italian', 'German'],
-      mealCategories: ['Hauptspeisen', 'Pizzen', 'Dessert'],
-      units: ['g', 'kg', 'ml', 'l'],
-      portionUnits: [{ id: 'portion', singular: 'Portion', plural: 'Portionen' }]
-    };
-    localStorage.setItem('customLists', JSON.stringify(customLists));
-    
-    // Create recipes with multiple categories
-    const multiCategoryRecipes = [
-      {
-        id: '1',
-        title: 'Pizza Margherita',
-        ingredients: ['Teig', 'Tomaten', 'Mozzarella'],
-        steps: ['Teig ausrollen', 'Belegen', 'Backen'],
-        speisekategorie: ['Hauptspeisen', 'Pizzen'],
-        authorId: 'test-user-id'
-      },
-      {
-        id: '2',
-        title: 'Pasta Carbonara',
-        ingredients: ['Pasta', 'Eier', 'Speck'],
-        steps: ['Pasta kochen', 'Sauce machen'],
-        speisekategorie: ['Hauptspeisen'],
-        authorId: 'test-user-id'
-      },
-      {
-        id: '3',
-        title: 'Tiramisu',
-        ingredients: ['Mascarpone', 'Kaffee'],
-        steps: ['Schichten'],
-        speisekategorie: ['Dessert'],
-        authorId: 'test-user-id'
-      }
-    ];
-    
-    localStorage.setItem('recipes', JSON.stringify(multiCategoryRecipes));
-    
-    render(<App />);
-    
-    // Initially all recipes should be visible
-    expect(screen.getByText('Pizza Margherita')).toBeInTheDocument();
-    expect(screen.getByText('Pasta Carbonara')).toBeInTheDocument();
-    expect(screen.getByText('Tiramisu')).toBeInTheDocument();
-    
-    // Filter by "Hauptspeisen" - should show both Pizza and Pasta
-    const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-    fireEvent.change(categoryFilter, { target: { value: 'Hauptspeisen' } });
-    
-    expect(screen.getByText('Pizza Margherita')).toBeInTheDocument();
-    expect(screen.getByText('Pasta Carbonara')).toBeInTheDocument();
-    expect(screen.queryByText('Tiramisu')).not.toBeInTheDocument();
-    
-    // Filter by "Pizzen" - should show only Pizza
-    fireEvent.change(categoryFilter, { target: { value: 'Pizzen' } });
-    
-    expect(screen.getByText('Pizza Margherita')).toBeInTheDocument();
-    expect(screen.queryByText('Pasta Carbonara')).not.toBeInTheDocument();
-    expect(screen.queryByText('Tiramisu')).not.toBeInTheDocument();
-    
-    // Filter by "Dessert" - should show only Tiramisu
-    fireEvent.change(categoryFilter, { target: { value: 'Dessert' } });
-    
-    expect(screen.queryByText('Pizza Margherita')).not.toBeInTheDocument();
-    expect(screen.queryByText('Pasta Carbonara')).not.toBeInTheDocument();
-    expect(screen.getByText('Tiramisu')).toBeInTheDocument();
-  });
-  
-  test('recipe with old string format category still works with filter', () => {
-    setupLoggedInUser();
-    
-    // Create recipes with old string format
-    const oldFormatRecipes = [
-      {
-        id: '1',
-        title: 'Old Format Recipe',
-        ingredients: ['Ingredient 1'],
-        steps: ['Step 1'],
-        speisekategorie: 'Main Course',
-        authorId: 'test-user-id'
-      }
-    ];
-    
-    localStorage.setItem('recipes', JSON.stringify(oldFormatRecipes));
-    
-    render(<App />);
-    
-    expect(screen.getByText('Old Format Recipe')).toBeInTheDocument();
-    
-    // Filter by the category
-    const categoryFilter = screen.getByRole('combobox', { name: /Nach Kategorie filtern/i });
-    fireEvent.change(categoryFilter, { target: { value: 'Main Course' } });
-    
-    // Recipe should still be visible
-    expect(screen.getByText('Old Format Recipe')).toBeInTheDocument();
-    
-    // Filter by different category
-    fireEvent.change(categoryFilter, { target: { value: 'Dessert' } });
-    
-    // Recipe should not be visible
-    expect(screen.queryByText('Old Format Recipe')).not.toBeInTheDocument();
-  });
 });

--- a/src/components/RecipeList.css
+++ b/src/components/RecipeList.css
@@ -63,39 +63,6 @@
    3. Header Controls / Buttons
    ========================================================= */
 
-.category-filter-arrow {
-  appearance: none;
-  -webkit-appearance: none;
-  border: none;
-  background: transparent;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 12px 12px;
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
-  margin-left: 6px;
-  padding: 0;
-  border-radius: 50%;
-  cursor: pointer;
-  flex-shrink: 0;
-  color: transparent;
-  font-size: 1px;
-  transition: all 0.3s ease;
-}
-
-.category-filter-arrow option {
-  background: white;
-  color: #333;
-  font-size: 1rem;
-}
-
-.category-filter-arrow:focus,
-.category-filter-arrow:focus-visible {
-  outline: none;
-}
-
 .view-mode-button {
   background: white;
   color: #1A1A1A;

--- a/src/components/RecipeList.js
+++ b/src/components/RecipeList.js
@@ -3,7 +3,7 @@ import './RecipeList.css';
 import { canEditRecipes, getUsers } from '../utils/userManagement';
 import { groupRecipesByParent, sortRecipeVersions } from '../utils/recipeVersioning';
 import { getUserFavorites } from '../utils/userFavorites';
-import { getCustomLists, getButtonIcons, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getSortSettings, DEFAULT_TRENDING_DAYS, DEFAULT_TRENDING_MIN_VIEWS, DEFAULT_NEW_RECIPE_DAYS, DEFAULT_RATING_MIN_VOTES } from '../utils/customLists';
+import { getButtonIcons, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getSortSettings, DEFAULT_TRENDING_DAYS, DEFAULT_TRENDING_MIN_VIEWS, DEFAULT_NEW_RECIPE_DAYS, DEFAULT_RATING_MIN_VOTES } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import SortCarousel from './SortCarousel';
 import { getRecentRecipeCalls } from '../utils/recipeCallsFirestore';
@@ -128,7 +128,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
   const handleSortChange = useCallback((sort) => setActiveSort(sort), []);
   const [allUsers, setAllUsers] = useState([]);
   const [favoriteIds, setFavoriteIds] = useState([]);
-  const [customLists, setCustomLists] = useState({ mealCategories: [] });
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [sortSettings, setSortSettings] = useState(null);
@@ -167,21 +166,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
       setAllUsers(users);
     };
     loadUsers();
-  }, []);
-
-  // Load custom lists (meal categories) on mount
-  useEffect(() => {
-    const loadCustomLists = async () => {
-      try {
-        const lists = await getCustomLists();
-        setCustomLists(lists);
-      } catch (error) {
-        console.error('Error loading custom lists:', error);
-        // Set to empty on error, component will still work
-        setCustomLists({ mealCategories: [] });
-      }
-    };
-    loadCustomLists();
   }, []);
 
   // Load sort settings on mount

--- a/src/components/RecipeList.js
+++ b/src/components/RecipeList.js
@@ -343,20 +343,6 @@ function RecipeList({ recipes, onSelectRecipe, onAddRecipe, categoryFilter, curr
             {currentUser?.sortCarousel && (
               <SortCarousel activeSort={activeSort} onSortChange={handleSortChange} />
             )}
-            {onCategoryFilterChange && (
-              <select
-                className="category-filter-arrow"
-                value={categoryFilter}
-                onChange={(e) => onCategoryFilterChange(e.target.value)}
-                title="Nach Kategorie filtern"
-                aria-label="Kategorie filtern"
-              >
-                <option value="">Alle Kategorien</option>
-                {customLists.mealCategories.map((category) => (
-                  <option key={category} value={category}>{category}</option>
-                ))}
-              </select>
-            )}
           </div>
           <div className="recipe-list-actions">
             <div className="filter-group">

--- a/src/components/SortCarousel.css
+++ b/src/components/SortCarousel.css
@@ -11,14 +11,19 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    max-width: 100%;
+    /* Break out of the recipe-list-container's 1rem side padding so the
+       carousel spans the full viewport width; the matching horizontal
+       padding below re-creates that 1rem gap for the pill at each end,
+       while pills mid-scroll can bleed all the way to the screen edge. */
+    width: calc(100% + 2rem);
+    margin: 0 -1rem;
     min-width: 0;
     overflow-x: auto;
     scroll-snap-type: x proximity;
     scrollbar-width: none;
     -ms-overflow-style: none;
     -webkit-overflow-scrolling: touch;
-    padding: 0.15rem 0.05rem;
+    padding: 0.15rem 1rem;
   }
 
   .sort-carousel::-webkit-scrollbar {

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -88,18 +88,6 @@
   background: #3a3a3a;
 }
 
-[data-theme="dark"] .category-filter-arrow {
-  background: transparent;
-  color: transparent;
-  border: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23e8e8e8' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 12px 12px;
-  transition: none;
-  -webkit-tap-highlight-color: transparent;
-}
-
 [data-theme="dark"] .action-button,
 [data-theme="dark"] .header-icon-btn {
   color: #e8e8e8;


### PR DESCRIPTION
The small circular arrow select next to the "Rezepte" heading let
users filter by a single meal category, but this duplicated the
category filtering already available via the full filter panel
("Weitere Filter"). Removes the control and its dark-mode styling,
and drops the tests that exercised it directly (heading-driven by a
categoryFilter prop is still covered separately in RecipeList.test.js).