### PR TITLE
Consolidate close button icon configuration

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -1641,7 +1641,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   recipes={recipes}
                   favoriteIds={favoriteIds}
                   searchQueries={searchQueries}
-                  closeIcon={getEffectiveIcon(buttonIcons, 'menuCloseButton', isDarkMode)}
+                  closeIcon={getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode)}
                   onRemoveSection={handleRemoveSection}
                   onDragEndRecipes={handleDragEndRecipes}
                   onRemoveRecipeFromSection={handleRemoveRecipeFromSection}

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -167,7 +167,6 @@ const DARK_MODE_ICON_ROWS = [
   { key: 'closeButton', label: 'Schließen-Button' },
   { key: 'closeButtonAlt', label: 'Schließen-Alt (helles Bild oben rechts)' },
   { key: 'closeButtonDefaultImg', label: 'Schließen-Button (Allgemein)' },
-  { key: 'menuCloseButton', label: 'Menü-Schließen-Button' },
   { key: 'filterButton', label: 'Filter-Button' },
   { key: 'filterButtonActive', label: 'Filter-Button (aktiv)' },
   { key: 'copyLink', label: 'Link kopieren' },

--- a/src/utils/customLists.js
+++ b/src/utils/customLists.js
@@ -696,7 +696,6 @@ export const DEFAULT_BUTTON_ICONS = {
   closeButtonAlt: '×',
   // Icon shown when the recipe uses the default category image (light mode)
   closeButtonDefaultImg: '×',
-  menuCloseButton: '×',
   filterButton: '⚙',
   filterButtonActive: '▼',
   copyLink: 'Link',
@@ -774,7 +773,6 @@ export const DEFAULT_BUTTON_ICONS = {
   closeButtonAltDark: '',
   // Dark mode variant for the default category image icon
   closeButtonDefaultImgDark: '',
-  menuCloseButtonDark: '',
   filterButtonDark: '',
   filterButtonActiveDark: '',
   copyLinkDark: '',


### PR DESCRIPTION
## Summary
This PR consolidates the close button icon configuration by removing the redundant `menuCloseButton` and `menuCloseButtonDark` icon keys and updating the MenuForm component to use the existing `closeButtonDefaultImg` icon instead.

## Key Changes
- Removed `menuCloseButton` and `menuCloseButtonDark` from `DEFAULT_BUTTON_ICONS` in `customLists.js`
- Updated MenuForm component to use `closeButtonDefaultImg` as the primary close icon, with fallback to `closeButton`
- Removed the corresponding settings UI row for `menuCloseButton` from Settings.js

## Implementation Details
The MenuForm's close icon now uses a fallback pattern: `getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode)`. This eliminates the need for a separate menu-specific close button icon while maintaining the same visual behavior through the existing icon hierarchy.

https://claude.ai/code/session_01Y2ox1EoJEyVWF8b9AR67x4