### PR TITLE
Fix recipe kulinarik tags layout to prevent wrapping

### DIFF
--- a/src/components/RecipeList.css
+++ b/src/components/RecipeList.css
@@ -354,17 +354,15 @@
 
 .recipe-kulinarik {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.4rem;
   margin-top: 0.25rem;
   overflow: hidden;
-
-  /* ca. 2 Zeilen sichtbar */
-  max-height: 3.2rem;
 }
 
 .kulinarik-tag {
   display: inline-block;
+  flex-shrink: 0;
   background: #F5F2EF;
   color: #3E2B1C;
   border: 1px solid #E5DED8;
@@ -372,6 +370,7 @@
   padding: 0.15rem 0.6rem;
   font-size: 0.78rem;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .kulinarik-tag-more {


### PR DESCRIPTION
## Summary
Updated the recipe kulinarik tags component to display as a single-line horizontal list without wrapping, improving the visual presentation and consistency of the tag display.

## Key Changes
- Changed `.recipe-kulinarik` flex-wrap from `wrap` to `nowrap` to prevent tags from breaking to multiple lines
- Removed the `max-height: 3.2rem` constraint that was limiting visible content to approximately 2 lines
- Added `flex-shrink: 0` to `.kulinarik-tag` to prevent tags from shrinking below their natural width
- Added `white-space: nowrap` to `.kulinarik-tag` to ensure tag text stays on a single line
- Removed unnecessary blank line in the CSS

## Implementation Details
These changes ensure that kulinarik tags display in a single horizontal row with proper overflow handling. The `flex-shrink: 0` and `white-space: nowrap` properties work together to maintain tag integrity while the `flex-wrap: nowrap` setting prevents any line breaks in the container.

https://claude.ai/code/session_01VV23qM1YQhmDmw8hGagqYv