### PR TITLE
Restore mobile FAB buttons for menu filtering and creation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -54,6 +54,8 @@
 
   .App .add-icon-button,
   .App .filter-button,
+  .App .menu-favorites-filter-button,
+  .App .add-menu-fab-button,
   .App .events-add-fab-button {
     bottom: calc(16px + env(safe-area-inset-bottom, 0px));
     transition:
@@ -114,8 +116,10 @@
   .App .startseite-fab-button,
   .App .kueche-fab-button,
   .App .add-icon-button,
+  .App .add-menu-fab-button,
   .App .events-add-fab-button,
   .App .events-page-container .edit-fab-button,
+  .App .menu-favorites-filter-button,
   .App .recipe-detail-container .edit-fab-button,
   .App .recipe-detail-container .new-version-fab-button,
   .App .recipe-detail-container .delete-fab-button,

--- a/src/App.css.test.js
+++ b/src/App.css.test.js
@@ -68,13 +68,15 @@ describe('App CSS FAB bottom offset selectors', () => {
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px) + var(--bottom-nav-offset, 0px));');
   });
 
-  test('keeps recipe overview FAB buttons at fixed hidden-nav position', () => {
+  test('keeps recipe and menu overview FAB buttons at fixed hidden-nav position', () => {
     const cssPath = path.join(__dirname, 'App.css');
     const css = fs.readFileSync(cssPath, 'utf8');
     const mobileBlock = getMediaBlock(css, '(max-width: 768px)');
 
     expect(mobileBlock).toContain('.App .add-icon-button,');
     expect(mobileBlock).toContain('.App .filter-button,');
+    expect(mobileBlock).toContain('.App .menu-favorites-filter-button,');
+    expect(mobileBlock).toContain('.App .add-menu-fab-button,');
     expect(mobileBlock).toContain('.App .events-add-fab-button {');
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px));');
   });

--- a/src/components/MenuFilterSidebar.css
+++ b/src/components/MenuFilterSidebar.css
@@ -1,7 +1,7 @@
 /* Persistent left-hand filter navigation for the menu overview, mirrors
-   RecipeFilterSidebar.css's visual language. Unlike the recipe sidebar this
-   stays visible on narrow viewports (non-sticky, full width) since menus
-   have no separate mobile filter entry point to fall back on. */
+   RecipeFilterSidebar.css's visual language. Desktop-only: below the 900px
+   breakpoint the mobile view keeps its original FAB buttons (see
+   MenuList.css) instead of the sidebar. */
 
 .menu-filter-sidebar {
   display: flex;
@@ -146,7 +146,6 @@
 
 @media (max-width: 900px) {
   .menu-filter-sidebar {
-    position: static;
-    width: 100%;
+    display: none;
   }
 }

--- a/src/components/MenuList.css
+++ b/src/components/MenuList.css
@@ -22,6 +22,9 @@
   padding: 0 0 1rem;
 }
 
