### PR TITLE
Fix desktop homepage reload loop (service worker scope collision)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,19 @@ root.render(
   </React.StrictMode>
 );
 
+// Guard against triggering more than one reload: onUpdate can fire again
+// before the pending reload has happened, and controllerchange can also
+// fire for unrelated service worker registrations (e.g. Firebase Messaging).
+let refreshingAfterSwUpdate = false;
+navigator.serviceWorker?.addEventListener('controllerchange', () => {
+  if (refreshingAfterSwUpdate) return;
+  refreshingAfterSwUpdate = true;
+  window.location.reload();
+});
+
 serviceWorkerRegistration.register({
   onUpdate: (registration) => {
     if (registration && registration.waiting) {
-      // Erst auf controllerchange warten, DANN neu laden
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        window.location.reload();
-      });
-      // Neuen Service Worker aktivieren
       registration.waiting.postMessage({ type: 'SKIP_WAITING' });
     }
   },

--- a/src/utils/pushNotifications.js
+++ b/src/utils/pushNotifications.js
@@ -26,7 +26,7 @@ export const registerMessagingServiceWorker = async () => {
   try {
     const registration = await navigator.serviceWorker.register(
       '/firebase-messaging-sw.js',
-      { scope: '/' }
+      { scope: '/firebase-cloud-messaging-push-scope' }
     );
 
     // Give the service worker time to activate, then send the config


### PR DESCRIPTION
## Summary
- The FCM push-notification service worker (`firebase-messaging-sw.js`) was registered on the same scope (`/`) as the PWA precache service worker (`service-worker.js`). Since the Service Worker spec keys registrations by scope, the browser treated the second registration as an "update" to the first every time a logged-in user opened the app — regardless of whether a real deployment had happened — triggering `SKIP_WAITING` → `controllerchange` → `window.location.reload()` on every open.
- Gave the FCM service worker its own dedicated scope (`/firebase-cloud-messaging-push-scope`) so it no longer collides with `service-worker.js`.
- Added a de-dupe guard around the `controllerchange` reload in `src/index.js` so a legitimate service worker update can only trigger a single reload instead of one per `onUpdate`/`controllerchange` call.

## Test plan
- [x] `npm ci`
- [x] `CI=true npx react-scripts test --watchAll=false --testPathPattern="pushNotifications|Header"` — 37/37 passed
- [ ] Manual verification in a browser that opening the app no longer repeatedly reloads and push notifications still work

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZmEiSTJMVgxyqpRPGwMLg)_