### PR TITLE
Split pill carousels into independent rows to prevent column alignment

### DIFF
--- a/src/components/MobileSearchOverlay.css
+++ b/src/components/MobileSearchOverlay.css
@@ -253,17 +253,8 @@
 .mobile-search-cuisine-grid {
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-  align-content: flex-start;
-  align-items: flex-start;
   gap: 8px;
   padding: 4px 12px 8px;
-  /* Limit to exactly 2 rows; excess pills overflow into a horizontal carousel.
-     Pill height = 12 px vertical padding + 3 px border + ~17 px line-height
-                 ≈ 32 px. Two rows + one 8 px gap = 72 px (content area).
-     Because box-sizing: border-box applies globally, the container padding
-     (4 px top + 8 px bottom = 12 px) must be added: 72 + 12 = 84 px. */
-  max-height: 84px;
   overflow-x: auto;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
@@ -274,6 +265,16 @@
 
 .mobile-search-cuisine-grid::-webkit-scrollbar {
   display: none;
+}
+
+/* Each row scrolls its own pills independently of the other row, so pills
+   never need to line up in columns – this keeps the gap between pills
+   uniform even when their widths differ. */
+.mobile-search-cuisine-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 8px;
 }
 
 /* ─── Autorenkarussell single-row carousel (below cuisine filter) ─────────── */

--- a/src/components/MobileSearchOverlay.js
+++ b/src/components/MobileSearchOverlay.js
@@ -34,6 +34,26 @@ function incrementCuisineUsage(cuisineName) {
 }
 
 /**
+ * Splits a pill list into two independent rows (first half / second half) so
+ * the two-row carousel doesn't have to align pill columns – each row wraps
+ * its own content and keeps a uniform gap regardless of neighboring pill
+ * widths. Row membership is derived from the stable (unfiltered-by-selection)
+ * pill list so a pill never jumps rows just because it becomes active –
+ * that would force React to unmount/remount it and drop focus mid-click.
+ */
+function splitIntoTwoRows(items) {
+  const half = Math.ceil(items.length / 2);
+  return [items.slice(0, half), items.slice(half)];
+}
+
+/** Reorders a row's pills so active (selected) ones come first, without changing row membership. */
+function reorderActiveFirst(items, selected) {
+  const active = items.filter((name) => selected.includes(name));
+  const inactive = items.filter((name) => !selected.includes(name));
+  return [...active, ...inactive];
+}
+
+/**
  * Compute all cuisine types sorted by usage frequency (localStorage) desc,
  * then recipe count desc. Only includes types that have at least one recipe.
  */
@@ -355,12 +375,20 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
     return result;
   }, [allCuisinePills, debouncedTerm, cuisineGroups, allSortedCuisineTypes]);
 
-  // Active (selected) pills are always shown first (leftmost) in the carousel
-  const orderedCuisinePills = useMemo(() => {
-    const active = visibleCuisinePills.filter((name) => selectedCuisines.includes(name));
-    const inactive = visibleCuisinePills.filter((name) => !selectedCuisines.includes(name));
-    return [...active, ...inactive];
-  }, [visibleCuisinePills, selectedCuisines]);
+  // Row membership stays stable regardless of selection; within each row,
+  // active (selected) pills are always shown first (leftmost).
+  const [cuisineRow1Base, cuisineRow2Base] = useMemo(
+    () => splitIntoTwoRows(visibleCuisinePills),
+    [visibleCuisinePills]
+  );
+  const cuisinePillsRow1 = useMemo(
+    () => reorderActiveFirst(cuisineRow1Base, selectedCuisines),
+    [cuisineRow1Base, selectedCuisines]
+  );
+  const cuisinePillsRow2 = useMemo(
+    () => reorderActiveFirst(cuisineRow2Base, selectedCuisines),
+    [cuisineRow2Base, selectedCuisines]
+  );
 
   // Speisekategorien with at least one matching recipe
   const availableCategories = useMemo(() => {
@@ -384,12 +412,20 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
     return availableCategories.filter((name) => name.toLowerCase().includes(lower));
   }, [availableCategories, debouncedTerm]);
 
