### PR TITLE
Refactor menu filters from FAB buttons to persistent sidebar

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ Sobald eine ingredientID den Status **Freigegeben** erhält, wird zusätzlich da
 ### Menü erstellen
 <!-- id: faq-menue-erstellen -->
 
-1. Navigiere über das Hauptmenü zu **„Menüs"** und klicke auf **„+ Menü erstellen"**.
+1. Navigiere über das Hauptmenü zu **„Menüs"** und klicke auf **„+ Menü"**.
 2. Gib einen **Namen** (Pflichtfeld) und optional eine **Beschreibung** sowie ein **Datum** ein.
 3. Füge **Abschnitte** (Gänge) hinzu, z. B. „Vorspeise", „Hauptgang", „Dessert".
 4. Weise jedem Abschnitt über die Rezeptsuche die passenden Rezepte zu.

--- a/public/FAQ.md
+++ b/public/FAQ.md
@@ -99,7 +99,7 @@ Sobald eine ingredientID den Status **Freigegeben** erhält, wird zusätzlich da
 ### Menü erstellen
 <!-- id: faq-menue-erstellen -->
 
-1. Navigiere über das Hauptmenü zu **„Menüs"** und klicke auf **„+ Menü erstellen"**.
+1. Navigiere über das Hauptmenü zu **„Menüs"** und klicke auf **„+ Menü"**.
 2. Gib einen **Namen** (Pflichtfeld) und optional eine **Beschreibung** sowie ein **Datum** ein.
 3. Füge **Abschnitte** (Gänge) hinzu, z. B. „Vorspeise", „Hauptgang", „Dessert".
 4. Weise jedem Abschnitt über die Rezeptsuche die passenden Rezepte zu.

--- a/src/App.css
+++ b/src/App.css
@@ -54,8 +54,6 @@
 
   .App .add-icon-button,
   .App .filter-button,
-  .App .menu-favorites-filter-button,
-  .App .add-menu-fab-button,
   .App .events-add-fab-button {
     bottom: calc(16px + env(safe-area-inset-bottom, 0px));
     transition:
@@ -116,10 +114,8 @@
   .App .startseite-fab-button,
   .App .kueche-fab-button,
   .App .add-icon-button,
-  .App .add-menu-fab-button,
   .App .events-add-fab-button,
   .App .events-page-container .edit-fab-button,
-  .App .menu-favorites-filter-button,
   .App .recipe-detail-container .edit-fab-button,
   .App .recipe-detail-container .new-version-fab-button,
   .App .recipe-detail-container .delete-fab-button,

--- a/src/App.css.test.js
+++ b/src/App.css.test.js
@@ -68,15 +68,13 @@ describe('App CSS FAB bottom offset selectors', () => {
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px) + var(--bottom-nav-offset, 0px));');
   });
 
-  test('keeps recipe and menu overview FAB buttons at fixed hidden-nav position', () => {
+  test('keeps recipe overview FAB buttons at fixed hidden-nav position', () => {
     const cssPath = path.join(__dirname, 'App.css');
     const css = fs.readFileSync(cssPath, 'utf8');
     const mobileBlock = getMediaBlock(css, '(max-width: 768px)');
 
     expect(mobileBlock).toContain('.App .add-icon-button,');
     expect(mobileBlock).toContain('.App .filter-button,');
-    expect(mobileBlock).toContain('.App .menu-favorites-filter-button,');
-    expect(mobileBlock).toContain('.App .add-menu-fab-button,');
     expect(mobileBlock).toContain('.App .events-add-fab-button {');
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px));');
   });

