### PR TITLE
Move form action buttons from FAB to header on desktop

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -7,12 +7,83 @@
 
 .menu-form-header {
   margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 }
 
 .menu-form-header h2 {
   margin: 0;
   color: #333;
   font-size: 1.75rem;
+}
+
+.menu-form-header-actions {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.menu-form-header-cancel,
+.menu-form-header-save {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: white;
+  transition: all 0.3s ease;
+}
+
+.menu-form-header-cancel {
+  border: 1px solid #ddd;
+  color: #666;
+}
+
+.menu-form-header-cancel:hover:not(:disabled) {
+  background: #f5f5f5;
+}
+
+.menu-form-header-save {
+  border: 1px solid #402C1C;
+  color: #402C1C;
+}
+
+.menu-form-header-save:hover:not(:disabled) {
+  background: #402C1C;
+  color: white;
+}
+
+.menu-form-header-cancel:disabled,
+.menu-form-header-save:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Desktop: buttons live in the header instead of floating FABs */
+@media (min-width: 769px) {
+  .menu-form-header-title {
+    display: none;
+  }
+
+  .menu-form-header-actions {
+    display: flex;
+  }
+
+  .menu-form-header {
+    justify-content: flex-end;
+  }
+
+  .cancel-fab-button,
+  .save-fab-button {
+    display: none;
+  }
 }
 
 .menu-form {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1397,7 +1397,29 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   return (
     <div className="menu-form-container">
       <div className="menu-form-header">
-        <h2>{menu ? 'Menü bearbeiten' : 'Neues Menü erstellen'}</h2>
+        <h2 className="menu-form-header-title">{menu ? 'Menü bearbeiten' : 'Neues Menü erstellen'}</h2>
+        <div className="menu-form-header-actions">
+          <button
+            type="button"
+            className="menu-form-header-cancel"
+            onClick={onCancel}
+            disabled={savingMenu}
+            title="Abbrechen"
+            aria-label="Menübearbeitung abbrechen"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            className="menu-form-header-save"
+            onClick={handleFabClick}
+            disabled={savingMenu}
+            title={menu ? 'Menü aktualisieren' : 'Menü speichern'}
+            aria-label={menu ? 'Menü aktualisieren' : 'Menü speichern'}
+          >
+            {savingMenu ? '…' : (menu ? 'Aktualisieren' : 'Speichern')}
+          </button>
+        </div>
       </div>
 
       <form ref={formRef} className="menu-form" onSubmit={handleSubmit}>

--- a/src/components/RecipeForm.css
+++ b/src/components/RecipeForm.css
@@ -17,6 +17,72 @@
   font-size: 1.75rem;
 }
 
+.recipe-form-header-actions {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.recipe-form-header-cancel,
+.recipe-form-header-save {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: white;
+  transition: all 0.3s ease;
+}
+
+.recipe-form-header-cancel {
+  border: 1px solid #ddd;
+  color: #666;
+}
+
+.recipe-form-header-cancel:hover {
+  background: #f5f5f5;
+}
+
+.recipe-form-header-save {
+  border: 1px solid #402C1C;
+  color: #402C1C;
+}
+
+.recipe-form-header-save:hover:not(:disabled) {
+  background: #402C1C;
+  color: white;
+}
+
+.recipe-form-header-save:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* Desktop: buttons live in the header instead of floating FABs */
+@media (min-width: 769px) {
+  .recipe-form-header-title {
+    display: none;
+  }
+
+  .recipe-form-header-actions {
+    display: flex;
+  }
+
+  .recipe-form-header {
+    justify-content: flex-end;
+  }
+
+  .cancel-fab-button,
+  .save-fab-button {
+    display: none;
+  }
+}
+
 /* Toolbar row: private list selector + import buttons on one line */
 .recipe-form-toolbar {
   display: flex;

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -1280,9 +1280,30 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   return (
     <div className="recipe-form-container">
       <div className="recipe-form-header">
-        <h2>
+        <h2 className="recipe-form-header-title">
           {isCreatingVersion ? 'Eigene Version erstellen' : (recipe ? 'Rezept bearbeiten' : 'Neues Rezept hinzufügen')}
         </h2>
+        <div className="recipe-form-header-actions">
+          <button
+            type="button"
+            className="recipe-form-header-cancel"
+            onClick={onCancel}
+            title="Abbrechen"
+            aria-label="Rezeptbearbeitung abbrechen"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            className="recipe-form-header-save"
+            onClick={handleFabClick}
+            disabled={isSaving}
+            title={recipe ? 'Rezept aktualisieren' : 'Rezept speichern'}
+            aria-label={recipe ? 'Rezept aktualisieren' : 'Rezept speichern'}
+          >
+            {isSaving ? '…' : (recipe ? 'Aktualisieren' : 'Speichern')}
+          </button>
+        </div>
       </div>
 
       {isCreatingVersion && (

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -521,6 +521,23 @@
   color: #e8e8e8;
 }
 
+[data-theme="dark"] .recipe-form-header-cancel,
+[data-theme="dark"] .recipe-form-header-save {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #555;
+}
+
+[data-theme="dark"] .recipe-form-header-cancel:hover {
+  background: #333;
+}
+
+[data-theme="dark"] .recipe-form-header-save:hover:not(:disabled) {
+  background: #402C1C;
+  color: white;
+  border-color: #402C1C;
+}
+
 [data-theme="dark"] .form-section {
   background: #1e1e1e;
   border-color: #3d3d3d;
@@ -1020,6 +1037,23 @@
 
 [data-theme="dark"] .menu-form-header h2 {
   color: #e8e8e8;
+}
+
+[data-theme="dark"] .menu-form-header-cancel,
+[data-theme="dark"] .menu-form-header-save {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #555;
+}
+
+[data-theme="dark"] .menu-form-header-cancel:hover:not(:disabled) {
+  background: #333;
+}
+
+[data-theme="dark"] .menu-form-header-save:hover:not(:disabled) {
+  background: #402C1C;
+  color: white;
+  border-color: #402C1C;
 }
 
 [data-theme="dark"] .menu-form .form-group label {


### PR DESCRIPTION
## Summary
Refactored the RecipeForm and MenuForm components to display Save and Cancel buttons in the form header on desktop devices, while maintaining floating action buttons (FABs) on mobile. This improves the desktop UX by keeping action buttons visible and accessible without requiring scrolling.

## Key Changes
- **MenuForm & RecipeForm Components**: Added header action buttons (Cancel/Save) that are hidden on mobile and displayed on desktop (769px+)
  - Buttons are positioned in the form header using flexbox layout
  - Title is hidden on desktop to make room for action buttons
  - FAB buttons are hidden on desktop via media query
  - Buttons show loading state with ellipsis when saving

- **Styling (MenuForm.css & RecipeForm.css)**:
  - Updated `.menu-form-header` and `.recipe-form-header` to use flexbox with space-between justification
  - Added `.menu-form-header-actions` and `.recipe-form-header-actions` containers
  - Styled Cancel and Save buttons with consistent 48px height, rounded corners, and hover effects
  - Cancel button: light gray border with subtle hover background
  - Save button: brown border (#402C1C) with brown background on hover
  - Added disabled state styling (60% opacity)
  - Media query hides title and FABs on desktop, shows header actions instead

- **Dark Mode Support (darkMode.css)**:
  - Added dark theme styles for new header action buttons
  - Cancel button: dark gray background (#2a2a2a) with lighter hover state
  - Save button: maintains brown accent color on hover in dark mode

## Implementation Details
- Buttons are disabled during save operations to prevent duplicate submissions
- Proper ARIA labels and titles for accessibility
- Smooth transitions (0.3s ease) on button state changes
- Responsive design: mobile-first approach with desktop enhancement via media query

https://claude.ai/code/session_018Co1oTu3N9UYx8uSdvYHEM