### PR TITLE
Fix SortCarousel re-expanding when collapse triggers scroll event

### DIFF
--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -14,6 +14,15 @@ export const SORT_OPTIONS = [
 // collapses back down to just the active pill.
 const COLLAPSE_DELAY_MS = 1200;
 
+// Collapsing shrinks the inactive pills' max-width to 0 (see
+// SortCarousel.css), which can shrink the scroll container's content
+// enough that the browser adjusts scrollLeft to keep it in range. That
+// adjustment fires its own native "scroll" event, which would otherwise
+// be mistaken for a user swipe and re-expand the carousel mid-collapse.
+// Scroll events are ignored for this long after any collapse we trigger
+// ourselves.
+const IGNORE_SCROLL_MS = 400;
+
 // Tap-to-select pill bar with native horizontal scrolling/snapping. Only
 // the active pill is shown until the user swipes (or taps/focuses it),
 // which reveals the rest. Expansion is driven purely by the browser's own
@@ -23,10 +32,20 @@ const COLLAPSE_DELAY_MS = 1200;
 function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   const itemRefs = useRef([]);
   const collapseTimer = useRef(null);
+  const ignoreScrollTimer = useRef(null);
+  const ignoreScroll = useRef(false);
   const [expanded, setExpanded] = useState(false);
 
   const activeIndex = SORT_OPTIONS.findIndex((o) => o.id === activeSort);
   const safeIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  const suppressScroll = useCallback(() => {
+    ignoreScroll.current = true;
+    clearTimeout(ignoreScrollTimer.current);
+    ignoreScrollTimer.current = setTimeout(() => {
+      ignoreScroll.current = false;
+    }, IGNORE_SCROLL_MS);
+  }, []);
 
   useEffect(() => {
     itemRefs.current[safeIndex]?.scrollIntoView?.({
@@ -36,20 +55,34 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
     });
   }, [safeIndex]);
 
-  useEffect(() => () => clearTimeout(collapseTimer.current), []);
+  useEffect(
+    () => () => {
+      clearTimeout(collapseTimer.current);
+      clearTimeout(ignoreScrollTimer.current);
+    },
+    []
+  );
+
+  // Collapsing itself can trigger a spurious scroll event (see
+  // IGNORE_SCROLL_MS above), so every path that collapses the carousel
+  // goes through here rather than calling setExpanded(false) directly.
+  const collapseNow = useCallback(() => {
+    suppressScroll();
+    setExpanded(false);
+  }, [suppressScroll]);
 
   const scheduleCollapse = useCallback(() => {
     clearTimeout(collapseTimer.current);
-    collapseTimer.current = setTimeout(() => setExpanded(false), COLLAPSE_DELAY_MS);
-  }, []);
+    collapseTimer.current = setTimeout(collapseNow, COLLAPSE_DELAY_MS);
+  }, [collapseNow]);
 
   const handleSelect = useCallback(
     (id) => {
       if (id !== activeSort) onSortChange?.(id);
       clearTimeout(collapseTimer.current);
-      setExpanded(false);
+      collapseNow();
     },
-    [activeSort, onSortChange]
+    [activeSort, onSortChange, collapseNow]
   );
 
   const onKeyDown = useCallback(
@@ -65,8 +98,11 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   );
 
   // A real swipe moves the container's native scroll position; we just
-  // react to that signal instead of tracking touch points ourselves.
+  // react to that signal instead of tracking touch points ourselves. Scroll
+  // events caused by our own collapse animation are filtered out via
+  // ignoreScroll, so they don't get mistaken for a swipe and re-expand.
   const handleScroll = useCallback(() => {
+    if (ignoreScroll.current) return;
     setExpanded(true);
     scheduleCollapse();
   }, [scheduleCollapse]);
@@ -74,13 +110,14 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   // Lets mouse, keyboard and screen-reader users reach the other pills
   // without needing a swipe gesture.
   const handleActivePillTap = useCallback(() => {
-    setExpanded((prev) => {
-      const next = !prev;
-      if (next) scheduleCollapse();
-      else clearTimeout(collapseTimer.current);
-      return next;
-    });
-  }, [scheduleCollapse]);
+    if (expanded) {
+      clearTimeout(collapseTimer.current);
+      collapseNow();
+    } else {
+      setExpanded(true);
+      scheduleCollapse();
+    }
+  }, [expanded, collapseNow, scheduleCollapse]);
 
   const handleFocus = useCallback(() => {
     clearTimeout(collapseTimer.current);

--- a/src/components/SortCarousel.test.js
+++ b/src/components/SortCarousel.test.js
@@ -140,5 +140,31 @@ describe('SortCarousel', () => {
       expect(handleChange).toHaveBeenCalledWith('trending');
       expect(tablist).not.toHaveClass('sort-carousel--expanded');
     });
+
+    test('a scroll event fired right after collapsing (the layout-shift side effect of the pills shrinking) does not re-expand the carousel', () => {
+      const handleChange = jest.fn();
+      render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
+      const tablist = screen.getByRole('tablist');
+
+      fireEvent.scroll(tablist);
+      expect(tablist).toHaveClass('sort-carousel--expanded');
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Nach Relevanz' }));
+      expect(tablist).not.toHaveClass('sort-carousel--expanded');
+
+      // The collapse CSS transition shrinking the other pills can itself
+      // trigger a native scroll event as the container's scrollLeft is
+      // clamped to the new (smaller) scrollWidth. That should be ignored,
+      // not mistaken for a user swipe.
+      fireEvent.scroll(tablist);
+      expect(tablist).not.toHaveClass('sort-carousel--expanded');
+
+      // Once the ignore window has passed, real swipes work again.
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      fireEvent.scroll(tablist);
+      expect(tablist).toHaveClass('sort-carousel--expanded');
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixed a bug in the SortCarousel component where the carousel would unexpectedly re-expand immediately after collapsing due to a native scroll event fired as a side effect of the CSS collapse animation.

## Problem
When the carousel collapses, the inactive pills' max-width shrinks to 0, which reduces the scroll container's content width. The browser automatically adjusts `scrollLeft` to keep it in valid range, firing a native "scroll" event in the process. This scroll event was being mistaken for a user swipe gesture, causing the carousel to re-expand mid-collapse.

## Solution
Implemented a scroll event suppression mechanism that:
- Tracks when we trigger a collapse ourselves via a new `suppressScroll()` function
- Ignores scroll events for 400ms after any collapse we initiate (defined by `IGNORE_SCROLL_MS`)
- Uses `ignoreScroll` ref to filter out these spurious scroll events in the `handleScroll` handler
- Ensures all collapse paths go through the new `collapseNow()` function to properly suppress scroll events

## Key Changes
- Added `IGNORE_SCROLL_MS` constant (400ms window to ignore scroll events)
- Added `ignoreScrollTimer` and `ignoreScroll` refs to track suppression state
- Created `suppressScroll()` callback to manage the ignore window
- Created `collapseNow()` callback to centralize collapse logic with scroll suppression
- Updated `handleScroll()` to check `ignoreScroll.current` before expanding
- Refactored `handleActivePillTap()` to use explicit state logic instead of setState updater
- Updated cleanup effect to clear both timers
- Added comprehensive test case verifying the fix works correctly

## Implementation Details
The solution uses a time-based suppression window rather than event-based filtering because the spurious scroll event can fire asynchronously during the CSS transition. The 400ms window is long enough to cover the collapse animation while being short enough that legitimate user interactions aren't affected.

https://claude.ai/code/session_015x5gM7JX4umBmvFoiDfXL1