--- a/src/components/MenuFilterSidebar.css
+++ b/src/components/MenuFilterSidebar.css
@@ -1,0 +1,152 @@
+/* Persistent left-hand filter navigation for the menu overview, mirrors
+   RecipeFilterSidebar.css's visual language. Unlike the recipe sidebar this
+   stays visible on narrow viewports (non-sticky, full width) since menus
+   have no separate mobile filter entry point to fall back on. */
+
+.menu-filter-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  width: 280px;
+  flex-shrink: 0;
+  padding: 1.5rem 1.25rem;
+  box-sizing: border-box;
+  background: #FFFFFF;
+  border: 1px solid #E6E2DD;
+  border-radius: 16px;
+  align-self: flex-start;
+  position: sticky;
+  top: 1rem;
+  transition: width 0.2s ease, padding 0.2s ease;
+}
+
+.menu-filter-sidebar--collapsed {
+  width: auto;
+  gap: 0;
+  padding: 1rem 0.6rem;
+  align-items: center;
+}
+
+.menu-filter-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.menu-filter-sidebar--collapsed .menu-filter-sidebar-header {
+  justify-content: center;
+}
+
+.menu-filter-sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  border: 1.5px solid #211F1C;
+  background: white;
+  color: #211F1C;
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 0.15s ease;
+}
+
+.menu-filter-sidebar-toggle:hover {
+  border-color: #DF7A00;
+}
+
+.menu-filter-sidebar-toggle:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
+.menu-filter-sidebar-add-button {
+  flex: 1;
+  min-width: 0;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.75rem;
+  background: white;
+  border: 1.5px solid #211F1C;
+  border-radius: 10px;
+  color: #211F1C;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 0.3s ease;
+}
+
+.menu-filter-sidebar-add-button:hover {
+  background: #211F1C;
+  color: white;
+}
+
+.menu-filter-sidebar-add-button:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
+.menu-filter-sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.menu-filter-sidebar-quickfilters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.menu-filter-sidebar-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  border: 1px solid #E6E2DD;
+  background: #F4F2F0;
+  color: #2C2925;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.menu-filter-sidebar-pill--quick {
+  justify-content: flex-start;
+  width: 100%;
+  padding: 11px 18px;
+}
+
+.menu-filter-sidebar-pill:hover {
+  border-color: #DF7A00;
+}
+
+.menu-filter-sidebar-pill.active {
+  background: #DF7A00;
+  color: white;
+  font-weight: 700;
+  border-color: #DF7A00;
+}
+
+.menu-filter-sidebar-pill:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 900px) {
+  .menu-filter-sidebar {
+    position: static;
+    width: 100%;
+  }
+}

