### PR TITLE
Remove duplicate close buttons from event selection pages

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -370,14 +370,6 @@ function EventDrinkSelectionPage({
     <div className="events-page-container events-drink-selection-page">
       <div className="events-page-header">
         <h2>Getränke</h2>
-        <button
-          className="events-close-btn"
-          onClick={onBack}
-          aria-label="Abbrechen"
-          title="Abbrechen"
-        >
-          ×
-        </button>
       </div>
 
       <div className="events-form">

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -264,27 +264,7 @@ describe('EventDrinkSelectionPage', () => {
       />,
     );
 
-    const abrechenButtons = screen.getAllByRole('button', { name: 'Abbrechen' });
-    fireEvent.click(abrechenButtons[abrechenButtons.length - 1]);
-
-    expect(onBack).toHaveBeenCalledTimes(1);
-  });
-
-  test('calls onBack when header close button is clicked', () => {
-    const onBack = jest.fn();
-    render(
-      <EventDrinkSelectionPage
-        customDrinks={customDrinks}
-        customDrinkIds={[]}
-        guestPreferenceMultipliers={{}}
-        selectedGuestIds={[]}
-        onSave={jest.fn()}
-        onBack={onBack}
-      />,
-    );
-
-    const abrechenButtons = screen.getAllByRole('button', { name: 'Abbrechen' });
-    fireEvent.click(abrechenButtons[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
 
     expect(onBack).toHaveBeenCalledTimes(1);
   });

--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -92,14 +92,6 @@ function EventGuestSelectionPage({
     <div className="events-page-container">
       <div className="events-page-header">
         <h2>Gäste</h2>
-        <button
-          className="events-close-btn"
-          onClick={onBack}
-          aria-label="Abbrechen"
-          title="Abbrechen"
-        >
-          ×
-        </button>
       </div>
 
       <div className="events-form">

--- a/src/components/EventGuestSelectionPage.test.js
+++ b/src/components/EventGuestSelectionPage.test.js
@@ -238,9 +238,7 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    // There are two Abbrechen buttons (header close and form action); click the form action one
-    const abrechenButtons = screen.getAllByRole('button', { name: 'Abbrechen' });
-    fireEvent.click(abrechenButtons[abrechenButtons.length - 1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
 
     expect(onBack).toHaveBeenCalledTimes(1);
   });
@@ -262,24 +260,5 @@ describe('EventGuestSelectionPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
     expect(onSave).toHaveBeenCalledWith([], []);
-  });
-
-  test('calls onBack when header close button is clicked', () => {
-    const onBack = jest.fn();
-    render(
-      <EventGuestSelectionPage
-        currentUser={currentUser}
-        selectedGuestIds={[]}
-        driverGuestIds={[]}
-        onSave={jest.fn()}
-        onBack={onBack}
-      />
-    );
-
-    // Header close button is the first Abbrechen button
-    const abrechenButtons = screen.getAllByRole('button', { name: 'Abbrechen' });
-    fireEvent.click(abrechenButtons[0]);
-
-    expect(onBack).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
Removed duplicate "Abbrechen" (Cancel) close buttons from the header of EventGuestSelectionPage and EventDrinkSelectionPage components. Each page now has a single cancel button in the form action area instead of two buttons (one in the header and one in the form).

## Key Changes
- **EventGuestSelectionPage.js**: Removed the close button (×) from the page header
- **EventDrinkSelectionPage.js**: Removed the close button (×) from the page header
- **EventGuestSelectionPage.test.js**: 
  - Simplified the "calls onBack when form Abbrechen button is clicked" test to use `getByRole` instead of `getAllByRole` with index selection
  - Removed the redundant "calls onBack when header close button is clicked" test
- **EventDrinkSelectionPage.test.js**:
  - Simplified the "calls onBack when form Abbrechen button is clicked" test to use `getByRole` instead of `getAllByRole` with index selection
  - Removed the redundant "calls onBack when header close button is clicked" test

## Implementation Details
The changes eliminate UI redundancy by keeping only the form action cancel button. This simplifies the component structure and test logic, as there is now only one "Abbrechen" button per page, making test selectors more straightforward and the user interface cleaner.

https://claude.ai/code/session_01PgQ1wNhZbKxLRhmfBf2dbE