### PR TITLE
Shorten recipe add button labels in sidebar

### DIFF
--- a/src/components/RecipeFilterSidebar.js
+++ b/src/components/RecipeFilterSidebar.js
@@ -179,7 +179,7 @@ function RecipeFilterSidebar({
             title={activePrivateListId ? 'Privates Rezept hinzufügen' : 'Rezept hinzufügen'}
             aria-label={activePrivateListId ? 'Privates Rezept hinzufügen' : 'Rezept hinzufügen'}
           >
-            {activePrivateListId ? 'Privates Rezept hinzufügen' : 'Rezept hinzufügen'}
+            {activePrivateListId ? '+ Privates Rezept' : '+ Rezept'}
           </button>
         )}
         <button


### PR DESCRIPTION
## Summary
Updated the text labels for the recipe add button in the RecipeFilterSidebar component to be more concise.

## Changes
- Shortened "Rezept hinzufügen" to "+ Rezept" for the standard recipe add button
- Shortened "Privates Rezept hinzufügen" to "+ Privates Rezept" for the private recipe add button
- Added "+" prefix to both labels to make the action more visually apparent

## Details
This change improves the UI by reducing button label length while maintaining clarity through the addition of a "+" symbol, which is a common convention for "add" actions. The conditional logic remains unchanged—the button still displays the appropriate label based on whether a private list is active.

https://claude.ai/code/session_01F3aZHDJudToe2HE3BdBkmy