### PR TITLE
Add collapsible filter sidebar and search filtering to RecipeFilterSidebar

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -265,6 +265,14 @@
   align-items: center;
 }
 
+/* On desktop the recipe overview's filter sidebar already provides search,
+   so the header search button would be a redundant second entry point. */
+@media (min-width: 901px) {
+  .search-container {
+    display: none;
+  }
+}
+
 .search-btn {
   background: transparent;
   border: none;

--- a/src/components/RecipeFilterSidebar.css
+++ b/src/components/RecipeFilterSidebar.css
@@ -14,6 +14,44 @@
   align-self: flex-start;
   position: sticky;
   top: 1rem;
+  transition: width 0.2s ease, padding 0.2s ease;
+}
+
+.recipe-filter-sidebar--collapsed {
+  width: auto;
+  gap: 0;
+  padding: 1rem 0.6rem;
+  align-items: center;
+}
+
+.recipe-filter-sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid #E5DED8;
+  background: white;
+  color: #3E2B1C;
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 0.15s ease;
+}
+
+.recipe-filter-sidebar--collapsed .recipe-filter-sidebar-toggle {
+  align-self: center;
+}
+
+.recipe-filter-sidebar-toggle:hover {
+  border-color: #DF7A00;
+}
+
+.recipe-filter-sidebar-toggle:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
 }
 
 .recipe-filter-sidebar-search {

--- a/src/components/RecipeFilterSidebar.js
+++ b/src/components/RecipeFilterSidebar.js
@@ -1,11 +1,22 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import './RecipeFilterSidebar.css';
+
+const COLLAPSED_STORAGE_KEY = 'recipeFilterSidebar_collapsed';
+
+function getStoredCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Persistent left-hand navigation for the recipe overview on larger screens.
  * Mirrors every filter offered by MobileSearchOverlay's bottom sheet (search,
  * Favoriten/Saisonal toggles, Speisekategorien, Kulinariktypen, Autoren and
  * private Listen) so desktop users get the same filtering capabilities.
