### PR TITLE
Refactor remove section button to reuse app-close-button styles

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -317,23 +317,22 @@
   border-color: #402C1C;
 }
 
-.remove-section-button {
-  background: transparent;
-  border: none;
+/* Shares base look/touch behavior with .app-close-button (App.css); these
+   overrides keep its distinct compact size and red hover tint, and win on
+   specificity regardless of CSS file order. */
+.remove-section-button.app-close-button {
   color: #999;
   font-size: 1.2rem;
   width: 32px;
   height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: color 0.2s ease;
+  margin-left: 0;
   padding: 0;
+  transition: color 0.2s ease;
 }
 
-.remove-section-button:hover {
+.remove-section-button.app-close-button:hover {
   color: #dc3545;
+  opacity: 1;
 }
 
 .remove-section-button .button-icon-image {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -181,7 +181,7 @@ function SortableSection({
         <div className="section-actions">
           <button
             type="button"
-            className="remove-section-button"
+            className="app-close-button remove-section-button"
             onClick={() => onRemoveSection(sectionIndex)}
             title="Abschnitt löschen"
           >


### PR DESCRIPTION
## Summary
Refactored the `.remove-section-button` to inherit base styles from `.app-close-button` while maintaining its distinct appearance through CSS specificity overrides. This reduces style duplication and ensures consistent button behavior across the application.

## Key Changes
- Updated `.remove-section-button` to use combined selector `.remove-section-button.app-close-button` in CSS, allowing it to inherit base styles (transparent background, flexbox layout, cursor, etc.) from `.app-close-button`
- Moved button-specific overrides (color, size, padding, transition) into the combined selector to maintain the compact 32x32px appearance and red hover tint
- Added `margin-left: 0` override to prevent inherited margin from `.app-close-button`
- Added `opacity: 1` to the hover state to override any opacity changes from the base button class
- Updated the button's className in MenuForm.js to include both `app-close-button` and `remove-section-button` classes
- Added clarifying comment explaining the style inheritance pattern and specificity strategy

## Implementation Details
The refactoring uses CSS specificity (compound selector) to ensure the overrides apply regardless of CSS file load order. This approach eliminates duplicate flexbox and cursor declarations while preserving the button's distinct visual identity with its specific color scheme and dimensions.

https://claude.ai/code/session_01AHkh5HtghLc4gPbYgSASXx