### PR TITLE
Refactor GroupDetail layout: separate toolbar from header actions

### DIFF
--- a/src/components/GroupDetail.css
+++ b/src/components/GroupDetail.css
@@ -112,6 +112,23 @@
   justify-content: flex-end;
 }
 
+/* Filter/sort/add controls for the recipe tab, kept on their own row below
+   the title so the shopping-list/settings/close buttons in
+   .group-header-actions always stay next to the heading (matching the
+   layout of the Einstellungen tab, which has no toolbar row). */
+.group-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.group-toolbar-row:empty {
+  display: none;
+  margin-bottom: 0;
+}
+
 .group-header-actions .shopping-list-trigger-button {
   background: transparent;
   border: none;

--- a/src/components/GroupDetail.js
+++ b/src/components/GroupDetail.js
@@ -501,49 +501,6 @@ function GroupDetail({
           )}
         </div>
         <div className="group-header-actions">
-          {!isPublic && activeTab === TAB_RECIPES && (
-            <button
-              className={`filter-button ${hasActiveFilters ? 'has-active-filters' : ''} ${filterPressed ? 'pressed' : ''}`}
-              onTouchStart={handleFilterTouchStart}
-              onTouchEnd={handleFilterTouchEnd}
-              onTouchCancel={handleFilterTouchCancel}
-              onClick={handleFilterClick}
-              onMouseDown={() => setFilterPressed(true)}
-              onMouseUp={() => setFilterPressed(false)}
-              onMouseLeave={() => setFilterPressed(false)}
-              title="Weitere Filter"
-              aria-label="Weitere Filter"
-            >
-              {isBase64Image(filterIcon) ? (
-                <img src={filterIcon} alt={hasActiveFilters ? 'Filter aktiv' : 'Filter'} className="button-icon-image" draggable="false" />
-              ) : (
-                filterIcon
-              )}
-            </button>
-          )}
-          {!isPublic && activeTab === TAB_RECIPES && currentUser?.sortCarousel && (
-            <SortCarousel activeSort={activeSort} onSortChange={setActiveSort} />
-          )}
-          {onAddRecipe && (isOwner || isMember) && !showPortionSelector && !showShoppingListModal && (isPublic || activeTab === TAB_RECIPES) && (
-            <button
-              className={`add-icon-button ${addPressed ? 'pressed' : ''}`}
-              onClick={() => onAddRecipe(group.id)}
-              onTouchStart={() => setAddPressed(true)}
-              onTouchEnd={() => setAddPressed(false)}
-              onTouchCancel={() => setAddPressed(false)}
-              onMouseDown={() => setAddPressed(true)}
-              onMouseUp={() => setAddPressed(false)}
-              onMouseLeave={() => setAddPressed(false)}
-              title={addRecipeLabel}
-              aria-label={addRecipeLabel}
-            >
-              {isBase64Image(addRecipeIcon) ? (
-                <img src={addRecipeIcon} alt={addRecipeLabel} className="button-icon-image" draggable="false" />
-              ) : (
-                addRecipeIcon
-              )}
-            </button>
-          )}
           {groupRecipes.length > 0 && (
             <button
               className="shopping-list-trigger-button"
@@ -581,6 +538,54 @@ function GroupDetail({
           </button>
         </div>
       </div>
+
+      {activeTab === TAB_RECIPES && (
+        <div className="group-toolbar-row">
+          {!isPublic && (
+            <button
+              className={`filter-button ${hasActiveFilters ? 'has-active-filters' : ''} ${filterPressed ? 'pressed' : ''}`}
+              onTouchStart={handleFilterTouchStart}
+              onTouchEnd={handleFilterTouchEnd}
+              onTouchCancel={handleFilterTouchCancel}
+              onClick={handleFilterClick}
+              onMouseDown={() => setFilterPressed(true)}
+              onMouseUp={() => setFilterPressed(false)}
+              onMouseLeave={() => setFilterPressed(false)}
+              title="Weitere Filter"
+              aria-label="Weitere Filter"
+            >
+              {isBase64Image(filterIcon) ? (
+                <img src={filterIcon} alt={hasActiveFilters ? 'Filter aktiv' : 'Filter'} className="button-icon-image" draggable="false" />
+              ) : (
+                filterIcon
+              )}
+            </button>
+          )}
+          {!isPublic && currentUser?.sortCarousel && (
+            <SortCarousel activeSort={activeSort} onSortChange={setActiveSort} />
+          )}
+          {onAddRecipe && (isOwner || isMember) && !showPortionSelector && !showShoppingListModal && (
+            <button
+              className={`add-icon-button ${addPressed ? 'pressed' : ''}`}
+              onClick={() => onAddRecipe(group.id)}
+              onTouchStart={() => setAddPressed(true)}
+              onTouchEnd={() => setAddPressed(false)}
+              onTouchCancel={() => setAddPressed(false)}
+              onMouseDown={() => setAddPressed(true)}
+              onMouseUp={() => setAddPressed(false)}
+              onMouseLeave={() => setAddPressed(false)}
+              title={addRecipeLabel}
+              aria-label={addRecipeLabel}
+            >
+              {isBase64Image(addRecipeIcon) ? (
+                <img src={addRecipeIcon} alt={addRecipeLabel} className="button-icon-image" draggable="false" />
+              ) : (
+                addRecipeIcon
+              )}
+            </button>
+          )}
+        </div>
+      )}
 
       {(isPublic || activeTab === TAB_RECIPES) && (
         <div className="group-detail-section group-recipes-section">


### PR DESCRIPTION
## Summary
Restructured the GroupDetail component's header layout to separate recipe tab controls (filter, sort, add) into their own toolbar row, while keeping navigation buttons (shopping list, settings, close) in the main header. This improves layout consistency across different tabs and prevents button repositioning when switching views.

## Key Changes
- **Moved toolbar controls to dedicated row**: Filter, sort carousel, and add recipe buttons now render in a new `.group-toolbar-row` that only displays when viewing the recipes tab
- **Consolidated header actions**: Shopping list, settings, and close buttons now always remain in `.group-header-actions` regardless of active tab
- **Simplified conditional logic**: Removed redundant `activeTab === TAB_RECIPES` checks from individual button conditions since the entire toolbar row is now tab-aware
- **Added CSS styling**: New `.group-toolbar-row` class with flexbox layout and empty state handling to prevent unnecessary spacing

## Implementation Details
- The toolbar row is conditionally rendered only when `activeTab === TAB_RECIPES`, keeping the header clean on other tabs
- The `.group-toolbar-row:empty` selector hides the row and removes margin when no buttons are present
- Button visibility logic within the toolbar remains unchanged (e.g., filter button still respects `!isPublic` condition)
- Layout now matches the settings tab structure, which has no toolbar row

https://claude.ai/code/session_011tLtSUgVa6XcZm9YSXJTH6