--- a/src/components/MenuFilterSidebar.js
+++ b/src/components/MenuFilterSidebar.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import './MenuFilterSidebar.css';
+
+const COLLAPSED_STORAGE_KEY = 'menuFilterSidebar_collapsed';
+
+function getStoredCollapsed() {
+  try {
+    return localStorage.getItem(COLLAPSED_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persistent left-hand navigation for the menu overview, mirroring
+ * RecipeFilterSidebar's layout (add button + collapsible pill filters)
+ * but scoped to the single Favoriten quick filter menus offer.
+ */
+function MenuFilterSidebar({ onAddMenu, showFavoritesOnly = false, onFavoritesToggle }) {
+  const [collapsed, setCollapsed] = useState(getStoredCollapsed);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(COLLAPSED_STORAGE_KEY, next ? '1' : '0');
+      } catch {
+        // ignore storage errors
+      }
+      return next;
+    });
+  };
+
+  return (
+    <nav
+      className={`menu-filter-sidebar${collapsed ? ' menu-filter-sidebar--collapsed' : ''}`}
+      aria-label="Menüfilter"
+    >
+      <div className="menu-filter-sidebar-header">
+        {!collapsed && (
+          <button
+            type="button"
+            className="menu-filter-sidebar-add-button"
+            onClick={onAddMenu}
+            title="Menü hinzufügen"
+            aria-label="Menü hinzufügen"
+          >
+            + Menü
+          </button>
+        )}
+        <button
+          type="button"
+          className="menu-filter-sidebar-toggle"
+          onClick={toggleCollapsed}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Filter einblenden' : 'Filter ausblenden'}
+          title={collapsed ? 'Filter einblenden' : 'Filter ausblenden'}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            {collapsed ? <polyline points="9 6 15 12 9 18" /> : <polyline points="15 6 9 12 15 18" />}
+          </svg>
+        </button>
+      </div>
+
+      {!collapsed && (
+        <div className="menu-filter-sidebar-section menu-filter-sidebar-quickfilters">
+          <button
+            type="button"
+            className={`menu-filter-sidebar-pill menu-filter-sidebar-pill--quick${showFavoritesOnly ? ' active' : ''}`}
+            onClick={() => onFavoritesToggle?.(!showFavoritesOnly)}
+            aria-pressed={showFavoritesOnly}
+            title={showFavoritesOnly ? 'Alle Festtafeln anzeigen' : 'Nur Favoriten anzeigen'}
+          >
+            ★ Favoriten
+          </button>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+export default MenuFilterSidebar;

--- a/src/components/MenuList.css
+++ b/src/components/MenuList.css
@@ -4,6 +4,35 @@
   padding: 1rem;
 }
 
+.menu-overview-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 1rem 1rem 0;
+}
+
+.menu-overview-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.menu-overview-main .menu-list-container {
+  padding: 0 0 1rem;
+}
+
+@media (max-width: 900px) {
+  .menu-overview-layout {
+    display: block;
+    padding: 0;
+  }
+
+  .menu-overview-main .menu-list-container {
+    padding: 1rem;
+  }
+}
+
 .menu-list-header {
   display: flex;
   justify-content: space-between;
@@ -21,106 +50,6 @@
   display: flex;
   gap: 0.75rem;
   align-items: center;
-}
-
-.menu-favorites-filter-button {
-  position: fixed;
-  bottom: 20px;
-  left: 20px;
-  z-index: 1101;
-  width: 56px;
-  height: 56px;
-  min-width: 56px;
-  max-width: 56px;
-  border-radius: 50%;
-  padding: 0;
-  background: white;
-  color: #666;
-  border: 1px solid #ddd;
-  opacity: 0.85;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 1.4rem;
-  font-weight: 600;
-  -webkit-tap-highlight-color: transparent;
-  -webkit-appearance: none;
-  appearance: none;
-  touch-action: manipulation;
-  will-change: transform;
-  transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),
-              background 0.15s ease,
-              box-shadow 0.15s ease;
-}
-
-.menu-favorites-filter-button.pressed {
-  transform: scale(1.15);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
-}
-
-.menu-favorites-filter-button:focus,
-.menu-favorites-filter-button:focus-visible {
-  outline: none;
-}
-
-.menu-favorites-filter-button:active {
-  outline: none;
-}
-
-.menu-favorites-filter-button.active {
-  background: #DF7A00;
-  border-color: #DF7A00;
-  color: white;
-}
-
-.menu-favorites-filter-button .button-icon-image {
-  width: 1.4rem;
-  height: 1.4rem;
-  object-fit: contain;
-}
-
-.add-menu-fab-button {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  z-index: 1101;
-  width: 56px;
-  height: 56px;
-  min-width: 56px;
-  max-width: 56px;
-  border-radius: 50%;
-  padding: 0;
-  background: white;
-  color: white;
-  border: 1px solid #ddd;
-  opacity: 0.85;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
-  -webkit-appearance: none;
-  appearance: none;
-  touch-action: manipulation;
-  will-change: transform;
-  transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),
-              background 0.15s ease,
-              box-shadow 0.15s ease;
-  font-size: 1.1rem;
-}
-
-.add-menu-fab-button.pressed {
-  transform: scale(1.15);
-  box-shadow: 0 8px 18px rgba(0,0,0,0.3);
-}
-
-.add-menu-fab-button .button-icon-image {
-  width: 1.4rem;
-  height: 1.4rem;
-  object-fit: contain;
 }
 
 .empty-state {

--- a/src/components/MenuList.js
+++ b/src/components/MenuList.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './MenuList.css';
+import MenuFilterSidebar from './MenuFilterSidebar';
 import { getUserMenuFavorites } from '../utils/menuFavorites';
 import { getButtonIcons, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
@@ -7,8 +8,6 @@ import { isBase64Image } from '../utils/imageUtils';
 function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorite, currentUser, allUsers }) {
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [favoriteIds, setFavoriteIds] = useState([]);
-  const [addPressed, setAddPressed] = useState(false);
-  const [favPressed, setFavPressed] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
 
@@ -105,18 +104,25 @@ function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorit
   }).sort((a, b) => getMenuSortDate(b) - getMenuSortDate(a));
 
   return (
+    <div className="menu-overview-layout">
+      <MenuFilterSidebar
+        onAddMenu={onAddMenu}
+        showFavoritesOnly={showFavoritesOnly}
+        onFavoritesToggle={setShowFavoritesOnly}
+      />
+      <div className="menu-overview-main">
     <div className="menu-list-container">
       <div className="menu-list-header">
         <h2>{showFavoritesOnly ? 'Meine Festtafel' : 'Festtafel'}</h2>
       </div>
-      
+
       {filteredMenus.length === 0 ? (
         <div className="empty-state">
           <p>{showFavoritesOnly ? 'Keine favorisierten Menüs!' : 'Noch keine Menüs!'}</p>
           <p className="empty-hint">
             {showFavoritesOnly 
               ? 'Markiere Menüs als Favorit, so findest du sie schneller.' 
-              : 'Tippe auf "Menü erstellen", um deine Rezepte in Menüs zu organisieren'}
+              : 'Tippe auf "+ Menü", um deine Rezepte in Menüs zu organisieren'}
           </p>
         </div>
       ) : (
@@ -182,50 +188,8 @@ function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorit
           })}
         </div>
       )}
