### PR TITLE
Refactor MenuDetail layout: separate header and mobile action buttons

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -157,9 +157,13 @@
   background: #2e7d32;
   color: white;
   border: none;
-  border-radius: 8px;
-  padding: 0.4rem 0.85rem;
-  font-size: 0.85rem;
+  border-radius: 6px;
+  padding: 0 1rem;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.2s ease;
@@ -175,8 +179,12 @@
 .menu-delete-button {
   background: white;
   border: 1px solid #ddd;
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  padding: 0 1rem;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
@@ -211,7 +219,35 @@
   background: white;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.menu-detail-body {
   padding: 2rem;
+}
+
+.menu-detail-image {
+  width: 100%;
+  height: 300px;
+  overflow: hidden;
+  background: #f0f0f0;
+  position: relative;
+}
+
+.menu-detail-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mobile-action-buttons {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .menu-title-row {
@@ -378,8 +414,12 @@
     gap: 1rem;
   }
 
-  .menu-detail-content {
+  .menu-detail-body {
     padding: 1.5rem;
+  }
+
+  .menu-detail-image {
+    height: 250px;
   }
 
   .menu-title {
@@ -419,7 +459,7 @@
     margin-left: auto;
   }
 
-  .menu-detail-content {
+  .menu-detail-body {
     padding: 1rem;
   }
 

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -528,11 +528,59 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     return combineIngredients(converted);
   };
 
+  const canEdit = canEditMenu(currentUser, menu);
+  const showHeaderButtons = !isMobileOrTablet && (
+    (canEdit && onEdit) ||
+    (menu.privat && canEdit && onPublish) ||
+    (canDeleteMenu(currentUser, menu) && onDelete)
+  );
+
   return (
     <div className="menu-detail-container">
-      <div className="menu-detail-header">
+      {showHeaderButtons && (
+        <div className="menu-detail-header">
           <div className="action-buttons">
-          <button 
+            {canEdit && onEdit && !showShoppingListModal && !showPortionSelector && (
+              <button
+                className="menu-edit-button"
+                onClick={() => onEdit(menu)}
+                title="Menü bearbeiten"
+              >
+                Bearbeiten
+              </button>
+            )}
+            {menu.privat && canEdit && onPublish && (
+              <button
+                className="publish-menu-button"
+                onClick={handlePublish}
+                disabled={publishLoading}
+                title="Menü veröffentlichen"
+              >
+                {publishLoading ? '…' : 'Veröffentlichen'}
+              </button>
+            )}
+            {canDeleteMenu(currentUser, menu) && onDelete && (
+              <button
+                className="menu-delete-button"
+                onClick={handleDelete}
+                title="Menü löschen"
+              >
+                Löschen
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="menu-detail-content">
+        {menu.image && (
+          <div className="menu-detail-image">
+            <img src={menu.image} alt={menu.name} />
+          </div>
+        )}
+
+        <div className="mobile-action-buttons">
+          <button
             className={`favorite-button ${isFavorite ? 'favorite-active' : ''}`}
             onClick={handleToggleFavorite}
             title={isFavorite ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
@@ -563,35 +611,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               shoppingListIcon
             )}
           </button>
-          {!isMobileOrTablet && canEditMenu(currentUser, menu) && onEdit && !showShoppingListModal && !showPortionSelector && (
-            <button
-              className="menu-edit-button"
-              onClick={() => onEdit(menu)}
-              title="Menü bearbeiten"
-            >
-              Bearbeiten
-            </button>
-          )}
-          {!isMobileOrTablet && menu.privat && canEditMenu(currentUser, menu) && onPublish && (
-            <button
-              className="publish-menu-button"
-              onClick={handlePublish}
-              disabled={publishLoading}
-              title="Menü veröffentlichen"
-            >
-              {publishLoading ? '…' : 'Veröffentlichen'}
-            </button>
-          )}
-          {!isMobileOrTablet && canDeleteMenu(currentUser, menu) && onDelete && (
-            <button
-              className="menu-delete-button"
-              onClick={handleDelete}
-              title="Menü löschen"
-            >
-              Löschen
-            </button>
-          )}
-          {canEditMenu(currentUser, menu) && !menu.shareId && (
+          {canEdit && !menu.shareId && (
             <button
               className="share-button"
               onClick={handleToggleShare}
@@ -601,7 +621,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               {shareLoading ? '…' : '↑ Teilen'}
             </button>
           )}
-          {canEditMenu(currentUser, menu) && menu.shareId && (
+          {canEdit && menu.shareId && (
             <button
               className="share-copy-url-button"
               onClick={handleCopyShareUrl}
@@ -616,7 +636,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               )}
             </button>
           )}
-          {isSharedView && !canEditMenu(currentUser, menu) && (
+          {isSharedView && !canEdit && (
             <button
               className="share-copy-url-button"
               onClick={handleCopyShareUrl}
@@ -632,9 +652,8 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
             </button>
           )}
         </div>
-      </div>
 
-      <div className="menu-detail-content">
+        <div className="menu-detail-body">
         <div className="menu-title-row">
           <h1 className="menu-title">{menu.name}</h1>
           <button className="close-button" onClick={onBack} title="Schließen">
@@ -777,6 +796,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
             </section>
           );
         })}
+        </div>
       </div>
       {isMobileOrTablet && canDeleteMenu(currentUser, menu) && onDelete && (
         <button

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -121,7 +121,7 @@ describe('MenuDetail - Action Buttons', () => {
     expect(screen.getByTitle('Menü teilen')).toBeInTheDocument();
   });
 
-  test('action-buttons container wraps all buttons except delete', () => {
+  test('action-buttons header contains edit and delete, mobile-action-buttons contains favorite/shopping-list/share', () => {
     const { container } = render(
       <MenuDetail
         menu={mockMenu}
@@ -138,8 +138,13 @@ describe('MenuDetail - Action Buttons', () => {
 
     const actionButtons = container.querySelector('.action-buttons');
     expect(actionButtons).toBeInTheDocument();
-    const buttons = actionButtons.querySelectorAll('button');
-    expect(buttons.length).toBe(5);
+    const headerButtons = actionButtons.querySelectorAll('button');
+    expect(headerButtons.length).toBe(2);
+
+    const belowImageButtons = container.querySelector('.mobile-action-buttons');
+    expect(belowImageButtons).toBeInTheDocument();
+    const quickButtons = belowImageButtons.querySelectorAll('button');
+    expect(quickButtons.length).toBe(3);
   });
 
   test('desktop view does not render floating action buttons', () => {


### PR DESCRIPTION
## Summary
Restructured the MenuDetail component layout to improve organization and responsiveness by separating desktop header buttons from mobile action buttons, and adding support for menu images.

## Key Changes
- **Layout Restructuring**: Split the action buttons into two distinct sections:
  - Desktop header buttons (Edit, Publish, Delete) - only shown on non-mobile devices
  - Mobile action buttons (Favorite, Shopping List, Share) - displayed below the menu image
  
- **Menu Image Support**: Added a dedicated `.menu-detail-image` section that displays the menu's image with proper sizing and object-fit styling

- **CSS Updates**:
  - Standardized button heights to 48px with flexbox centering for consistency
  - Updated border-radius values (12px → 6px) for a more modern appearance
  - Added `.menu-detail-body` wrapper for content padding
  - Created `.mobile-action-buttons` container with flex layout and bottom border separator
  - Adjusted responsive breakpoints for tablet and mobile views

- **Code Optimization**: 
  - Extracted `canEdit` variable to reduce repeated `canEditMenu()` calls
  - Introduced `showHeaderButtons` flag to conditionally render the entire header section
  - Simplified button visibility logic by consolidating conditions

- **Test Updates**: Updated test expectations to reflect the new button organization (header buttons vs. mobile action buttons)

## Implementation Details
The refactoring maintains all existing functionality while improving the visual hierarchy and mobile responsiveness. Desktop users see edit/publish/delete buttons in a fixed header, while mobile users see quick-action buttons (favorite/shopping list/share) positioned below the menu image for easier thumb access.

https://claude.ai/code/session_01PGuQKt76DaZfCPczpA27L5