### PR TITLE
Cap category/cuisine pills at 5 with expandable toggle

### DIFF
--- a/src/components/RecipeFilterSidebar.css
+++ b/src/components/RecipeFilterSidebar.css
@@ -173,14 +173,25 @@
   outline-offset: 2px;
 }
 
+.recipe-filter-sidebar-pill--more {
+  color: #8A7A6B;
+  border-style: dashed;
+}
+
+.recipe-filter-sidebar-search-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
 .recipe-filter-sidebar-reset {
   background: none;
   border: none;
   color: #DF7A00;
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   font-weight: 600;
   cursor: pointer;
-  padding: 0.4rem 0;
+  padding: 0;
   text-align: left;
   text-decoration: underline;
 }

--- a/src/components/RecipeFilterSidebar.js
+++ b/src/components/RecipeFilterSidebar.js
@@ -3,6 +3,7 @@ import { canEditRecipes } from '../utils/userManagement';
 import './RecipeFilterSidebar.css';
 
 const COLLAPSED_STORAGE_KEY = 'recipeFilterSidebar_collapsed';
+const MAX_VISIBLE_PILLS = 5;
 
 function getStoredCollapsed() {
   try {
@@ -47,6 +48,8 @@ function RecipeFilterSidebar({
   activePrivateListId = null,
 }) {
   const [collapsed, setCollapsed] = useState(getStoredCollapsed);
+  const [showAllCategories, setShowAllCategories] = useState(false);
+  const [showAllCuisines, setShowAllCuisines] = useState(false);
   const userCanEdit = canEditRecipes(currentUser);
 
   const handleAddClick = () => {
@@ -70,7 +73,9 @@ function RecipeFilterSidebar({
   };
 
   // Only offer categories/cuisines that actually match at least one recipe,
-  // same rule MobileSearchOverlay applies for its pills.
+  // same rule MobileSearchOverlay applies for its pills. Sorted by recipe
+  // count (most recipes first) so the top-5 cap below keeps the most useful
+  // pills visible.
   const availableCategories = useMemo(() => {
     if (!mealCategories || mealCategories.length === 0) return [];
     const counts = {};
@@ -80,7 +85,9 @@ function RecipeFilterSidebar({
         : (recipe.speisekategorie ? [recipe.speisekategorie] : []);
       speisekategorie.forEach((c) => { counts[c] = (counts[c] || 0) + 1; });
     });
-    return mealCategories.filter((category) => counts[category] > 0);
+    return mealCategories
+      .filter((category) => counts[category] > 0)
+      .sort((a, b) => counts[b] - counts[a]);
   }, [recipes, mealCategories]);
 
   const cuisinePills = useMemo(() => {
@@ -91,22 +98,25 @@ function RecipeFilterSidebar({
       kulinarik.forEach((k) => { counts[k] = (counts[k] || 0) + 1; });
     });
     const availableTypes = new Set(cuisineTypes.filter((type) => counts[type] > 0));
-    const result = [];
-    const seen = new Set();
+    // A group pill's count is its own recipes plus every child's, so groups
+    // rank alongside standalone types by total reach rather than always
+    // sorting first.
+    const pillCounts = new Map();
     (cuisineGroups || []).forEach((group) => {
       const hasAvailableChild = (group.children || []).some((child) => availableTypes.has(child));
-      if ((availableTypes.has(group.name) || hasAvailableChild) && !seen.has(group.name)) {
-        result.push(group.name);
-        seen.add(group.name);
+      if ((availableTypes.has(group.name) || hasAvailableChild) && !pillCounts.has(group.name)) {
+        const childCount = (group.children || []).reduce((sum, child) => sum + (counts[child] || 0), 0);
+        pillCounts.set(group.name, (counts[group.name] || 0) + childCount);
       }
     });
     availableTypes.forEach((type) => {
-      if (!seen.has(type)) {
-        result.push(type);
-        seen.add(type);
+      if (!pillCounts.has(type)) {
+        pillCounts.set(type, counts[type] || 0);
       }
     });
-    return result;
+    return Array.from(pillCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([name]) => name);
   }, [recipes, cuisineTypes, cuisineGroups]);
 
   // Narrow the pill lists down to whatever matches the current search term,
@@ -114,15 +124,29 @@ function RecipeFilterSidebar({
   // pills are kept sorted first among the survivors.
   const trimmedSearch = searchTerm?.trim().toLowerCase() || '';
 
+  // While searching, show every match (no cap). Otherwise cap at the top 5
+  // (by recipe count); the rest stay hidden behind a "+" toggle.
   const visibleCategories = useMemo(() => {
-    if (!trimmedSearch) return availableCategories;
-    return availableCategories.filter((name) => name.toLowerCase().includes(trimmedSearch));
-  }, [availableCategories, trimmedSearch]);
+    if (trimmedSearch) {
+      return availableCategories.filter((name) => name.toLowerCase().includes(trimmedSearch));
+    }
+    return showAllCategories ? availableCategories : availableCategories.slice(0, MAX_VISIBLE_PILLS);
+  }, [availableCategories, trimmedSearch, showAllCategories]);
+
+  const hiddenCategoriesCount = trimmedSearch || showAllCategories
+    ? 0
+    : Math.max(0, availableCategories.length - MAX_VISIBLE_PILLS);
 
   const visibleCuisinePills = useMemo(() => {
-    if (!trimmedSearch) return cuisinePills;
-    return cuisinePills.filter((name) => name.toLowerCase().includes(trimmedSearch));
-  }, [cuisinePills, trimmedSearch]);
+    if (trimmedSearch) {
+      return cuisinePills.filter((name) => name.toLowerCase().includes(trimmedSearch));
+    }
+    return showAllCuisines ? cuisinePills : cuisinePills.slice(0, MAX_VISIBLE_PILLS);
+  }, [cuisinePills, trimmedSearch, showAllCuisines]);
+
+  const hiddenCuisinesCount = trimmedSearch || showAllCuisines
+    ? 0
+    : Math.max(0, cuisinePills.length - MAX_VISIBLE_PILLS);
 
   const visibleAuthors = useMemo(() => {
     if (!trimmedSearch) return availableAuthors;
@@ -198,21 +222,33 @@ function RecipeFilterSidebar({
 
       {!collapsed && (
         <>
-          <div className="recipe-filter-sidebar-search">
-            <span className="recipe-filter-sidebar-search-icon" aria-hidden="true">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="11" cy="11" r="8" />
-                <line x1="21" y1="21" x2="16.65" y2="16.65" />
-              </svg>
-            </span>
-            <input
-              type="search"
-              className="recipe-filter-sidebar-search-input"
-              placeholder="Rezepte durchsuchen …"
-              value={searchTerm}
-              onChange={(e) => onSearchChange?.(e.target.value)}
-              aria-label="Rezepte durchsuchen"
-            />
+          <div className="recipe-filter-sidebar-search-group">
+            <div className="recipe-filter-sidebar-search">
+              <span className="recipe-filter-sidebar-search-icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="11" cy="11" r="8" />
+                  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                </svg>
+              </span>
+              <input
+                type="search"
+                className="recipe-filter-sidebar-search-input"
+                placeholder="Rezepte durchsuchen …"
+                value={searchTerm}
+                onChange={(e) => onSearchChange?.(e.target.value)}
+                aria-label="Rezepte durchsuchen"
+              />
+            </div>
+
+            {hasActiveFilters && (
+              <button
+                type="button"
+                className="recipe-filter-sidebar-reset"
+                onClick={onClearAllFilters}
+              >
+                Filter zurücksetzen
+              </button>
+            )}
           </div>
 
           <div className="recipe-filter-sidebar-section recipe-filter-sidebar-row">
@@ -249,6 +285,28 @@ function RecipeFilterSidebar({
                     {name}
                   </button>
                 ))}
+                {hiddenCategoriesCount > 0 && (
+                  <button
+                    type="button"
+                    className="recipe-filter-sidebar-pill recipe-filter-sidebar-pill--more"
+                    onClick={() => setShowAllCategories(true)}
+                    aria-label={`${hiddenCategoriesCount} weitere Kategorien anzeigen`}
+                    title="Weitere Kategorien anzeigen"
+                  >
+                    +{hiddenCategoriesCount}
+                  </button>
+                )}
+                {!trimmedSearch && showAllCategories && availableCategories.length > MAX_VISIBLE_PILLS && (
+                  <button
+                    type="button"
+                    className="recipe-filter-sidebar-pill recipe-filter-sidebar-pill--more"
+                    onClick={() => setShowAllCategories(false)}
+                    aria-label="Weniger Kategorien anzeigen"
+                    title="Weniger Kategorien anzeigen"
+                  >
+                    −
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -268,6 +326,28 @@ function RecipeFilterSidebar({
                     {name}
                   </button>
                 ))}
+                {hiddenCuisinesCount > 0 && (
+                  <button
+                    type="button"
+                    className="recipe-filter-sidebar-pill recipe-filter-sidebar-pill--more"
+                    onClick={() => setShowAllCuisines(true)}
+                    aria-label={`${hiddenCuisinesCount} weitere Kulinariktypen anzeigen`}
+                    title="Weitere Kulinariktypen anzeigen"
+                  >
+                    +{hiddenCuisinesCount}
+                  </button>
+                )}
+                {!trimmedSearch && showAllCuisines && cuisinePills.length > MAX_VISIBLE_PILLS && (
+                  <button
+                    type="button"
+                    className="recipe-filter-sidebar-pill recipe-filter-sidebar-pill--more"
+                    onClick={() => setShowAllCuisines(false)}
+                    aria-label="Weniger Kulinariktypen anzeigen"
+                    title="Weniger Kulinariktypen anzeigen"
+                  >
+                    −
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -308,16 +388,6 @@ function RecipeFilterSidebar({
                 ))}
               </div>
             </div>
-          )}
-
-          {hasActiveFilters && (
-            <button
-              type="button"
-              className="recipe-filter-sidebar-reset"
-              onClick={onClearAllFilters}
-            >
-              Filter zurücksetzen
-            </button>
           )}
         </>
       )}

--- a/src/components/RecipeFilterSidebar.test.js
+++ b/src/components/RecipeFilterSidebar.test.js
@@ -113,3 +113,61 @@ describe('RecipeFilterSidebar', () => {
     expect(onSearchChange).toHaveBeenCalledWith('Sushi');
   });
 });
+
+describe('RecipeFilterSidebar top-5 category/cuisine cap', () => {
+  const manyRecipes = [
+    { id: '1', title: 'A', kulinarik: ['Küche 1'], speisekategorie: ['Kategorie 1'] },
+    { id: '2', title: 'B', kulinarik: ['Küche 1'], speisekategorie: ['Kategorie 1'] },
+    { id: '3', title: 'C', kulinarik: ['Küche 2'], speisekategorie: ['Kategorie 2'] },
+    { id: '4', title: 'D', kulinarik: ['Küche 3'], speisekategorie: ['Kategorie 3'] },
+    { id: '5', title: 'E', kulinarik: ['Küche 4'], speisekategorie: ['Kategorie 4'] },
+    { id: '6', title: 'F', kulinarik: ['Küche 5'], speisekategorie: ['Kategorie 5'] },
+    { id: '7', title: 'G', kulinarik: ['Küche 6'], speisekategorie: ['Kategorie 6'] },
+  ];
+  const manyCategories = ['Kategorie 1', 'Kategorie 2', 'Kategorie 3', 'Kategorie 4', 'Kategorie 5', 'Kategorie 6'];
+  const manyCuisines = ['Küche 1', 'Küche 2', 'Küche 3', 'Küche 4', 'Küche 5', 'Küche 6'];
+
+  function renderManySidebar(props = {}) {
+    return render(
+      <RecipeFilterSidebar
+        recipes={manyRecipes}
+        mealCategories={manyCategories}
+        cuisineTypes={manyCuisines}
+        {...props}
+      />
+    );
+  }
+
+  test('shows only the top 5 categories and cuisines by recipe count, most-used first', () => {
+    renderManySidebar();
+    expect(screen.getByText('Kategorie 1')).toBeInTheDocument();
+    expect(screen.getByText('Kategorie 5')).toBeInTheDocument();
+    expect(screen.queryByText('Kategorie 6')).not.toBeInTheDocument();
+    expect(screen.getByText('Küche 1')).toBeInTheDocument();
+    expect(screen.getByText('Küche 5')).toBeInTheDocument();
+    expect(screen.queryByText('Küche 6')).not.toBeInTheDocument();
+  });
+
+  test('expands to show all categories via the "+" pill, then collapses again via "-"', () => {
+    renderManySidebar();
+    fireEvent.click(screen.getByRole('button', { name: /weitere Kategorien anzeigen/i }));
+    expect(screen.getByText('Kategorie 6')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Weniger Kategorien anzeigen/i }));
+    expect(screen.queryByText('Kategorie 6')).not.toBeInTheDocument();
+  });
+
+  test('expands to show all cuisines via the "+" pill, then collapses again via "-"', () => {
+    renderManySidebar();
+    fireEvent.click(screen.getByRole('button', { name: /weitere Kulinariktypen anzeigen/i }));
+    expect(screen.getByText('Küche 6')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Weniger Kulinariktypen anzeigen/i }));
+    expect(screen.queryByText('Küche 6')).not.toBeInTheDocument();
+  });
+
+  test('does not cap results while a search term is active', () => {
+    renderManySidebar({ searchTerm: 'Kategorie' });
+    expect(screen.getByText('Kategorie 6')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
This PR improves the recipe filter sidebar by limiting the display of category and cuisine pills to the top 5 most-used options, with an expandable toggle to show all available filters. This reduces visual clutter while keeping the most relevant filters immediately visible.

## Key Changes
- **Pill limiting**: Categories and cuisines are now capped at 5 visible pills (by recipe count) with a "+N" button to expand and show the rest
- **Smart sorting**: Both category and cuisine pills are now sorted by recipe count (most recipes first) so the top 5 cap keeps the most useful filters visible
- **Improved cuisine ranking**: Cuisine group pills now count their child recipes in their total, so groups rank alongside standalone types by total reach rather than always appearing first
- **Search behavior**: When a search term is active, all matching pills are shown (no cap), allowing users to find less common filters
- **UI reorganization**: Moved the "Filter zurücksetzen" button next to the search input for better visual hierarchy
- **Styling updates**: Added dashed border styling for the "+N" and "−" toggle pills to distinguish them from regular filter pills

## Implementation Details
- Added `MAX_VISIBLE_PILLS` constant set to 5
- Added state for `showAllCategories` and `showAllCuisines` to track expansion state
- Refactored cuisine pill calculation to use a `Map` for tracking counts, enabling proper sorting by total recipe reach
- Added `hiddenCategoriesCount` and `hiddenCuisinesCount` computed values to determine when to show toggle buttons
- Toggle buttons only appear when there are hidden items and no search term is active
- Comprehensive test coverage for the new capping and expansion behavior

https://claude.ai/code/session_01QfqqVdA3LMLhSKz91D5KDa