### PR TITLE
Add delete button to guest cards in GuestManagementPage

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -90,6 +90,45 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
 }
 
+.events-guest-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.events-guest-card .events-card-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.events-guest-delete-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid #ececec;
+  background: white;
+  color: #b3261e;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.events-guest-delete-btn:hover {
+  background: #fdecea;
+  border-color: #f3b7b1;
+}
+
+.events-guest-delete-btn .swipe-delete-icon-image {
+  width: 1.1rem;
+  height: 1.1rem;
+  object-fit: contain;
+}
+
 .events-card-main h3 {
   margin: 0 0 4px;
   color: #2F5D50;

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -516,8 +516,9 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
               ? profile.bevorzugteKategorien.map(getDrinkCategoryLabel)
               : [];
             const preferredSummary = [...preferredDrinkNames, ...preferredCategoryNames];
+            const guestDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
             return (
-              <div key={profile.id} className="events-card" onClick={() => openEdit(profile)}>
+              <div key={profile.id} className="events-card events-guest-card" onClick={() => openEdit(profile)}>
                 <div className="events-card-main">
                   <h3>{fullName || 'Unbenannter Gast'}</h3>
                   {profile.kind === true && <p className="events-info-text">Kind</p>}
@@ -527,6 +528,22 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
                     </p>
                   )}
                 </div>
+                <button
+                  type="button"
+                  className="events-guest-delete-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(profile);
+                  }}
+                  aria-label={`${fullName || 'Gast'} löschen`}
+                  title="Gast löschen"
+                >
+                  {isBase64Image(guestDeleteIcon) ? (
+                    <img src={guestDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+                  ) : (
+                    <span className="swipe-delete-icon-text">{guestDeleteIcon}</span>
+                  )}
+                </button>
               </div>
             );
           })}

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -301,4 +301,37 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     const names = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
     expect(names).toEqual(['Anna Adler', 'Zora Adler', 'Bernd Zimmer']);
   });
+
+  test('clicking the delete button on a guest card deletes the guest without opening the edit form', () => {
+    window.confirm = jest.fn(() => true);
+    mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
+      cb([
+        { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
+      ]);
+      return jest.fn();
+    });
+
+    render(<GuestManagementPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
+
+    expect(window.confirm).toHaveBeenCalledWith('Möchtest du "Anna Adler" wirklich löschen?');
+    expect(mockDeleteGuestProfile).toHaveBeenCalledWith('u1', 'g1');
+  });
+
+  test('delete button click does not trigger the edit form to open', () => {
+    window.confirm = jest.fn(() => true);
+    mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
+      cb([
+        { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
+      ]);
+      return jest.fn();
+    });
+
+    render(<GuestManagementPage currentUser={currentUser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
+
+    expect(screen.queryByRole('heading', { name: 'Gast bearbeiten' })).not.toBeInTheDocument();
+  });
 });

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3951,6 +3951,17 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.45);
 }
 
+[data-theme="dark"] .events-guest-delete-btn {
+  background: #2a2a2a;
+  border-color: #555;
+  color: #e8837a;
+}
+
+[data-theme="dark"] .events-guest-delete-btn:hover {
+  background: #3a2323;
+  border-color: #6b3a35;
+}
+
 [data-theme="dark"] .events-guest-typeahead-list {
   background: #262626;
   border-color: #555;


### PR DESCRIPTION
## Summary
This PR adds a dedicated delete button to guest cards in the GuestManagementPage, allowing users to delete guests without opening the edit form. The delete button is positioned on the right side of each guest card and includes proper styling for both light and dark modes.

## Key Changes
- **Guest Card Layout**: Modified `.events-guest-card` to use flexbox with space-between alignment, positioning the delete button on the right
- **Delete Button Styling**: Added `.events-guest-delete-btn` with circular design, hover effects, and icon support (both base64 images and emoji)
- **Dark Mode Support**: Added dark mode styles for the delete button with appropriate color adjustments
- **Event Handling**: Implemented click handler that:
  - Prevents event propagation to avoid triggering the edit form
  - Shows a confirmation dialog before deletion
  - Calls `handleDelete()` to remove the guest
- **Accessibility**: Added proper `aria-label` and `title` attributes for screen readers and tooltips
- **Tests**: Added two test cases to verify:
  - Delete button correctly deletes the guest with confirmation
  - Delete button click does not open the edit form

## Implementation Details
- The delete button uses `e.stopPropagation()` to prevent the card's onClick handler from firing
- Icon support includes both custom base64 images and fallback emoji (🗑)
- Button styling includes smooth transitions and hover state feedback
- Dark mode colors use appropriate contrast ratios for the red delete action

https://claude.ai/code/session_01KgggTZwH1JtarSuwQWc7jg