+/* Below 900px the sidebar (see MenuFilterSidebar.css) hides itself and the
+   mobile view falls back to its original FAB buttons defined below, so the
+   mobile layout stays exactly as it was before the sidebar was introduced. */
 @media (max-width: 900px) {
   .menu-overview-layout {
     display: block;
@@ -66,6 +69,130 @@
 .empty-hint {
   font-size: 0.9rem;
   color: #999;
+}
+
+.empty-hint-mobile {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .empty-hint-desktop {
+    display: none;
+  }
+
+  .empty-hint-mobile {
+    display: block;
+  }
+}
+
+/* Mobile-only FAB buttons, restored to match the pre-sidebar mobile view.
+   Desktop uses the persistent MenuFilterSidebar instead (see
+   MenuFilterSidebar.css). */
+.menu-favorites-filter-button,
+.add-menu-fab-button {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .menu-favorites-filter-button {
+    display: flex;
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    z-index: 1101;
+    width: 56px;
+    height: 56px;
+    min-width: 56px;
+    max-width: 56px;
+    border-radius: 50%;
+    padding: 0;
+    background: white;
+    color: #666;
+    border: 1px solid #ddd;
+    opacity: 0.85;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.4rem;
+    font-weight: 600;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+    touch-action: manipulation;
+    will-change: transform;
+    transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),
+                background 0.15s ease,
+                box-shadow 0.15s ease;
+  }
+
+  .menu-favorites-filter-button.pressed {
+    transform: scale(1.15);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+  }
+
+  .menu-favorites-filter-button:focus,
+  .menu-favorites-filter-button:focus-visible {
+    outline: none;
+  }
+
+  .menu-favorites-filter-button:active {
+    outline: none;
+  }
+
+  .menu-favorites-filter-button.active {
+    background: #DF7A00;
+    border-color: #DF7A00;
+    color: white;
+  }
+
+  .menu-favorites-filter-button .button-icon-image {
+    width: 1.4rem;
+    height: 1.4rem;
+    object-fit: contain;
+  }
+
+  .add-menu-fab-button {
+    display: flex;
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1101;
+    width: 56px;
+    height: 56px;
+    min-width: 56px;
+    max-width: 56px;
+    border-radius: 50%;
+    padding: 0;
+    background: white;
+    color: white;
+    border: 1px solid #ddd;
+    opacity: 0.85;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+    touch-action: manipulation;
+    will-change: transform;
+    transition: transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),
+                background 0.15s ease,
+                box-shadow 0.15s ease;
+    font-size: 1.1rem;
+  }
+
+  .add-menu-fab-button.pressed {
+    transform: scale(1.15);
+    box-shadow: 0 8px 18px rgba(0,0,0,0.3);
+  }
+
+  .add-menu-fab-button .button-icon-image {
+    width: 1.4rem;
+    height: 1.4rem;
+    object-fit: contain;
+  }
 }
 
 .menu-grid {

--- a/src/components/MenuList.js
+++ b/src/components/MenuList.js
@@ -8,6 +8,8 @@ import { isBase64Image } from '../utils/imageUtils';
 function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorite, currentUser, allUsers }) {
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [favoriteIds, setFavoriteIds] = useState([]);
+  const [addPressed, setAddPressed] = useState(false);
+  const [favPressed, setFavPressed] = useState(false);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
 
@@ -119,11 +121,14 @@ function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorit
       {filteredMenus.length === 0 ? (
         <div className="empty-state">
           <p>{showFavoritesOnly ? 'Keine favorisierten Menüs!' : 'Noch keine Menüs!'}</p>
-          <p className="empty-hint">
-            {showFavoritesOnly 
-              ? 'Markiere Menüs als Favorit, so findest du sie schneller.' 
-              : 'Tippe auf "+ Menü", um deine Rezepte in Menüs zu organisieren'}
-          </p>
+          {showFavoritesOnly ? (
+            <p className="empty-hint">Markiere Menüs als Favorit, so findest du sie schneller.</p>
+          ) : (
+            <>
+              <p className="empty-hint empty-hint-desktop">Tippe auf "+ Menü", um deine Rezepte in Menüs zu organisieren</p>
+              <p className="empty-hint empty-hint-mobile">Tippe auf "Menü erstellen", um deine Rezepte in Menüs zu organisieren</p>
+            </>
+          )}
         </div>
       ) : (
         <div className="menu-grid">
@@ -188,6 +193,50 @@ function MenuList({ menus, recipes, onSelectMenu, onAddMenu, onToggleMenuFavorit
           })}
         </div>
       )}
+      <button
+        className={`add-menu-fab-button ${addPressed ? 'pressed' : ''}`}
+        onClick={onAddMenu}
+        onTouchStart={() => setAddPressed(true)}
+        onTouchEnd={() => setAddPressed(false)}
+        onTouchCancel={() => setAddPressed(false)}
+        onMouseDown={() => setAddPressed(true)}
+        onMouseUp={() => setAddPressed(false)}
+        onMouseLeave={() => setAddPressed(false)}
+        title="Menü erstellen"
+        aria-label="Menü erstellen"
+      >
+        {isBase64Image(getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)) ? (
+          <img src={getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)} alt="Menü erstellen" className="button-icon-image" draggable="false" />
+        ) : (
+          getEffectiveIcon(buttonIcons, 'addMenu', isDarkMode)
+        )}
+      </button>
+      <button
+        className={`menu-favorites-filter-button ${showFavoritesOnly ? 'active' : ''} ${favPressed ? 'pressed' : ''}`}
+        onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+        onTouchStart={() => setFavPressed(true)}
+        onTouchEnd={() => setFavPressed(false)}
+        onTouchCancel={() => setFavPressed(false)}
+        onMouseDown={() => setFavPressed(true)}
+        onMouseUp={() => setFavPressed(false)}
+        onMouseLeave={() => setFavPressed(false)}
+        title={showFavoritesOnly ? 'Alle Festtafeln anzeigen' : 'Nur Favoriten anzeigen'}
+        aria-label={showFavoritesOnly ? 'Alle Festtafeln anzeigen' : 'Nur Favoriten anzeigen'}
+      >
+        {showFavoritesOnly ? (
+          isBase64Image(getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)) ? (
+            <img src={getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)} alt="Favoriten aktiv" className="button-icon-image" draggable="false" />
+          ) : (
+            getEffectiveIcon(buttonIcons, 'menuFavoritesButtonActive', isDarkMode)
+          )
+        ) : (
+          isBase64Image(getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)) ? (
+            <img src={getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)} alt="Favoriten" className="button-icon-image" draggable="false" />
+          ) : (
+            getEffectiveIcon(buttonIcons, 'menuFavoritesButton', isDarkMode)
+          )
+        )}
+      </button>
     </div>
       </div>
     </div>