-      <button
-        className={`add-menu-fab-button ${addPressed ? 'pressed' : ''}`}
-        onClick={onAddMenu}
-        onTouchStart={() => setAddPressed(true)}
-        onTouchEnd={() => setAddPressed(false)}
-        onTouchCancel={() => setAddPressed(false)}
-        onMouseDown={() => setAddPressed(true)}
-        onMouseUp={() => setAddPressed(false)}
-        onMouseLeave={() => setAddPressed(false)}
-        title="Menü erstellen"
-        aria-label="Menü erstellen"
-      >
-        {isBase64Image(getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)) ? (
-          <img src={getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)} alt="Menü erstellen" className="button-icon-image" draggable="false" />
-        ) : (
-          getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)
-        )}
-      </button>
-      <button
-        className={`menu-favorites-filter-button ${showFavoritesOnly ? 'active' : ''} ${favPressed ? 'pressed' : ''}`}
-        onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
-        onTouchStart={() => setFavPressed(true)}
-        onTouchEnd={() => setFavPressed(false)}
-        onTouchCancel={() => setFavPressed(false)}
-        onMouseDown={() => setFavPressed(true)}
-        onMouseUp={() => setFavPressed(false)}
-        onMouseLeave={() => setFavPressed(false)}
-        title={showFavoritesOnly ? 'Alle Festtafeln anzeigen' : 'Nur Favoriten anzeigen'}
-        aria-label={showFavoritesOnly ? 'Alle Festtafeln anzeigen' : 'Nur Favoriten anzeigen'}
-      >
-        {showFavoritesOnly ? (
-          isBase64Image(getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)) ? (
-            <img src={getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)} alt="Favoriten aktiv" className="button-icon-image" draggable="false" />
-          ) : (
-            getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)
-          )
-        ) : (
-          isBase64Image(getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)) ? (
-            <img src={getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)} alt="Favoriten" className="button-icon-image" draggable="false" />
-          ) : (
-            getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)
-          )
-        )}
-      </button>
+    </div>
+      </div>
     </div>
   );
 }

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -245,6 +245,41 @@
   color: #1e1e1e;
 }
 
