### PR TITLE
Update remove section button hover and active states styling

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -330,9 +330,9 @@
   transition: color 0.2s ease;
 }
 
-.remove-section-button.app-close-button:hover {
-  color: #dc3545;
-  opacity: 1;
+.remove-section-button.app-close-button:hover,
+.remove-section-button.app-close-button:active {
+  opacity: 0.7;
 }
 
 .remove-section-button .button-icon-image {


### PR DESCRIPTION
## Summary
Updated the styling for the remove section button's interactive states to provide consistent visual feedback across hover and active interactions.

## Key Changes
- Modified `.remove-section-button.app-close-button:hover` selector to include `:active` pseudo-class
- Changed opacity behavior from `opacity: 1` to `opacity: 0.7` for both hover and active states
- Removed the `color: #dc3545` property that was previously applied on hover

## Implementation Details
The change consolidates the hover and active state styling into a single rule, applying a unified opacity effect (0.7) to both interactions. This provides a more consistent user experience when users interact with the remove section button, whether they're hovering over it or actively clicking it.

https://claude.ai/code/session_017YykXrEVknpaaKXXnaxR5q