--- a/src/components/MenuList.test.js
+++ b/src/components/MenuList.test.js
@@ -154,7 +154,10 @@ describe('MenuList - dynamic title', () => {
       />
     );
 
-    const favButton = await screen.findByTitle('Nur Favoriten anzeigen');
+    // Both the desktop sidebar pill and the mobile FAB expose this title;
+    // CSS media queries that hide one of them per viewport aren't applied
+    // in jsdom, so either match toggles the same shared state.
+    const [favButton] = await screen.findAllByTitle('Nur Favoriten anzeigen');
     fireEvent.click(favButton);
 
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Meine Festtafel');
@@ -175,11 +178,11 @@ describe('MenuList - dynamic title', () => {
       />
     );
 
-    const favButton = await screen.findByTitle('Nur Favoriten anzeigen');
+    const [favButton] = await screen.findAllByTitle('Nur Favoriten anzeigen');
     fireEvent.click(favButton);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Meine Festtafel');
 
-    const allButton = screen.getByTitle('Alle Festtafeln anzeigen');
+    const [allButton] = screen.getAllByTitle('Alle Festtafeln anzeigen');
     fireEvent.click(allButton);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Festtafel');
   });

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -991,6 +991,24 @@
   color: #aaa;
 }
 
+[data-theme="dark"] .menu-favorites-filter-button {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #555;
+}
+
+[data-theme="dark"] .menu-favorites-filter-button.active {
+  background: #DF7A00;
+  color: #fff;
+  border-color: #DF7A00;
+}
+
+[data-theme="dark"] .add-menu-fab-button {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #555;
+}
+
 [data-theme="dark"] .events-add-fab-button {
   background: #2a2a2a;
   color: #e8e8e8;


### PR DESCRIPTION
## Summary
Restores the mobile-optimized floating action button (FAB) interface for menu management, replacing the desktop-only sidebar on viewports below 900px. This ensures the mobile experience matches the pre-sidebar behavior while keeping the persistent sidebar on desktop.

## Key Changes
- **Mobile FAB buttons**: Added two fixed-position buttons for mobile viewports:
  - "Add menu" FAB (bottom-right) for creating new menus
  - "Favorites filter" FAB (bottom-left) for toggling favorites-only view
  
- **Responsive layout**: Updated `MenuFilterSidebar` to hide completely on mobile (below 900px) instead of adapting to full-width, allowing the FAB buttons to take over

- **Empty state messaging**: Split hint text into desktop and mobile variants to reflect the different UI patterns (sidebar vs FAB buttons)

- **Button styling**: Implemented FAB-specific styles with:
  - Circular 56px buttons with fixed positioning
  - Press/active state animations (scale transform)
  - Dark mode support
  - Touch and mouse event handlers for visual feedback
  - Proper z-index layering (1101) to appear above content

- **Safe area support**: Integrated mobile safe area insets in `App.css` for notch/home indicator compatibility

- **Test updates**: Fixed test selectors to handle both desktop sidebar and mobile FAB implementations coexisting in the DOM (CSS media queries don't apply in jsdom)

## Implementation Details
- FAB buttons use icon images from the existing `buttonIcons` system with dark mode awareness
- Press state is tracked separately for each button to provide visual feedback
- Both touch and mouse events are handled for cross-device compatibility
- The sidebar remains the primary interface on desktop (≥900px), maintaining the improved UX for larger screens

https://claude.ai/code/session_01GwxEXbEUBhxxqazEdJ59Ts