### PR TITLE
Improve touch interaction experience on close buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,6 +92,8 @@
   font-size: 1.5rem;
   color: #333;
   transition: opacity 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .app-close-button:hover {

--- a/src/components/RecipeDetail.css
+++ b/src/components/RecipeDetail.css
@@ -209,6 +209,8 @@
   font-size: 1.5rem;
   color: #333;
   transition: opacity 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .recipe-detail__close:hover {


### PR DESCRIPTION
## Summary
Enhanced the touch interaction experience for close buttons by removing the default tap highlight and optimizing touch action behavior on mobile devices.

## Key Changes
- Added `-webkit-tap-highlight-color: transparent;` to remove the default gray highlight that appears when tapping buttons on mobile browsers
- Added `touch-action: manipulation;` to allow faster click response by preventing double-tap zoom on these interactive elements
- Applied these improvements to both the main app close button (`.app-close-button`) and the recipe detail close button (`.recipe-detail__close`)

## Implementation Details
These CSS properties improve the mobile user experience by:
- Eliminating the visual feedback flash that can feel unresponsive
- Reducing the 300ms delay typically added by browsers to detect double-tap zoom gestures, resulting in snappier button interactions
- Maintaining accessibility while providing a more native app-like feel on touch devices

https://claude.ai/code/session_019SeNtDVXzJbHJjGA1EDnqM