### PR TITLE
Fix date input overflow on iOS Safari in mobile menu form

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -665,10 +665,6 @@
   .menu-form {
     padding: 1rem;
   }
-  
-  .form-group input[type="date"] {
-    max-width: 200px;
-  }
 }
 
 /* Mobile: Add-section FAB buttons in section gaps */
@@ -745,13 +741,21 @@
 .menu-date-row .menu-date-field {
   flex: 1;
   min-width: 150px;
+  /* Safety net: some browsers (notably iOS Safari) can render the native
+     date control wider than the box its layout size allows, letting it
+     visually spill onto the photo button instead of shrinking to fit.
+     Clipping here guarantees the button never gets covered. */
+  overflow: hidden;
 }
 
 .menu-date-row .menu-date-field input[type="date"] {
   height: 48px;
   padding-top: 0;
   padding-bottom: 0;
+  width: 100%;
   min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .menu-photo-upload-wrap {

--- a/src/components/MenuForm.css.test.js
+++ b/src/components/MenuForm.css.test.js
@@ -39,4 +39,29 @@ describe('MenuForm CSS mobile drag-handle layout', () => {
     expect(fieldRule).toContain('min-width: 150px;');
     expect(dateInputRule).toContain('min-width: 0;');
   });
+
+  test('clips the native date control instead of letting it visually spill onto the photo button', () => {
+    const fieldRule = getRuleBody(css, '.menu-date-row .menu-date-field');
+    const dateInputRule = getRuleBody(css, '.menu-date-row .menu-date-field input[type="date"]');
+
+    // Some browsers (notably iOS Safari) can paint the native date control
+    // wider than its layout box instead of shrinking it, so the field wraps
+    // to the date input's own width but still visually overlaps the photo
+    // button next to it. Clipping the field's overflow, and constraining
+    // the input to its own box, guarantees the button stays uncovered.
+    expect(fieldRule).toContain('overflow: hidden;');
+    expect(dateInputRule).toContain('width: 100%;');
+    expect(dateInputRule).toContain('max-width: 100%;');
+    expect(dateInputRule).toContain('box-sizing: border-box;');
+  });
+
+  test('does not cap the date input width with a stray max-width rule', () => {
+    // A leftover `.form-group input[type="date"] { max-width: 200px; }`
+    // rule (from before the photo button existed) capped the input's width
+    // on narrow viewports while the surrounding flex row was sized for the
+    // full-width layout below, leaving an unexplained gap before the
+    // button. The row's own rules are the single source of truth for the
+    // date input's width now.
+    expect(css).not.toMatch(/\.form-group input\[type="date"\]\s*\{\s*max-width:\s*200px;/);
+  });
 });


### PR DESCRIPTION
## Summary
Fixed a layout issue where the native date control in the menu form could visually overflow onto the adjacent photo button on iOS Safari and other browsers that render date inputs wider than their layout box.

## Key Changes
- Removed the legacy `max-width: 200px` rule on `.form-group input[type="date"]` that was causing unexplained gaps in the layout
- Added `overflow: hidden` to `.menu-date-field` to clip any visual overflow from the native date control
- Constrained the date input with `width: 100%`, `max-width: 100%`, and `box-sizing: border-box` to ensure it respects its container boundaries
- Added comprehensive test coverage to verify the overflow clipping behavior and ensure the legacy max-width rule doesn't reappear

## Implementation Details
The fix addresses a browser-specific rendering issue where iOS Safari (and potentially other browsers) paint the native date picker control wider than its layout box allows. By combining overflow clipping on the parent field with explicit width constraints on the input itself, the photo button next to the date field is guaranteed to remain uncovered and clickable on all platforms.

https://claude.ai/code/session_01Q8jkZzPocnZqPAUmDoeAqa