### PR TITLE
Fix form layout overlap on narrow viewports and Safari font scaling

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -737,19 +737,21 @@
 /* Menu photo upload styles */
 .menu-date-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: 0.75rem;
 }
 
 .menu-date-row .menu-date-field {
   flex: 1;
-  min-width: 0;
+  min-width: 150px;
 }
 
 .menu-date-row .menu-date-field input[type="date"] {
   height: 48px;
   padding-top: 0;
   padding-bottom: 0;
+  min-width: 0;
 }
 
 .menu-photo-upload-wrap {

--- a/src/components/MenuForm.css.test.js
+++ b/src/components/MenuForm.css.test.js
@@ -26,4 +26,17 @@ describe('MenuForm CSS mobile drag-handle layout', () => {
 
     expect(containerRule).toContain('padding: calc(1rem + env(safe-area-inset-top, 0px)) 1rem 1rem;');
   });
+
+  test('lets the photo button wrap below the date field instead of overlapping it', () => {
+    const rowRule = getRuleBody(css, '.menu-date-row');
+    const fieldRule = getRuleBody(css, '.menu-date-row .menu-date-field');
+    const dateInputRule = getRuleBody(css, '.menu-date-row .menu-date-field input[type="date"]');
+
+    // Without a wrap fallback, the fixed-width photo button and the date
+    // input can be squeezed into overlapping each other when the row is too
+    // narrow to fit both (e.g. iPhone landscape).
+    expect(rowRule).toContain('flex-wrap: wrap;');
+    expect(fieldRule).toContain('min-width: 150px;');
+    expect(dateInputRule).toContain('min-width: 0;');
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
   box-sizing: border-box;
 }
 
+html {
+  /* Prevent Safari from auto-boosting font sizes (most noticeable after an
+     orientation change on iPhone), which drifts form elements out of their
+     flex layout and causes them to visually overlap. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 button {
   -webkit-user-select: none;
   -moz-user-select: none;


### PR DESCRIPTION
## Summary
This PR fixes layout issues that cause form elements to overlap on narrow viewports (particularly iPhone landscape) and prevents Safari from auto-adjusting font sizes, which can break flex layouts.

## Key Changes
- **MenuForm.css**: Updated `.menu-date-row` flex layout to allow wrapping and adjusted min-width constraints
  - Added `flex-wrap: wrap` to `.menu-date-row` so the photo button wraps below the date field instead of overlapping
  - Changed `.menu-date-field` min-width from `0` to `150px` to ensure the date field maintains a reasonable minimum width
  - Added `min-width: 0` to the date input itself to allow it to shrink within its flex container when needed

- **index.css**: Added `-webkit-text-size-adjust: 100%` and `text-size-adjust: 100%` to the `html` element
  - Prevents Safari from auto-boosting font sizes after orientation changes, which was causing form elements to drift out of their flex layout

- **MenuForm.css.test.js**: Added test coverage for the new layout behavior
  - Verifies that the date row supports flex wrapping
  - Confirms min-width constraints are properly set to prevent overlap

## Implementation Details
The fix addresses a common mobile UX issue where narrow viewports (especially landscape orientation) can cause flex items to squeeze and overlap. By enabling flex-wrap and setting appropriate min-width values, the layout now gracefully wraps elements to new lines. The Safari font-size adjustment fix prevents a secondary issue where Safari's automatic font scaling could undo the flex layout constraints.

https://claude.ai/code/session_01XiUDvRAusaJXqm5uN4Vr94