### PR TITLE
Refactor SortCarousel to collapse/expand with native scroll events

### DIFF
--- a/src/components/SortCarousel.css
+++ b/src/components/SortCarousel.css
@@ -10,7 +10,6 @@
   .sort-carousel {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
     /* Break out of the recipe-list-container's 1rem side padding so the
        carousel spans the full viewport width; the matching horizontal
        padding below re-creates that 1rem gap for the pill at each end,
@@ -35,6 +34,7 @@
 
 .sort-carousel-item {
   flex: 0 0 auto;
+  min-width: 0;
   scroll-snap-align: center;
 
   appearance: none;
@@ -48,11 +48,38 @@
   font-size: 0.85rem;
   font-weight: 600;
   white-space: nowrap;
+  margin-right: 0.5rem;
 
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.15s ease,
+    max-width 0.25s ease, opacity 0.2s ease, margin-right 0.25s ease, padding 0.25s ease,
+    border-width 0.25s ease;
   -webkit-tap-highlight-color: transparent;
+}
+
+.sort-carousel-item:last-child {
+  margin-right: 0;
+}
+
+/* Collapsed (default) state: only the active pill is shown. The other
+   pills are shrunk to zero width via `max-width` rather than removed
+   from the DOM, so focus order, ARIA state and keyboard navigation stay
+   intact — they're just visually and pointer-wise unreachable until the
+   carousel expands. */
+.sort-carousel:not(.sort-carousel--expanded) .sort-carousel-item:not(.sort-carousel-item--active) {
+  max-width: 0;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.sort-carousel--expanded .sort-carousel-item {
+  max-width: 12rem;
 }
 
 .sort-carousel-item:active {

--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import './SortCarousel.css';
 
 export const SORT_OPTIONS = [
@@ -9,11 +9,21 @@ export const SORT_OPTIONS = [
   { id: 'index', label: 'Nach Relevanz' },
 ];
 
-// Simple tap-to-select pill bar with native horizontal scrolling/snapping.
-// Replaces the previous long-press + drag gesture carousel, whose custom
-// touch-velocity math reacted unpredictably.
+// How long the carousel stays expanded after the user stops interacting
+// with it (scrolling, tapping the active pill, or focusing it) before it
+// collapses back down to just the active pill.
+const COLLAPSE_DELAY_MS = 1200;
+
+// Tap-to-select pill bar with native horizontal scrolling/snapping. Only
+// the active pill is shown until the user swipes (or taps/focuses it),
+// which reveals the rest. Expansion is driven purely by the browser's own
+// scroll/focus events — no custom touch-position or velocity tracking —
+// unlike the previous long-press + drag gesture carousel, whose
+// reimplemented touch physics reacted unpredictably.
 function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   const itemRefs = useRef([]);
+  const collapseTimer = useRef(null);
+  const [expanded, setExpanded] = useState(false);
 
   const activeIndex = SORT_OPTIONS.findIndex((o) => o.id === activeSort);
   const safeIndex = activeIndex >= 0 ? activeIndex : 0;
@@ -26,9 +36,18 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
     });
   }, [safeIndex]);
 
+  useEffect(() => () => clearTimeout(collapseTimer.current), []);
+
+  const scheduleCollapse = useCallback(() => {
+    clearTimeout(collapseTimer.current);
+    collapseTimer.current = setTimeout(() => setExpanded(false), COLLAPSE_DELAY_MS);
+  }, []);
+
   const handleSelect = useCallback(
     (id) => {
       if (id !== activeSort) onSortChange?.(id);
+      clearTimeout(collapseTimer.current);
+      setExpanded(false);
     },
     [activeSort, onSortChange]
   );
@@ -45,25 +64,66 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
     [safeIndex, handleSelect]
   );
 
