### PR TITLE
Add private list management to GroupDetail component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2180,6 +2180,10 @@ function App() {
             showFavoritesOnly={showFavoritesOnly}
             showSeasonalOnly={showSeasonalOnly}
             onActiveTabChange={(tab) => setIsPrivateListSettingsTabOpen(tab === 'einstellungen')}
+            onAddToPrivateList={handleAddRecipeToPrivateList}
+            onRemoveFromPrivateList={handleRemoveRecipeFromPrivateList}
+            publicGroupId={publicGroupId}
+            onMoveRecipeToPublic={handleMoveRecipeToPublic}
           />
         ) : (
           <GroupList

--- a/src/components/GroupDetail.js
+++ b/src/components/GroupDetail.js
@@ -64,7 +64,11 @@ function GroupDetail({
   activeFilters,
   showFavoritesOnly = false,
   showSeasonalOnly = false,
-  onActiveTabChange
+  onActiveTabChange,
+  onAddToPrivateList,
+  onRemoveFromPrivateList,
+  publicGroupId,
+  onMoveRecipeToPublic
 }) {
   const [saving, setSaving] = useState(false);
   const [activeTab, setActiveTab] = useState(TAB_RECIPES);
@@ -142,7 +146,7 @@ function GroupDetail({
       if (currentUser?.id) {
         try {
           const favorites = await getUserFavorites(currentUser.id);
-          setFavoriteIds(favorites);
+          setFavoriteIds(Array.isArray(favorites) ? favorites : []);
         } catch {
           setFavoriteIds([]);
         }
@@ -591,6 +595,14 @@ function GroupDetail({
                   recipe={recipe}
                   onClick={() => onSelectRecipe && onSelectRecipe(recipe)}
                   currentUser={currentUser}
+                  isFavorite={favoriteIds.includes(recipe.id)}
+                  favoriteActiveIcon={getEffectiveIcon(allButtonIcons, 'menuFavoritesButtonActive', isDarkMode)}
+                  privateLists={privateLists}
+                  onAddToPrivateList={onAddToPrivateList}
+                  onRemoveFromPrivateList={onRemoveFromPrivateList}
+                  swipeRightIcon={getEffectiveIcon(allButtonIcons, 'recipeCardSwipeRight', isDarkMode)}
+                  publicGroupId={publicGroupId}
+                  onMoveRecipeToPublic={onMoveRecipeToPublic}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
Enhanced the GroupDetail component to support managing recipes in private lists, including the ability to add/remove recipes from private lists and move recipes to public groups.

## Key Changes
- **Props Addition**: Added four new props to GroupDetail component:
  - `onAddToPrivateList`: Callback handler for adding recipes to private lists
  - `onRemoveFromPrivateList`: Callback handler for removing recipes from private lists
  - `publicGroupId`: Identifier for the public group
  - `onMoveRecipeToPublic`: Callback handler for moving recipes to public groups

- **RecipeCard Enhancement**: Updated RecipeCard component rendering to pass additional props:
  - `isFavorite`: Boolean flag indicating if recipe is favorited
  - `favoriteActiveIcon`: Icon for active favorite state
  - `privateLists`: Available private lists for the user
  - `swipeRightIcon`: Icon for swipe right gesture
  - All new callback handlers and public group ID

- **Bug Fix**: Fixed potential issue in favorites loading by ensuring `setFavoriteIds` receives an array:
  - Changed `setFavoriteIds(favorites)` to `setFavoriteIds(Array.isArray(favorites) ? favorites : [])`
  - Prevents errors if API returns non-array value

- **App Integration**: Connected handlers in App.js to pass through to GroupDetail:
  - `handleAddRecipeToPrivateList`
  - `handleRemoveRecipeFromPrivateList`
  - `handleMoveRecipeToPublic`

## Implementation Details
The changes enable users to manage recipe organization across private and public lists directly from the GroupDetail view, with proper icon theming support for dark mode.

https://claude.ai/code/session_01FruupoytbXw22WSzzefDAL