### PR TITLE
Standardize close button styling across app pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -72,6 +72,44 @@
   }
 }
 
+/*
+ * Standardized "close" button used across the app (Küchenbetrieb, Mise en Place,
+ * Private Liste, Küchenstars, Menüdetailansicht, Events, Eventkarte,
+ * Getränke verwalten, Gäste verwalten). Matches the recipe detail close button
+ * (.recipe-detail__close in RecipeDetail.css) exactly, so all of these render
+ * identically in size, position, hover/active state and dark mode.
+ */
+.app-close-button {
+  background: transparent;
+  border: none;
+  padding: 1rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: 1.5rem;
+  color: #333;
+  transition: opacity 0.2s ease;
+}
+
+.app-close-button:hover {
+  opacity: 0.7;
+}
+
+.app-close-button:focus-visible {
+  outline: 2px solid #333;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.app-close-button-icon-img {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .App .startseite-fab-button,
   .App .kueche-fab-button,

--- a/src/App.css.test.js
+++ b/src/App.css.test.js
@@ -105,3 +105,33 @@ describe('App CSS FAB bottom offset selectors', () => {
     expect(reducedMotionBlock).toContain('.App .recipe-detail-container .reset-thumbnail-fab-button,');
   });
 });
+
+describe('App CSS standardized close button', () => {
+  const getRuleBody = (css, selector) => {
+    const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`, 'm'));
+    return match ? match[1] : '';
+  };
+
+  test('matches the recipe detail close button (.recipe-detail__close) exactly', () => {
+    const appCssPath = path.join(__dirname, 'App.css');
+    const appCss = fs.readFileSync(appCssPath, 'utf8');
+    const recipeDetailCssPath = path.join(__dirname, 'components', 'RecipeDetail.css');
+    const recipeDetailCss = fs.readFileSync(recipeDetailCssPath, 'utf8');
+
+    const closeButtonRule = getRuleBody(appCss, '.app-close-button');
+    const closeButtonHoverRule = getRuleBody(appCss, '.app-close-button:hover');
+    const closeButtonFocusVisibleRule = getRuleBody(appCss, '.app-close-button:focus-visible');
+    const closeButtonIconRule = getRuleBody(appCss, '.app-close-button-icon-img');
+
+    const referenceRule = getRuleBody(recipeDetailCss, '.recipe-detail__close');
+    const referenceHoverRule = getRuleBody(recipeDetailCss, '.recipe-detail__close:hover');
+    const referenceFocusVisibleRule = getRuleBody(recipeDetailCss, '.recipe-detail__close:focus-visible');
+    const referenceIconRule = getRuleBody(recipeDetailCss, '.close-button-icon-img');
+
+    expect(closeButtonRule.replace(/\s/g, '')).toBe(referenceRule.replace(/\s/g, ''));
+    expect(closeButtonHoverRule.replace(/\s/g, '')).toBe(referenceHoverRule.replace(/\s/g, ''));
+    expect(closeButtonFocusVisibleRule.replace(/\s/g, '')).toBe(referenceFocusVisibleRule.replace(/\s/g, ''));
+    expect(closeButtonIconRule.replace(/\s/g, '')).toBe(referenceIconRule.replace(/\s/g, ''));
+  });
+});

--- a/src/components/AppCallsPage.js
+++ b/src/components/AppCallsPage.js
@@ -200,7 +200,7 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
       setLocalActiveTab(tab);
     }
   };
-  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.privateListBack);
+  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.closeButtonDefaultImg);
   const [nutritionEmptyIcon, setNutritionEmptyIcon] = useState(normalizeNutritionEmptyIcon());
   const [nutritionManualSaveIcon, setNutritionManualSaveIcon] = useState(DEFAULT_BUTTON_ICONS.nutritionManualSave || '💾');
   const [allButtonIcons, setAllButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
@@ -350,7 +350,11 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
   }, []);
 
   useEffect(() => {
-    setCloseIcon(getEffectiveIcon(allButtonIcons, 'privateListBack', isDarkMode) || DEFAULT_BUTTON_ICONS.privateListBack);
+    setCloseIcon(
+      getEffectiveIcon(allButtonIcons, 'closeButtonDefaultImg', isDarkMode) ||
+      getEffectiveIcon(allButtonIcons, 'closeButton', isDarkMode) ||
+      DEFAULT_BUTTON_ICONS.closeButtonDefaultImg
+    );
     setNutritionEmptyIcon(normalizeNutritionEmptyIcon(getEffectiveIcon(allButtonIcons, 'nutritionEmpty', isDarkMode)));
     setNutritionManualSaveIcon(getEffectiveIcon(allButtonIcons, 'nutritionManualSave', isDarkMode) || DEFAULT_BUTTON_ICONS.nutritionManualSave || '💾');
   }, [allButtonIcons, isDarkMode]);
@@ -1145,15 +1149,15 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
         <div className="app-calls-header">
           <h2>Küchenbetrieb</h2>
           <button
-            className="group-list-close-btn"
+            className="app-close-button"
             onClick={onBack}
             aria-label="Schließen"
             title="Schließen"
           >
             {isBase64Image(closeIcon) ? (
-              <img src={closeIcon} alt="Schließen" className="group-list-close-icon-img" />
+              <img src={closeIcon} alt="Schließen" className="app-close-button-icon-img" />
             ) : (
-              <span>{closeIcon}</span>
+              closeIcon
             )}
           </button>
         </div>
@@ -1171,15 +1175,15 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
       <div className="app-calls-header">
         <h2>Küchenbetrieb</h2>
         <button
-          className="group-list-close-btn"
+          className="app-close-button"
           onClick={onBack}
           aria-label="Schließen"
           title="Schließen"
         >
           {isBase64Image(closeIcon) ? (
-            <img src={closeIcon} alt="Schließen" className="group-list-close-icon-img" />
+            <img src={closeIcon} alt="Schließen" className="app-close-button-icon-img" />
           ) : (
-            <span>{closeIcon}</span>
+            closeIcon
           )}
         </button>
       </div>

--- a/src/components/AppCallsPage.test.js
+++ b/src/components/AppCallsPage.test.js
@@ -71,7 +71,7 @@ jest.mock('../utils/recipeFirestore', () => ({
 
 jest.mock('../utils/customLists', () => ({
   getButtonIcons: jest.fn(() => Promise.resolve({})),
-  DEFAULT_BUTTON_ICONS: { privateListBack: '✕', nutritionManualSave: '💾' },
+  DEFAULT_BUTTON_ICONS: { closeButtonDefaultImg: '✕', nutritionManualSave: '💾' },
   getEffectiveIcon: jest.fn((icons, key, isDarkMode) => {
     if (isDarkMode && icons[`${key}Dark`]) return icons[`${key}Dark`];
     return icons[key] ?? '';

--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -538,14 +538,6 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     <div className="events-page-container">
       <div className="events-page-header">
         <h2>Einkauf & Verbrauch</h2>
-        <button
-          className="events-close-btn"
-          onClick={onCancel}
-          aria-label="Abbrechen"
-          title="Abbrechen"
-        >
-          ×
-        </button>
       </div>
       {prefillWarnings.length > 0 && (
         <div className="events-warnings">

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -423,14 +423,6 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
       <div className="events-page-container">
         <div className="events-page-header">
           <h2>{editId ? 'Getränk bearbeiten' : 'Neues Getränk'}</h2>
-          <button
-            className="events-close-btn"
-            onClick={closeForm}
-            aria-label="Abbrechen"
-            title="Abbrechen"
-          >
-            ×
-          </button>
         </div>
         <form className="events-form" onSubmit={handleSave} ref={formRef}>
           <label className="events-form-field">
@@ -707,6 +699,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   }
 
   const swipeDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
+  const closeIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
   return (
     <div className="events-page-container">
@@ -714,12 +707,16 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
         <h2>Getränke verwalten</h2>
         {onBack && (
           <button
-            className="events-close-btn"
+            className="app-close-button"
             onClick={onBack}
-            aria-label="Zurück"
-            title="Zurück"
+            aria-label="Getränke verwalten schließen"
+            title="Getränke verwalten schließen"
           >
-            ×
+            {isBase64Image(closeIcon) ? (
+              <img src={closeIcon} alt="Getränke verwalten schließen" className="app-close-button-icon-img" />
+            ) : (
+              closeIcon || '×'
+            )}
           </button>
         )}
       </div>

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -304,14 +304,6 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
     <div className="events-page-container">
       <div className="events-page-header">
         <h2>{isEditing ? 'Event bearbeiten' : 'Neues Event'}</h2>
-        <button
-          className="events-close-btn"
-          onClick={onCancel}
-          aria-label="Abbrechen"
-          title="Abbrechen"
-        >
-          ×
-        </button>
       </div>
       <form className="events-form" onSubmit={handleSubmit}>
         <label className="events-form-field">

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -197,6 +197,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     return events.find((e) => e.id === selectedEventId) || fallbackEvent || null;
   }, [events, selectedEventId, fallbackEvent]);
   const editEventIcon = getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode);
+  const eventsCloseIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
   const handleSelectEvent = (event) => {
     setOpenedFromMenuLink(false);
@@ -296,7 +297,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         <div className="events-page-header">
           <h2>{selectedEvent.eventName}</h2>
           <button
-            className="events-close-btn"
+            className="app-close-button"
             onClick={() => {
               if (openedFromMenuLink && onCloseLinkedEventDetail) {
                 setOpenedFromMenuLink(false);
@@ -310,7 +311,11 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             aria-label={openedFromMenuLink ? 'Zurück zum Menü' : 'Zurück zur Liste'}
             title={openedFromMenuLink ? 'Zurück zum Menü' : 'Zurück zur Liste'}
           >
-            ×
+            {isBase64Image(eventsCloseIcon) ? (
+              <img src={eventsCloseIcon} alt="Schließen" className="app-close-button-icon-img" />
+            ) : (
+              eventsCloseIcon || '×'
+            )}
           </button>
         </div>
 
@@ -446,12 +451,16 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         <h2>Events</h2>
         {onBack && (
           <button
-            className="events-close-btn"
+            className="app-close-button"
             onClick={onBack}
-            aria-label="Schließen"
-            title="Schließen"
+            aria-label="Events schließen"
+            title="Events schließen"
           >
-            ×
+            {isBase64Image(eventsCloseIcon) ? (
+              <img src={eventsCloseIcon} alt="Events schließen" className="app-close-button-icon-img" />
+            ) : (
+              eventsCloseIcon || '×'
+            )}
           </button>
         )}
       </div>

--- a/src/components/GroupDetail.css
+++ b/src/components/GroupDetail.css
@@ -13,12 +13,6 @@
   flex-wrap: wrap;
 }
 
-.group-back-icon-img {
-  width: 1.4rem;
-  height: 1.4rem;
-  object-fit: contain;
-}
-
 .group-detail-title {
   display: flex;
   align-items: center;
@@ -154,40 +148,12 @@
     transform 0.15s ease;
 }
 
-.group-header-actions .group-back-icon-btn {
-  width: 48px !important;
-  height: 48px !important;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: transparent !important;
-  border: none !important;
-  border-radius: 12px;
-  color: #555;
-  line-height: 1;
-  font-size: 1.4rem;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
-  transition:
-    color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.15s ease;
-}
-
 .group-header-actions .list-settings-trigger-button:active {
   transform: scale(1.1);
   opacity: 0.2;
 }
 
 .group-header-actions .shopping-list-trigger-button:active {
-  transform: scale(1.1);
-  opacity: 0.2;
-}
-
-.group-header-actions .group-back-icon-btn:active {
   transform: scale(1.1);
   opacity: 0.2;
 }

--- a/src/components/GroupDetail.darkMode.css.test.js
+++ b/src/components/GroupDetail.darkMode.css.test.js
@@ -53,22 +53,16 @@ describe('GroupDetail dark mode styles', () => {
 });
 
 describe('GroupDetail light mode styles', () => {
-  test('keeps settings button boxed but back button transparent in header actions', () => {
+  test('keeps settings button boxed in header actions', () => {
     const cssPath = path.join(__dirname, 'GroupDetail.css');
     const css = fs.readFileSync(cssPath, 'utf8');
     const settingsRule = getRuleBody(css, '.group-header-actions .list-settings-trigger-button');
     const shoppingRule = getRuleBody(css, '.group-header-actions .shopping-list-trigger-button');
     const settingsIconRule = getRuleBody(css, '.list-settings-icon-img');
-    const backRule = getRuleBody(css, '.group-header-actions .group-back-icon-btn');
 
     expect(settingsRule).toContain('background: #fff !important;');
     expect(settingsRule).toContain('border: 1px solid #f0f0f0 !important;');
-    expect(backRule).toContain('background: transparent !important;');
-    expect(backRule).toContain('border: none !important;');
-    expect(backRule).toContain('-webkit-tap-highlight-color: transparent;');
-    expect(backRule).toContain('touch-action: manipulation;');
     expect(settingsRule).toContain('display: inline-flex;');
-    expect(backRule).toContain('display: inline-flex;');
     expect(settingsRule).toContain('-webkit-tap-highlight-color: transparent;');
     expect(settingsRule).toContain('touch-action: manipulation;');
     expect(shoppingRule).toContain('-webkit-tap-highlight-color: transparent;');

--- a/src/components/GroupDetail.js
+++ b/src/components/GroupDetail.js
@@ -72,7 +72,7 @@ function GroupDetail({
     setActiveTab(tab);
     if (onActiveTabChange) onActiveTabChange(tab);
   };
-  const [backIcon, setBackIcon] = useState(DEFAULT_BUTTON_ICONS.privateListBack);
+  const [backIcon, setBackIcon] = useState(DEFAULT_BUTTON_ICONS.closeButtonDefaultImg);
   const [shoppingListIcon, setShoppingListIcon] = useState(DEFAULT_BUTTON_ICONS.shoppingList || 'Einkauf');
   const [listSettingsIcon, setListSettingsIcon] = useState(DEFAULT_BUTTON_ICONS.listSettings || DEFAULT_LIST_SETTINGS_ICON);
   const [listSettingsActiveIcon, setListSettingsActiveIcon] = useState(resolveListSettingsActiveIcon(DEFAULT_BUTTON_ICONS, getDarkModePreference()));
@@ -120,7 +120,11 @@ function GroupDetail({
   }, []);
 
   useEffect(() => {
-    setBackIcon(getEffectiveIcon(allButtonIcons, 'privateListBack', isDarkMode) || DEFAULT_BUTTON_ICONS.privateListBack);
+    setBackIcon(
+      getEffectiveIcon(allButtonIcons, 'closeButtonDefaultImg', isDarkMode) ||
+      getEffectiveIcon(allButtonIcons, 'closeButton', isDarkMode) ||
+      DEFAULT_BUTTON_ICONS.closeButtonDefaultImg
+    );
     setShoppingListIcon(getEffectiveIcon(allButtonIcons, 'shoppingList', isDarkMode) || DEFAULT_BUTTON_ICONS.shoppingList || 'Einkauf');
     setListSettingsIcon(getEffectiveIcon(allButtonIcons, 'listSettings', isDarkMode) || DEFAULT_BUTTON_ICONS.listSettings || DEFAULT_LIST_SETTINGS_ICON);
     setListSettingsActiveIcon(resolveListSettingsActiveIcon(allButtonIcons, isDarkMode));
@@ -564,11 +568,11 @@ function GroupDetail({
               )}
             </button>
           )}
-          <button className="group-back-icon-btn" onClick={onBack} aria-label="Zurück">
+          <button className="app-close-button" onClick={onBack} aria-label="Private Liste schließen" title="Private Liste schließen">
             {isBase64Image(backIcon) ? (
-              <img src={backIcon} alt="Zurück" className="group-back-icon-img" />
+              <img src={backIcon} alt="Private Liste schließen" className="app-close-button-icon-img" />
             ) : (
-              <span>{backIcon}</span>
+              backIcon
             )}
           </button>
         </div>

--- a/src/components/GroupList.css
+++ b/src/components/GroupList.css
@@ -42,68 +42,6 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
-.group-list-close-btn {
-  width: 48px;
-  height: 48px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: transparent;
-  border: none;
-  outline: none;
-  -webkit-appearance: none;
-  appearance: none;
-  border-radius: 12px;
-  cursor: pointer;
-  line-height: 1;
-  font-size: 1.4rem;
-  color: #555;
-  -webkit-tap-highlight-color: transparent;
-  -webkit-appearance: none;
-  appearance: none;
-  touch-action: manipulation;
-  transition:
-    color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.15s ease;
-}
-
-.group-list-close-btn:hover {
-  background: #f0f0f0;
-}
-
-.group-list-close-btn:focus {
-  outline: none;
-  background: transparent;
-  box-shadow: none;
-  -webkit-box-shadow: none;
-}
-
-.group-list-close-btn:focus-visible {
-  outline: 2px solid #5A2A4A;
-  outline-offset: 2px;
-  background: transparent;
-}
-
-.group-list-close-btn:focus:not(:focus-visible) {
-  background: transparent !important;
-  outline: none;
-  box-shadow: none;
-}
-
-.group-list-close-btn:active {
-  transform: scale(1.1);
-  opacity: 0.2;
-}
-
-.group-list-close-icon-img {
-  width: 1.4rem;
-  height: 1.4rem;
-  object-fit: contain;
-}
-
 .group-section {
   margin-bottom: 2rem;
 }

--- a/src/components/GroupList.css.test.js
+++ b/src/components/GroupList.css.test.js
@@ -19,38 +19,6 @@ describe('GroupList CSS layout', () => {
     expect(headingRule).toContain('flex: 1;');
   });
 
-  test('keeps the close button centered with transparent light mode chrome', () => {
-    const cssPath = path.join(__dirname, 'GroupList.css');
-    const css = fs.readFileSync(cssPath, 'utf8');
-    const closeButtonRule = getRuleBody(css, '.group-list-close-btn');
-    const closeButtonHoverRule = getRuleBody(css, '.group-list-close-btn:hover');
-    const closeButtonFocusRule = getRuleBody(css, '.group-list-close-btn:focus');
-    const closeButtonFocusVisibleRule = getRuleBody(css, '.group-list-close-btn:focus-visible');
-    const closeButtonFocusNotVisibleRule = getRuleBody(css, '.group-list-close-btn:focus:not(:focus-visible)');
-
-    expect(closeButtonRule).toContain('display: inline-flex;');
-    expect(closeButtonRule).toContain('align-items: center;');
-    expect(closeButtonRule).toContain('justify-content: center;');
-    expect(closeButtonRule).toContain('background: transparent;');
-    expect(closeButtonRule).toContain('border: none;');
-    expect(closeButtonRule).toContain('outline: none;');
-    expect(closeButtonRule).toContain('-webkit-appearance: none;');
-    expect(closeButtonRule).toContain('appearance: none;');
-    expect(closeButtonRule).toContain('-webkit-tap-highlight-color: transparent;');
-    expect(closeButtonRule).toContain('touch-action: manipulation;');
-    expect(closeButtonHoverRule).toContain('background: #f0f0f0;');
-    expect(closeButtonFocusRule).toContain('outline: none;');
-    expect(closeButtonFocusRule).toContain('background: transparent;');
-    expect(closeButtonFocusRule).toContain('box-shadow: none;');
-    expect(closeButtonFocusRule).toContain('-webkit-box-shadow: none;');
-    expect(closeButtonFocusVisibleRule).toContain('outline: 2px solid #5A2A4A;');
-    expect(closeButtonFocusVisibleRule).toContain('outline-offset: 2px;');
-    expect(closeButtonFocusVisibleRule).toContain('background: transparent;');
-    expect(closeButtonFocusNotVisibleRule).toContain('background: transparent !important;');
-    expect(closeButtonFocusNotVisibleRule).toContain('outline: none;');
-    expect(closeButtonFocusNotVisibleRule).toContain('box-shadow: none;');
-  });
-
   test('shows full card descriptions without line clamp and keeps card height content-driven', () => {
     const cssPath = path.join(__dirname, 'GroupList.css');
     const css = fs.readFileSync(cssPath, 'utf8');

--- a/src/components/GroupList.js
+++ b/src/components/GroupList.js
@@ -19,7 +19,7 @@ import { LIST_KIND_OPTIONS } from '../utils/groupFirestore';
  */
 function GroupList({ groups, allUsers, currentUser, onSelectGroup, onCreateGroup, onBack }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.privateListBack);
+  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.closeButtonDefaultImg);
   const [allButtonIcons, setAllButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [addFabPressed, setAddFabPressed] = useState(false);
@@ -32,7 +32,11 @@ function GroupList({ groups, allUsers, currentUser, onSelectGroup, onCreateGroup
   }, []);
 
   useEffect(() => {
-    setCloseIcon(getEffectiveIcon(allButtonIcons, 'privateListBack', isDarkMode) || DEFAULT_BUTTON_ICONS.privateListBack);
+    setCloseIcon(
+      getEffectiveIcon(allButtonIcons, 'closeButtonDefaultImg', isDarkMode) ||
+      getEffectiveIcon(allButtonIcons, 'closeButton', isDarkMode) ||
+      DEFAULT_BUTTON_ICONS.closeButtonDefaultImg
+    );
   }, [allButtonIcons, isDarkMode]);
 
   useEffect(() => {
@@ -69,15 +73,15 @@ function GroupList({ groups, allUsers, currentUser, onSelectGroup, onCreateGroup
         {onBack && (
           <button
             ref={closeBtnRef}
-            className="group-list-close-btn"
+            className="app-close-button"
             onClick={onBack}
-            aria-label="Private Liste schließen"
-            title="Private Liste schließen"
+            aria-label="Meine Mise en Place schließen"
+            title="Meine Mise en Place schließen"
           >
             {isBase64Image(closeIcon) ? (
-              <img src={closeIcon} alt="Private Liste schließen" className="group-list-close-icon-img" />
+              <img src={closeIcon} alt="Meine Mise en Place schließen" className="app-close-button-icon-img" />
             ) : (
-              <span>{closeIcon}</span>
+              closeIcon
             )}
           </button>
         )}

--- a/src/components/GroupList.test.js
+++ b/src/components/GroupList.test.js
@@ -4,8 +4,8 @@ import GroupList from './GroupList';
 
 // Mock customLists so icon loading resolves immediately
 jest.mock('../utils/customLists', () => ({
-  getButtonIcons: () => Promise.resolve({ privateListBack: '✕', addRecipe: '+' }),
-  DEFAULT_BUTTON_ICONS: { privateListBack: '✕', addRecipe: '+' },
+  getButtonIcons: () => Promise.resolve({ closeButtonDefaultImg: '✕', addRecipe: '+' }),
+  DEFAULT_BUTTON_ICONS: { closeButtonDefaultImg: '✕', addRecipe: '+' },
   getEffectiveIcon: (icons, key) => icons[key] ?? '',
   getDarkModePreference: () => false,
 }));
@@ -212,7 +212,7 @@ describe('GroupList', () => {
     );
     const titleRow = container.querySelector('.group-list-header');
     expect(titleRow).toBeInTheDocument();
-    const closeBtn = titleRow.querySelector('.group-list-close-btn');
+    const closeBtn = titleRow.querySelector('.app-close-button');
     expect(closeBtn).toBeInTheDocument();
   });
 
@@ -229,7 +229,7 @@ describe('GroupList', () => {
     );
     const actions = container.querySelector('.group-list-actions');
     expect(actions).toBeInTheDocument();
-    const closeBtnInActions = actions.querySelector('.group-list-close-btn');
+    const closeBtnInActions = actions.querySelector('.app-close-button');
     expect(closeBtnInActions).not.toBeInTheDocument();
   });
 

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -51,6 +51,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
 
   const canManageGuests = canEditRecipes(currentUser);
+  const closeIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
   useEffect(() => {
     const loadIcons = async () => {
@@ -213,12 +214,16 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
           <h2>Gäste verwalten</h2>
           {onBack && (
             <button
-              className="events-close-btn"
+              className="app-close-button"
               onClick={onBack}
-              aria-label="Zurück"
-              title="Zurück"
+              aria-label="Gäste verwalten schließen"
+              title="Gäste verwalten schließen"
             >
-              ×
+              {isBase64Image(closeIcon) ? (
+                <img src={closeIcon} alt="Gäste verwalten schließen" className="app-close-button-icon-img" />
+              ) : (
+                closeIcon || '×'
+              )}
             </button>
           )}
         </div>
@@ -234,14 +239,6 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
       <div className="events-page-container">
         <div className="events-page-header">
           <h2>{editId ? 'Gast bearbeiten' : 'Neuen Gast erfassen'}</h2>
-          <button
-            className="events-close-btn"
-            onClick={() => setShowForm(false)}
-            aria-label="Abbrechen"
-            title="Abbrechen"
-          >
-            ×
-          </button>
         </div>
         <form className="events-form" onSubmit={handleSave} ref={formRef}>
           <div className="events-form-row">
@@ -483,12 +480,16 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         <h2>Gäste verwalten</h2>
         {onBack && (
           <button
-            className="events-close-btn"
+            className="app-close-button"
             onClick={onBack}
-            aria-label="Zurück"
-            title="Zurück"
+            aria-label="Gäste verwalten schließen"
+            title="Gäste verwalten schließen"
           >
-            ×
+            {isBase64Image(closeIcon) ? (
+              <img src={closeIcon} alt="Gäste verwalten schließen" className="app-close-button-icon-img" />
+            ) : (
+              closeIcon || '×'
+            )}
           </button>
         )}
       </div>

--- a/src/components/MeineKuechenstarsPage.css
+++ b/src/components/MeineKuechenstarsPage.css
@@ -11,32 +11,6 @@
   margin-bottom: 20px;
 }
 
-.meine-kuechenstars-close-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: 1.4rem;
-  line-height: 1;
-  padding: 0.25rem 0.5rem;
-  border-radius: 6px;
-  color: #555;
-  transition: background 0.2s, color 0.2s;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.meine-kuechenstars-close-btn:hover {
-  background: rgba(0, 0, 0, 0.08);
-  color: #222;
-}
-
-.meine-kuechenstars-close-icon-img {
-  width: 1.4rem;
-  height: 1.4rem;
-  object-fit: contain;
-}
-
 .meine-kuechenstars-header h2 {
   margin: 0;
   color: #2F5D50;

--- a/src/components/MeineKuechenstarsPage.js
+++ b/src/components/MeineKuechenstarsPage.js
@@ -7,7 +7,7 @@ import { isBase64Image } from '../utils/imageUtils';
 function MeineKuechenstarsPage({ onBack, currentUser, recipes = [] }) {
   const [recipeCalls, setRecipeCalls] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.privateListBack);
+  const [closeIcon, setCloseIcon] = useState(DEFAULT_BUTTON_ICONS.closeButtonDefaultImg);
   const [allButtonIcons, setAllButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
 
@@ -30,7 +30,11 @@ function MeineKuechenstarsPage({ onBack, currentUser, recipes = [] }) {
   }, []);
 
   useEffect(() => {
-    setCloseIcon(getEffectiveIcon(allButtonIcons, 'privateListBack', isDarkMode) || DEFAULT_BUTTON_ICONS.privateListBack);
+    setCloseIcon(
+      getEffectiveIcon(allButtonIcons, 'closeButtonDefaultImg', isDarkMode) ||
+      getEffectiveIcon(allButtonIcons, 'closeButton', isDarkMode) ||
+      DEFAULT_BUTTON_ICONS.closeButtonDefaultImg
+    );
   }, [allButtonIcons, isDarkMode]);
 
   useEffect(() => {
@@ -59,15 +63,15 @@ function MeineKuechenstarsPage({ onBack, currentUser, recipes = [] }) {
         <h2>Meine Küchenstars</h2>
         {onBack && (
           <button
-            className="meine-kuechenstars-close-btn"
+            className="app-close-button"
             onClick={onBack}
-            aria-label="Schließen"
-            title="Schließen"
+            aria-label="Meine Küchenstars schließen"
+            title="Meine Küchenstars schließen"
           >
             {isBase64Image(closeIcon) ? (
-              <img src={closeIcon} alt="Schließen" className="meine-kuechenstars-close-icon-img" />
+              <img src={closeIcon} alt="Meine Küchenstars schließen" className="app-close-button-icon-img" />
             ) : (
-              <span>{closeIcon}</span>
+              closeIcon
             )}
           </button>
         )}

--- a/src/components/MeineKuechenstarsPage.test.js
+++ b/src/components/MeineKuechenstarsPage.test.js
@@ -8,7 +8,7 @@ jest.mock('../utils/recipeCallsFirestore', () => ({
 
 jest.mock('../utils/customLists', () => ({
   getButtonIcons: () => Promise.resolve({}),
-  DEFAULT_BUTTON_ICONS: { privateListBack: '✕' },
+  DEFAULT_BUTTON_ICONS: { closeButtonDefaultImg: '✕' },
   getEffectiveIcon: (icons, key) => icons[key] ?? '',
   getDarkModePreference: () => false,
 }));

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -95,7 +95,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
   useEffect(() => {
     if (!allButtonIcons) return;
     const eff = (key) => getEffectiveIcon(allButtonIcons, key, isDarkMode);
-    setCloseButtonIcon(eff('menuCloseButton') || '×');
+    setCloseButtonIcon(eff('closeButtonDefaultImg') || eff('closeButton') || '×');
     setCopyLinkIcon(eff('copyLink') || 'Link');
     setOpenEventIcon(eff('openLinkedEvent') || '📅');
     setShoppingListIcon(eff('shoppingList') || 'Einkauf');
@@ -667,9 +667,9 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
         <div className="menu-detail-body">
         <div className="menu-title-row">
           <h1 className="menu-title">{menu.name}</h1>
-          <button className="close-button" onClick={onBack} title="Schließen">
+          <button className="app-close-button" onClick={onBack} aria-label="Menüdetailansicht schließen" title="Menüdetailansicht schließen">
             {isBase64Image(closeButtonIcon) ? (
-              <img src={closeButtonIcon} alt="Schließen" className="close-button-icon-img" />
+              <img src={closeButtonIcon} alt="Menüdetailansicht schließen" className="app-close-button-icon-img" />
             ) : (
               closeButtonIcon
             )}

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -39,7 +39,7 @@ jest.mock('../utils/menuSections', () => {
 });
 
 jest.mock('../utils/customLists', () => ({
-  getButtonIcons: () => Promise.resolve({ menuCloseButton: '✕', copyLink: '📋' }),
+  getButtonIcons: () => Promise.resolve({ closeButtonDefaultImg: '✕', copyLink: '📋' }),
   getCustomLists: () => Promise.resolve({ conversionTable: [] }),
   addMissingConversionEntries: jest.fn(() => Promise.resolve()),
   getEffectiveIcon: (icons, key) => icons[key] ?? '',
@@ -210,7 +210,7 @@ describe('MenuDetail - Close Button in Title Row', () => {
 
     const titleRow = container.querySelector('.menu-title-row');
     expect(titleRow).toBeInTheDocument();
-    const closeButton = titleRow.querySelector('.close-button');
+    const closeButton = titleRow.querySelector('.app-close-button');
     expect(closeButton).toBeInTheDocument();
   });
 
@@ -231,7 +231,7 @@ describe('MenuDetail - Close Button in Title Row', () => {
 
     const header = container.querySelector('.menu-detail-header');
     expect(header).toBeInTheDocument();
-    const closeButtonInHeader = header.querySelector('.close-button');
+    const closeButtonInHeader = header.querySelector('.app-close-button');
     expect(closeButtonInHeader).not.toBeInTheDocument();
   });
 });

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -166,7 +166,7 @@ const DARK_MODE_ICON_ROWS = [
   { key: 'webImport', label: 'Web-Import-Button' },
   { key: 'closeButton', label: 'Schließen-Button' },
   { key: 'closeButtonAlt', label: 'Schließen-Alt (helles Bild oben rechts)' },
-  { key: 'closeButtonDefaultImg', label: 'Schließen-Button (Standard-Kategoriebild)' },
+  { key: 'closeButtonDefaultImg', label: 'Schließen-Button (Allgemein)' },
   { key: 'menuCloseButton', label: 'Menü-Schließen-Button' },
   { key: 'filterButton', label: 'Filter-Button' },
   { key: 'filterButtonActive', label: 'Filter-Button (aktiv)' },

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -1179,23 +1179,7 @@
   background: #2a2a2a;
 }
 
-[data-theme="dark"] .group-list-close-btn {
-  background: transparent !important;
-  border-color: transparent !important;
-  color: #e8e8e8;
-}
-
-[data-theme="dark"] .group-list-close-btn:hover {
-  background: #333 !important;
-}
-
 /* ---- Group Detail ---- */
-[data-theme="dark"] .group-header-actions .group-back-icon-btn {
-  background: transparent !important;
-  border-color: transparent !important;
-  color: #e8e8e8;
-}
-
 [data-theme="dark"] .group-header-actions .list-settings-trigger-button {
   background: #2a2a2a !important;
   border-color: #555 !important;


### PR DESCRIPTION
## Summary
Consolidates close button styling across multiple pages (Küchenbetrieb, Mise en Place, Meine Küchenstars, Events, Getränke verwalten, Gäste verwalten) by introducing a standardized `.app-close-button` class in App.css that matches the existing recipe detail close button styling exactly.

## Key Changes
- **New standardized close button class**: Added `.app-close-button` and `.app-close-button-icon-img` to App.css with styling that matches `.recipe-detail__close` exactly for consistency across the app
- **Removed component-specific close button styles**: Deleted duplicate close button CSS from:
  - GroupList.css (`.group-list-close-btn`)
  - GroupDetail.css (`.group-back-icon-btn`)
  - MeineKuechenstarsPage.css (`.meine-kuechenstars-close-btn`)
- **Updated component implementations**: Migrated all close buttons to use the new standardized class:
  - AppCallsPage.js
  - GroupList.js
  - GroupDetail.js
  - MeineKuechenstarsPage.js
  - EventsPage.js
  - DrinkManagementPage.js
  - GuestManagementPage.js
  - MenuDetail.js
- **Unified icon handling**: Updated all components to use `closeButtonDefaultImg` or `closeButton` icon keys consistently instead of component-specific keys like `privateListBack` or `menuCloseButton`
- **Removed form close buttons**: Eliminated close buttons from form headers in EventForm.js, ConsumptionForm.js, and form sections in DrinkManagementPage.js and GuestManagementPage.js
- **Updated dark mode styles**: Removed component-specific dark mode overrides for close buttons from darkMode.css
- **Updated tests**: Modified CSS tests to verify the new standardized button matches recipe detail styling, and updated component tests to reference the new class names and icon keys

## Implementation Details
- All close buttons now render identically in size, position, hover/active states, and dark mode across the entire app
- Icon loading logic updated to check for `closeButtonDefaultImg` first, then fall back to `closeButton` key
- Maintained backward compatibility by keeping fallback to `×` character if no icon is available
- Added comprehensive test to ensure `.app-close-button` styling exactly matches `.recipe-detail__close`

https://claude.ai/code/session_0168T5K8qosxZKX5AHGVEzPf