+ * Collapsible so it can be tucked away on desktop when not needed.
  */
 function RecipeFilterSidebar({
   recipes = [],
@@ -32,6 +43,20 @@ function RecipeFilterSidebar({
   showPrivateListFilters = true,
   onClearAllFilters,
 }) {
+  const [collapsed, setCollapsed] = useState(getStoredCollapsed);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(COLLAPSED_STORAGE_KEY, next ? '1' : '0');
+      } catch {
+        // ignore storage errors
+      }
+      return next;
+    });
+  };
+
   // Only offer categories/cuisines that actually match at least one recipe,
   // same rule MobileSearchOverlay applies for its pills.
   const availableCategories = useMemo(() => {
@@ -72,6 +97,31 @@ function RecipeFilterSidebar({
     return result;
   }, [recipes, cuisineTypes, cuisineGroups]);
 
+  // Narrow the pill lists down to whatever matches the current search term,
+  // same behaviour as MobileSearchOverlay's pill carousels. Already active
+  // pills are kept sorted first among the survivors.
+  const trimmedSearch = searchTerm?.trim().toLowerCase() || '';
+
+  const visibleCategories = useMemo(() => {
+    if (!trimmedSearch) return availableCategories;
+    return availableCategories.filter((name) => name.toLowerCase().includes(trimmedSearch));
+  }, [availableCategories, trimmedSearch]);
+
+  const visibleCuisinePills = useMemo(() => {
+    if (!trimmedSearch) return cuisinePills;
+    return cuisinePills.filter((name) => name.toLowerCase().includes(trimmedSearch));
+  }, [cuisinePills, trimmedSearch]);
+
+  const visibleAuthors = useMemo(() => {
+    if (!trimmedSearch) return availableAuthors;
+    return availableAuthors.filter((author) => author.name?.toLowerCase().includes(trimmedSearch));
+  }, [availableAuthors, trimmedSearch]);
+
+  const visiblePrivateLists = useMemo(() => {
+    if (!trimmedSearch) return privateLists;
+    return privateLists.filter((list) => list.name?.toLowerCase().includes(trimmedSearch));
+  }, [privateLists, trimmedSearch]);
+
   const hasActiveFilters = !!(
     searchTerm?.trim() ||
     showFavoritesOnly ||
@@ -104,127 +154,147 @@ function RecipeFilterSidebar({
   };
 
   return (
-    <nav className="recipe-filter-sidebar" aria-label="Rezeptfilter">
-      <div className="recipe-filter-sidebar-search">
-        <span className="recipe-filter-sidebar-search-icon" aria-hidden="true">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-        </span>
-        <input
-          type="search"
-          className="recipe-filter-sidebar-search-input"
-          placeholder="Rezepte durchsuchen …"
-          value={searchTerm}
-          onChange={(e) => onSearchChange?.(e.target.value)}
-          aria-label="Rezepte durchsuchen"
-        />
-      </div>
+    <nav
+      className={`recipe-filter-sidebar${collapsed ? ' recipe-filter-sidebar--collapsed' : ''}`}
+      aria-label="Rezeptfilter"
+    >
+      <button
+        type="button"
+        className="recipe-filter-sidebar-toggle"
+        onClick={toggleCollapsed}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? 'Filter einblenden' : 'Filter ausblenden'}
+        title={collapsed ? 'Filter einblenden' : 'Filter ausblenden'}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          {collapsed ? <polyline points="9 6 15 12 9 18" /> : <polyline points="15 6 9 12 15 18" />}
+        </svg>
+      </button>
 
-      <div className="recipe-filter-sidebar-section recipe-filter-sidebar-row">
-        <button
-          type="button"
-          className={`recipe-filter-sidebar-pill${showFavoritesOnly ? ' active' : ''}`}
-          onClick={() => onFavoritesToggle?.(!showFavoritesOnly)}
-          aria-pressed={showFavoritesOnly}
-        >
-          ★ Favoriten
-        </button>
-        <button
-          type="button"
-          className={`recipe-filter-sidebar-pill${showSeasonalOnly ? ' active' : ''}`}
-          onClick={() => onSeasonalToggle?.(!showSeasonalOnly)}
-          aria-pressed={showSeasonalOnly}
-        >
-          Saisonal
-        </button>
-      </div>
-
-      {availableCategories.length > 0 && (
-        <div className="recipe-filter-sidebar-section">
-          <h3 className="recipe-filter-sidebar-heading">Kategorien</h3>
-          <div className="recipe-filter-sidebar-row">
-            {availableCategories.map((name) => (
-              <button
-                key={name}
-                type="button"
-                className={`recipe-filter-sidebar-pill${selectedCategories.includes(name) ? ' active' : ''}`}
-                onClick={() => handleCategoryClick(name)}
-                aria-pressed={selectedCategories.includes(name)}
-              >
-                {name}
-              </button>
-            ))}
+      {!collapsed && (
+        <>
+          <div className="recipe-filter-sidebar-search">
+            <span className="recipe-filter-sidebar-search-icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            </span>
+            <input
+              type="search"
+              className="recipe-filter-sidebar-search-input"
+              placeholder="Rezepte durchsuchen …"
+              value={searchTerm}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+              aria-label="Rezepte durchsuchen"
+            />
           </div>
-        </div>
-      )}
 
-      {cuisinePills.length > 0 && (
-        <div className="recipe-filter-sidebar-section">
-          <h3 className="recipe-filter-sidebar-heading">Küche</h3>
-          <div className="recipe-filter-sidebar-row">
-            {cuisinePills.map((name) => (
-              <button
-                key={name}
-                type="button"
-                className={`recipe-filter-sidebar-pill${selectedCuisines.includes(name) ? ' active' : ''}`}
-                onClick={() => handleCuisineClick(name)}
-                aria-pressed={selectedCuisines.includes(name)}
-              >
-                {name}
-              </button>
-            ))}
+          <div className="recipe-filter-sidebar-section recipe-filter-sidebar-row">
+            <button
+              type="button"
+              className={`recipe-filter-sidebar-pill${showFavoritesOnly ? ' active' : ''}`}
+              onClick={() => onFavoritesToggle?.(!showFavoritesOnly)}
+              aria-pressed={showFavoritesOnly}
+            >
+              ★ Favoriten
+            </button>
+            <button
+              type="button"
+              className={`recipe-filter-sidebar-pill${showSeasonalOnly ? ' active' : ''}`}
+              onClick={() => onSeasonalToggle?.(!showSeasonalOnly)}
+              aria-pressed={showSeasonalOnly}
+            >
+              Saisonal
+            </button>
           </div>
-        </div>
-      )}
 
-      {availableAuthors.length > 0 && (
-        <div className="recipe-filter-sidebar-section">
-          <h3 className="recipe-filter-sidebar-heading">Autoren</h3>
-          <div className="recipe-filter-sidebar-row">
-            {availableAuthors.map((author) => (
-              <button
-                key={author.id}
-                type="button"
-                className={`recipe-filter-sidebar-pill${selectedAuthors.includes(author.id) ? ' active' : ''}`}
-                onClick={() => handleAuthorClick(author.id)}
-                aria-pressed={selectedAuthors.includes(author.id)}
-              >
-                {author.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
+          {visibleCategories.length > 0 && (
+            <div className="recipe-filter-sidebar-section">
+              <h3 className="recipe-filter-sidebar-heading">Kategorien</h3>
+              <div className="recipe-filter-sidebar-row">
+                {visibleCategories.map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className={`recipe-filter-sidebar-pill${selectedCategories.includes(name) ? ' active' : ''}`}
+                    onClick={() => handleCategoryClick(name)}
+                    aria-pressed={selectedCategories.includes(name)}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
-      {showPrivateListFilters && currentUser && privateLists.length > 0 && (
-        <div className="recipe-filter-sidebar-section">
-          <h3 className="recipe-filter-sidebar-heading">Listen</h3>
-          <div className="recipe-filter-sidebar-row">
-            {privateLists.map((list) => (
-              <button
-                key={list.id}
-                type="button"
-                className={`recipe-filter-sidebar-pill${selectedPrivateLists.includes(list.id) ? ' active' : ''}`}
-                onClick={() => handlePrivateListClick(list.id)}
-                aria-pressed={selectedPrivateLists.includes(list.id)}
-              >
-                {list.name}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
+          {visibleCuisinePills.length > 0 && (
+            <div className="recipe-filter-sidebar-section">
+              <h3 className="recipe-filter-sidebar-heading">Küche</h3>
+              <div className="recipe-filter-sidebar-row">
+                {visibleCuisinePills.map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className={`recipe-filter-sidebar-pill${selectedCuisines.includes(name) ? ' active' : ''}`}
+                    onClick={() => handleCuisineClick(name)}
+                    aria-pressed={selectedCuisines.includes(name)}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
-      {hasActiveFilters && (
-        <button
-          type="button"
-          className="recipe-filter-sidebar-reset"
-          onClick={onClearAllFilters}
-        >
-          Filter zurücksetzen
-        </button>
+          {visibleAuthors.length > 0 && (
+            <div className="recipe-filter-sidebar-section">
+              <h3 className="recipe-filter-sidebar-heading">Autoren</h3>
+              <div className="recipe-filter-sidebar-row">
+                {visibleAuthors.map((author) => (
+                  <button
+                    key={author.id}
+                    type="button"
+                    className={`recipe-filter-sidebar-pill${selectedAuthors.includes(author.id) ? ' active' : ''}`}
+                    onClick={() => handleAuthorClick(author.id)}
+                    aria-pressed={selectedAuthors.includes(author.id)}
+                  >
+                    {author.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {showPrivateListFilters && currentUser && visiblePrivateLists.length > 0 && (
+            <div className="recipe-filter-sidebar-section">
+              <h3 className="recipe-filter-sidebar-heading">Listen</h3>
+              <div className="recipe-filter-sidebar-row">
+                {visiblePrivateLists.map((list) => (
+                  <button
+                    key={list.id}
+                    type="button"
+                    className={`recipe-filter-sidebar-pill${selectedPrivateLists.includes(list.id) ? ' active' : ''}`}
+                    onClick={() => handlePrivateListClick(list.id)}
+                    aria-pressed={selectedPrivateLists.includes(list.id)}
+                  >
+                    {list.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {hasActiveFilters && (
+            <button
+              type="button"
+              className="recipe-filter-sidebar-reset"
+              onClick={onClearAllFilters}
+            >
+              Filter zurücksetzen
+            </button>
+          )}
+        </>
       )}
     </nav>
   );

--- a/src/components/RecipeList.css
+++ b/src/components/RecipeList.css
@@ -147,6 +147,16 @@
   border-color: #DF7A00;
 }
 
+/* On desktop the recipe overview's filter sidebar already provides search
+   and filtering, so this heading button would be a redundant second entry
+   point. Scoped to the main recipe overview only (.recipe-overview-main) so
+   other views without the sidebar (e.g. private list detail) keep it. */
+@media (min-width: 901px) {
+  .recipe-overview-main .filter-button {
+    display: none;
+  }
+}
+
 .add-button {
   background: white;
   color: white;


### PR DESCRIPTION
## Summary
Enhanced the RecipeFilterSidebar component with collapsibility and search-based filtering capabilities. The sidebar can now be toggled open/closed with state persisted to localStorage, and filter pills are dynamically filtered based on the search term to match the behavior of the mobile search overlay.

## Key Changes

- **Collapsible sidebar**: Added a toggle button that collapses/expands the entire filter sidebar, with state persisted to localStorage using the `COLLAPSED_STORAGE_KEY`
- **Search-based filtering**: Implemented four new `useMemo` hooks that filter categories, cuisines, authors, and private lists based on the current search term (case-insensitive substring matching)
- **Conditional rendering**: Filter content is now wrapped in a conditional block that only renders when the sidebar is not collapsed
- **Styling updates**: Added CSS for the collapsed state with smooth transitions, toggle button styling with hover and focus states, and responsive media queries to hide redundant UI elements on desktop
- **Accessibility improvements**: Added proper ARIA attributes (`aria-expanded`, `aria-label`) to the toggle button and updated the component documentation

## Implementation Details

- The collapse state uses `getStoredCollapsed()` helper function with error handling for localStorage access
- Filter visibility is determined by case-insensitive substring matching against `trimmedSearch`
- The toggle button displays different SVG chevron directions based on collapsed state
- Desktop-specific CSS hides the filter button in RecipeList and search container in Header when the sidebar is available (min-width: 901px)
- All filter sections gracefully hide when they have no visible items after search filtering

https://claude.ai/code/session_01DCVrjmUiTMAhXXpjfWWHDK