-  // Active (selected) pills are always shown first (leftmost) in the carousel
-  const orderedCategoryPills = useMemo(() => {
-    const active = visibleCategoryPills.filter((name) => selectedCategories.includes(name));
-    const inactive = visibleCategoryPills.filter((name) => !selectedCategories.includes(name));
-    return [...active, ...inactive];
-  }, [visibleCategoryPills, selectedCategories]);
+  // Row membership stays stable regardless of selection; within each row,
+  // active (selected) pills are always shown first (leftmost).
+  const [categoryRow1Base, categoryRow2Base] = useMemo(
+    () => splitIntoTwoRows(visibleCategoryPills),
+    [visibleCategoryPills]
+  );
+  const categoryPillsRow1 = useMemo(
+    () => reorderActiveFirst(categoryRow1Base, selectedCategories),
+    [categoryRow1Base, selectedCategories]
+  );
+  const categoryPillsRow2 = useMemo(
+    () => reorderActiveFirst(categoryRow2Base, selectedCategories),
+    [categoryRow2Base, selectedCategories]
+  );
 
   // Author pills: filtered by search term, active (selected) authors shown first
   const orderedAuthorPills = useMemo(() => {
@@ -505,16 +541,20 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
         {/* Active (selected) pills are always shown first (leftmost) in the carousel */}
         {visibleCategoryPills.length > 0 && (
           <div className="mobile-search-cuisine-grid mobile-search-category-grid">
-            {orderedCategoryPills.map((name) => (
-              <button
-                key={name}
-                className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCategories.includes(name) ? ' active' : ''}`}
-                onClick={() => handleCategoryPillClick(name)}
-                aria-pressed={selectedCategories.includes(name)}
-                title={selectedCategories.includes(name) ? 'Filter aufheben' : `Nach ${name} filtern`}
-              >
-                {name}
-              </button>
+            {[categoryPillsRow1, categoryPillsRow2].filter((row) => row.length > 0).map((row, rowIndex) => (
+              <div className="mobile-search-cuisine-row" key={rowIndex}>
+                {row.map((name) => (
+                  <button
+                    key={name}
+                    className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCategories.includes(name) ? ' active' : ''}`}
+                    onClick={() => handleCategoryPillClick(name)}
+                    aria-pressed={selectedCategories.includes(name)}
+                    title={selectedCategories.includes(name) ? 'Filter aufheben' : `Nach ${name} filtern`}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         )}
@@ -523,16 +563,20 @@ function MobileSearchOverlay({ isOpen, onClose, recipes, onSelectRecipe, onSearc
         {/* Active (selected) pills are always shown first (leftmost) in the carousel */}
         {visibleCuisinePills.length > 0 && (
           <div className="mobile-search-cuisine-grid">
-            {orderedCuisinePills.map((name) => (
-              <button
-                key={name}
-                className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCuisines.includes(name) ? ' active' : ''}`}
-                onClick={() => handleCuisinePillClick(name)}
-                aria-pressed={selectedCuisines.includes(name)}
-                title={selectedCuisines.includes(name) ? 'Filter aufheben' : `Nach ${name} filtern`}
-              >
-                {name}
-              </button>
+            {[cuisinePillsRow1, cuisinePillsRow2].filter((row) => row.length > 0).map((row, rowIndex) => (
+              <div className="mobile-search-cuisine-row" key={rowIndex}>
+                {row.map((name) => (
+                  <button
+                    key={name}
+                    className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCuisines.includes(name) ? ' active' : ''}`}
+                    onClick={() => handleCuisinePillClick(name)}
+                    aria-pressed={selectedCuisines.includes(name)}
+                    title={selectedCuisines.includes(name) ? 'Filter aufheben' : `Nach ${name} filtern`}
+                  >
+                    {name}
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         )}

--- a/src/components/MobileSearchOverlay.test.js
+++ b/src/components/MobileSearchOverlay.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import MobileSearchOverlay from './MobileSearchOverlay';
 
 const mockNutritionReferenceState = {
@@ -420,25 +420,26 @@ describe('MobileSearchOverlay – active cuisine pills shown leftmost', () => {
     expandCuisineSelection.mockImplementation((selected) => selected);
   });
 
-  test('active pill moves to the first position after clicking', () => {
-    renderOverlay();
+  test('active pill moves to the first position within its row after clicking', () => {
+    const { container } = renderOverlay();
 
-    const pills = () =>
-      screen.getAllByRole('button', { name: /Küche$/ });
+    const getRows = () => container.querySelectorAll('.mobile-search-cuisine-row');
 
-    // Before clicking, get the initial order
-    const initialFirstPill = pills()[0];
+    // Pick the carousel's second row and its last pill
+    const rowsBefore = getRows();
+    expect(rowsBefore.length).toBe(2);
+    const secondRowButtonsBefore = within(rowsBefore[1]).getAllByRole('button');
+    const initialFirstOfRow = secondRowButtonsBefore[0];
+    const lastPill = secondRowButtonsBefore[secondRowButtonsBefore.length - 1];
 
-    // Click the last cuisine pill to make it active
-    const lastPill = pills()[pills().length - 1];
     fireEvent.click(lastPill);
 
-    // After clicking, the active pill should now be the first pill
-    const updatedPills = pills();
-    expect(updatedPills[0]).toHaveClass('active');
-    // And the previously first pill (if it wasn't the one we clicked) should no longer be first
-    if (initialFirstPill !== lastPill) {
-      expect(updatedPills[0]).not.toBe(initialFirstPill);
+    // After clicking, the clicked pill should now be first within its own row
+    // (rows are independent, so it doesn't need to become globally first)
+    const secondRowButtonsAfter = within(getRows()[1]).getAllByRole('button');
+    expect(secondRowButtonsAfter[0]).toHaveClass('active');
+    if (initialFirstOfRow !== lastPill) {
+      expect(secondRowButtonsAfter[0]).not.toBe(initialFirstOfRow);
     }
   });
 
@@ -691,7 +692,7 @@ describe('MobileSearchOverlay – meal category (Speisekategorie) pills', () => 
     expect(screen.getByText('Desserts')).not.toHaveClass('active');
   });
 
-  test('active category pills are shown before inactive ones', () => {
+  test('active category pills are shown before inactive ones within their row', () => {
     renderOverlay({
       recipes: mealCategoryRecipes,
       mealCategories: mockMealCategories,
@@ -700,11 +701,15 @@ describe('MobileSearchOverlay – meal category (Speisekategorie) pills', () => 
     const categoryPill = (name) =>
       screen.getAllByRole('button', { name: /^(Hauptspeisen|Desserts|Vorspeisen)$/ }).find((btn) => btn.textContent === name);
 
-    fireEvent.click(categoryPill('Vorspeisen'));
+    const clickedPill = categoryPill('Vorspeisen');
+    fireEvent.click(clickedPill);
 
-    const updatedPills = screen.getAllByRole('button', { name: /^(Hauptspeisen|Desserts|Vorspeisen)$/ });
-    expect(updatedPills[0]).toHaveTextContent('Vorspeisen');
-    expect(updatedPills[0]).toHaveClass('active');
+    // The clicked pill should now be first within its own row (rows are
+    // independent, so it doesn't need to become globally first).
+    const ownRow = clickedPill.closest('.mobile-search-cuisine-row');
+    const rowButtons = within(ownRow).getAllByRole('button');
+    expect(rowButtons[0]).toHaveTextContent('Vorspeisen');
+    expect(rowButtons[0]).toHaveClass('active');
   });
 });
 

--- a/src/components/TagesmenuFilterOverlay.js
+++ b/src/components/TagesmenuFilterOverlay.js
@@ -6,6 +6,13 @@ const DEBOUNCE_DELAY_MS = 200;
 // a head-start before the keyboard appears, preventing a jarring layout jump.
 const FOCUS_DELAY_MS = 120;
 
+/** Reorders a row's pills so active (selected) ones come first, without changing row membership. */
+function reorderActiveFirst(items, selected) {
+  const active = items.filter((name) => selected.includes(name));
+  const inactive = items.filter((name) => !selected.includes(name));
+  return [...active, ...inactive];
+}
+
 /**
  * Filter overlay for the Tagesmenü page.
  *
@@ -116,12 +123,26 @@ function TagesmenuFilterOverlay({
     onSelectCategory?.(newValue);
   };
 
-  // Active (selected) category pills are shown first
-  const orderedCategoryPills = useMemo(() => {
-    const active = categoryOptions.filter((name) => selectedCategories.includes(name));
-    const inactive = categoryOptions.filter((name) => !selectedCategories.includes(name));
-    return [...active, ...inactive];
-  }, [categoryOptions, selectedCategories]);
+  // Split into two independent rows (first half / second half) so the
+  // two-row carousel doesn't need pills to line up in columns – see
+  // MobileSearchOverlay's splitIntoTwoRows for the same pattern. Row
+  // membership is derived from the stable categoryOptions list (not the
+  // active-first ordering below) so a pill never jumps rows just because it
+  // becomes active, which would force React to unmount/remount it.
+  const [categoryRow1Base, categoryRow2Base] = useMemo(() => {
+    const half = Math.ceil(categoryOptions.length / 2);
+    return [categoryOptions.slice(0, half), categoryOptions.slice(half)];
+  }, [categoryOptions]);
+
+  // Within each row, active (selected) pills are always shown first (leftmost)
+  const categoryPillsRow1 = useMemo(
+    () => reorderActiveFirst(categoryRow1Base, selectedCategories),
+    [categoryRow1Base, selectedCategories]
+  );
+  const categoryPillsRow2 = useMemo(
+    () => reorderActiveFirst(categoryRow2Base, selectedCategories),
+    [categoryRow2Base, selectedCategories]
+  );
 
   const handleClear = () => {
     setSearchTerm('');
@@ -142,16 +163,20 @@ function TagesmenuFilterOverlay({
       <div className="mobile-search-panel" style={{ bottom: panelBottom }}>
         {categoryOptions.length > 0 && (
           <div className="mobile-search-cuisine-grid">
-            {orderedCategoryPills.map((category) => (
-              <button
-                key={category}
-                className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCategories.includes(category) ? ' active' : ''}`}
-                onClick={() => handleCategoryPillClick(category)}
-                aria-pressed={selectedCategories.includes(category)}
-                title={selectedCategories.includes(category) ? 'Filter aufheben' : `Nach ${category} filtern`}
-              >
-                {category}
-              </button>
+            {[categoryPillsRow1, categoryPillsRow2].filter((row) => row.length > 0).map((row, rowIndex) => (
+              <div className="mobile-search-cuisine-row" key={rowIndex}>
+                {row.map((category) => (
+                  <button
+                    key={category}
+                    className={`mobile-search-filter-pill mobile-search-cuisine-pill${selectedCategories.includes(category) ? ' active' : ''}`}
+                    onClick={() => handleCategoryPillClick(category)}
+                    aria-pressed={selectedCategories.includes(category)}
+                    title={selectedCategories.includes(category) ? 'Filter aufheben' : `Nach ${category} filtern`}
+                  >
+                    {category}
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
Refactors the cuisine and category pill carousels in mobile search overlays to display as two independent rows instead of a single wrapped row. This prevents pills from needing to align in columns and allows each row to maintain uniform gaps regardless of varying pill widths.

## Key Changes

- **New utility functions**: Added `splitIntoTwoRows()` and `reorderActiveFirst()` helper functions to manage row splitting and active pill ordering
- **Stable row membership**: Pills are assigned to rows based on the stable (unfiltered) pill list, preventing pills from jumping rows when selected/deselected, which would cause React to unmount/remount them and lose focus
- **Independent row rendering**: Updated both `MobileSearchOverlay` and `TagesmenuFilterOverlay` to render pills in two separate `.mobile-search-cuisine-row` containers instead of a single flat list
- **CSS restructuring**: 
  - Removed `flex-wrap`, `align-content`, `align-items`, and `max-height` constraints from `.mobile-search-cuisine-grid`
  - Added new `.mobile-search-cuisine-row` class with `flex-direction: row` and `flex-wrap: nowrap` to create independent horizontal scrolling rows
- **Test updates**: Updated carousel tests to verify active pills move to the first position *within their row* rather than globally first, and added `within()` helper to scope assertions to individual rows

## Implementation Details

The refactoring maintains the UX goal of showing active (selected) pills first while improving layout stability. Each row independently reorders its pills with active ones first, but row membership never changes based on selection state. This prevents the jarring effect of pills jumping between rows during interaction.

https://claude.ai/code/session_01MaJ7tHn5ZMpoyippeZLra3