### PR TITLE
Align group header actions to the right

### DIFF
--- a/src/components/GroupDetail.css
+++ b/src/components/GroupDetail.css
@@ -108,6 +108,8 @@
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .group-header-actions .shopping-list-trigger-button {


### PR DESCRIPTION
## Summary
Updated the styling of the group header actions container to align its content to the right side of the header.

## Changes
- Added `margin-left: auto` to push the actions container to the right
- Added `justify-content: flex-end` to ensure flex items within the container are right-aligned

## Details
These CSS changes ensure that action buttons in the group header are positioned at the right edge of the header, improving the visual layout and following common UI patterns where primary actions are placed on the right side of headers.

https://claude.ai/code/session_01B1Mt2FLhiKNaizMcDCDw6d