+/* ---- Menu filter sidebar ---- */
+[data-theme="dark"] .menu-filter-sidebar {
+  background: #1e1e1e;
+  border-color: #3d3d3d;
+}
+
+[data-theme="dark"] .menu-filter-sidebar-pill {
+  background: #2A2623;
+  color: #E6DED6;
+  border-color: #3A342F;
+}
+
+[data-theme="dark"] .menu-filter-sidebar-pill.active {
+  background: #DF7A00;
+  color: white;
+  border-color: #DF7A00;
+}
+
+[data-theme="dark"] .menu-filter-sidebar-toggle {
+  background: #2a2a2a;
+  border-color: #3d3d3d;
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .menu-filter-sidebar-add-button {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #e8e8e8;
+}
+
+[data-theme="dark"] .menu-filter-sidebar-add-button:hover {
+  background: #e8e8e8;
+  color: #1e1e1e;
+}
+
 /* ---- Recipe List ---- */
 [data-theme="dark"] .recipe-list-container {
   background: #121212;
@@ -954,24 +989,6 @@
 
 [data-theme="dark"] .menu-card-meta {
   color: #aaa;
-}
-
-[data-theme="dark"] .menu-favorites-filter-button {
-  background: #2a2a2a;
-  color: #e8e8e8;
-  border-color: #555;
-}
-
-[data-theme="dark"] .menu-favorites-filter-button.active {
-  background: #DF7A00;
-  color: #fff;
-  border-color: #DF7A00;
-}
-
-[data-theme="dark"] .add-menu-fab-button {
-  background: #2a2a2a;
-  color: #e8e8e8;
-  border-color: #555;
 }
 
 [data-theme="dark"] .events-add-fab-button {


### PR DESCRIPTION
## Summary
Replaces the fixed floating action buttons (FAB) for menu filtering and creation with a persistent left-hand sidebar component, mirroring the design pattern used in the recipe filter sidebar. This improves discoverability and provides a more consistent UI across the application.

## Key Changes
- **New MenuFilterSidebar component** (`MenuFilterSidebar.js`): A persistent navigation sidebar with:
  - Add menu button (visible when expanded)
  - Collapsible toggle with localStorage persistence
  - Favorites quick filter pill
  - Responsive design that becomes full-width on narrow viewports
  
- **Updated MenuList layout**: Restructured to use a two-column layout with the sidebar on the left and menu content on the right
  - Added `.menu-overview-layout` and `.menu-overview-main` CSS classes
  - Removed FAB button state management (`addPressed`, `favPressed`)
  - Updated empty state hint text to reference "+ Menü" button

- **Removed FAB buttons**: Deleted CSS and functionality for:
  - `.menu-favorites-filter-button` (fixed position favorites toggle)
  - `.add-menu-fab-button` (fixed position add menu button)

- **Styling updates**:
  - New `MenuFilterSidebar.css` with 152 lines of component-specific styles
  - Added dark mode support in `darkMode.css` for sidebar elements
  - Updated responsive breakpoints in `MenuList.css` for mobile layout
  - Cleaned up `App.css` to remove FAB button safe-area offset rules

- **Documentation**: Updated FAQ.md to reflect new "+ Menü" button location

## Implementation Details
- Sidebar collapse state persists via localStorage (`menuFilterSidebar_collapsed`)
- Uses sticky positioning on desktop, static on mobile (≤900px)
- Maintains accessibility with proper ARIA labels and focus management
- Smooth transitions for collapse/expand animations
- Consistent visual language with existing RecipeFilterSidebar component

https://claude.ai/code/session_0182UyAXAMXu4o9iNTvYA1Xx