+  // A real swipe moves the container's native scroll position; we just
+  // react to that signal instead of tracking touch points ourselves.
+  const handleScroll = useCallback(() => {
+    setExpanded(true);
+    scheduleCollapse();
+  }, [scheduleCollapse]);
+
+  // Lets mouse, keyboard and screen-reader users reach the other pills
+  // without needing a swipe gesture.
+  const handleActivePillTap = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev;
+      if (next) scheduleCollapse();
+      else clearTimeout(collapseTimer.current);
+      return next;
+    });
+  }, [scheduleCollapse]);
+
+  const handleFocus = useCallback(() => {
+    clearTimeout(collapseTimer.current);
+    setExpanded(true);
+  }, []);
+
+  const handleBlur = useCallback(
+    (e) => {
+      if (e.currentTarget.contains(e.relatedTarget)) return;
+      scheduleCollapse();
+    },
+    [scheduleCollapse]
+  );
+
   return (
-    <div className="sort-carousel" role="tablist" aria-label="Sortierung">
-      {SORT_OPTIONS.map((option, idx) => (
-        <button
-          key={option.id}
-          ref={(el) => {
-            itemRefs.current[idx] = el;
-          }}
-          type="button"
-          role="tab"
-          aria-selected={idx === safeIndex}
-          tabIndex={idx === safeIndex ? 0 : -1}
-          className={`sort-carousel-item${idx === safeIndex ? ' sort-carousel-item--active' : ''}`}
-          onClick={() => handleSelect(option.id)}
-          onKeyDown={onKeyDown}
-        >
-          {option.label}
-        </button>
-      ))}
+    <div
+      className={`sort-carousel${expanded ? ' sort-carousel--expanded' : ''}`}
+      role="tablist"
+      aria-label="Sortierung"
+      onScroll={handleScroll}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
+      {SORT_OPTIONS.map((option, idx) => {
+        const isActive = idx === safeIndex;
+        return (
+          <button
+            key={option.id}
+            ref={(el) => {
+              itemRefs.current[idx] = el;
+            }}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={`sort-carousel-item${isActive ? ' sort-carousel-item--active' : ''}`}
+            onClick={() => (isActive ? handleActivePillTap() : handleSelect(option.id))}
+            onKeyDown={onKeyDown}
+          >
+            {option.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/SortCarousel.test.js
+++ b/src/components/SortCarousel.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import SortCarousel, { SORT_OPTIONS } from './SortCarousel';
 
 // JSDOM does not implement scrollIntoView — provide a no-op mock.
@@ -75,5 +75,70 @@ describe('SortCarousel', () => {
   test('has an accessible tablist role', () => {
     render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
     expect(screen.getByRole('tablist', { name: 'Sortierung' })).toBeInTheDocument();
+  });
+
+  describe('expand/collapse', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('starts collapsed, showing only the active pill', () => {
+      render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
+      expect(screen.getByRole('tablist')).not.toHaveClass('sort-carousel--expanded');
+    });
+
+    test('a native scroll event (the swipe gesture) expands the carousel', () => {
+      render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
+      fireEvent.scroll(screen.getByRole('tablist'));
+      expect(screen.getByRole('tablist')).toHaveClass('sort-carousel--expanded');
+    });
+
+    test('tapping the active pill toggles the expanded state without selecting', () => {
+      const handleChange = jest.fn();
+      render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
+      const activeTab = screen.getByRole('tab', { name: 'Alphabetisch' });
+
+      fireEvent.click(activeTab);
+      expect(screen.getByRole('tablist')).toHaveClass('sort-carousel--expanded');
+
+      fireEvent.click(activeTab);
+      expect(screen.getByRole('tablist')).not.toHaveClass('sort-carousel--expanded');
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    test('focusing the carousel expands it; blurring away from it schedules a collapse', () => {
+      render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
+      const tablist = screen.getByRole('tablist');
+      const activeTab = screen.getByRole('tab', { name: 'Alphabetisch' });
+
+      fireEvent.focus(activeTab);
+      expect(tablist).toHaveClass('sort-carousel--expanded');
+
+      // React's onBlur is backed by the (bubbling) native "focusout" event,
+      // not "blur" — fire that directly rather than fireEvent.blur, which
+      // jsdom does not pair with a focusout on its own.
+      fireEvent.focusOut(activeTab, { relatedTarget: null });
+      act(() => {
+        jest.advanceTimersByTime(1200);
+      });
+      expect(tablist).not.toHaveClass('sort-carousel--expanded');
+    });
+
+    test('selecting an option collapses the carousel again', () => {
+      const handleChange = jest.fn();
+      render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
+      const tablist = screen.getByRole('tablist');
+
+      fireEvent.scroll(tablist);
+      expect(tablist).toHaveClass('sort-carousel--expanded');
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Im Trend' }));
+      expect(handleChange).toHaveBeenCalledWith('trending');
+      expect(tablist).not.toHaveClass('sort-carousel--expanded');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Transforms the SortCarousel from a static pill bar into a collapsible component that shows only the active sort option by default and expands to reveal all options when the user interacts with it (swipe, tap, or focus). This replaces custom touch gesture handling with native browser scroll and focus events.

## Key Changes
- **Collapse/expand state management**: Added `expanded` state and `COLLAPSE_DELAY_MS` constant (1200ms) to automatically collapse the carousel after user interaction stops
- **Native scroll-driven expansion**: Replaced custom touch tracking with `handleScroll` callback that expands the carousel when the user swipes
- **Tap-to-toggle active pill**: Active pill now toggles expansion state instead of always selecting; other pills select normally
- **Keyboard/focus accessibility**: Added `handleFocus` and `handleBlur` handlers so keyboard and screen-reader users can access non-active pills without swiping
- **CSS-based visibility**: Inactive pills are hidden via `max-width: 0` and `opacity: 0` in collapsed state rather than being removed from DOM, preserving focus order and ARIA state
- **Smooth transitions**: Extended transition properties to animate the collapse/expand with max-width, opacity, margin, padding, and border-width changes
- **Test coverage**: Added comprehensive test suite covering expand/collapse behavior, swipe gestures, active pill toggling, focus management, and option selection

## Implementation Details
- The carousel uses CSS `scroll-snap-align: center` for native snapping behavior
- Collapse timer is properly cleaned up on component unmount and when user interacts
- Focus blur detection checks if focus moved within the carousel to avoid collapsing during internal navigation
- Inactive pills remain in the DOM and tab order but are pointer-event-disabled when collapsed, maintaining accessibility

https://claude.ai/code/session_01McqvSmznZQE8mvUJYm7LCZ