### PR TITLE
Add minimum height to events page header

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -10,6 +10,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 20px;
+  min-height: 3rem;
 }
 
 .events-page-header h2 {


### PR DESCRIPTION
## Summary
Added a minimum height constraint to the events page header container to ensure consistent spacing and prevent layout collapse.

## Key Changes
- Added `min-height: 3rem;` to `.events-page-header` CSS class to establish a minimum vertical space for the header container

## Implementation Details
This change ensures the header maintains a minimum height of 3rem (approximately 48px) regardless of content, which helps maintain consistent layout spacing and prevents the header from collapsing when content is minimal or dynamically loaded.

https://claude.ai/code/session_01DUcTLH6WBiNNBYdp19Q6yj