### PR TITLE
Prevent swipe-delete content overflow during active swipe

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1267,17 +1267,24 @@
 
 .events-drink-row {
   position: relative;
-  /* No overflow clipping here: the unit typeahead dropdown opens below the
-     input and must be able to spill outside the row's bottom edge. Mixing
-     overflow-x: hidden with overflow-y: visible doesn't work for that,
-     since browsers compute the visible axis as auto once the other axis is
-     non-visible, which re-clips the dropdown anyway. The swipe-to-delete
-     background below has its own matching border-radius instead, so it
-     never needs to be clipped by this container. */
+  /* No overflow clipping here by default: the unit typeahead dropdown opens
+     below the input and must be able to spill outside the row's bottom
+     edge. Mixing overflow-x: hidden with overflow-y: visible doesn't work
+     for that, since browsers compute the visible axis as auto once the
+     other axis is non-visible, which re-clips the dropdown anyway. The
+     swipe-to-delete background below has its own matching border-radius
+     instead, so it never needs to be clipped by this container.
+     While a swipe is active (see .swipe-delete-active below) the dropdown
+     can't be open, so clipping is safe and prevents the sliding content
+     from spilling past the row's left edge over the red background. */
   border-radius: 10px;
   background: white;
   border: 1px solid #e8e8e8;
   box-shadow: none;
+}
+
+.events-drink-row.swipe-delete-active {
+  overflow: hidden;
 }
 
 .events-drink-row-swipe-background {


### PR DESCRIPTION
## Summary
Added overflow clipping to the events drink row during active swipe-to-delete gestures to prevent sliding content from spilling past the row's left edge over the red delete background.

## Changes
- Added `.events-drink-row.swipe-delete-active` CSS rule with `overflow: hidden` to clip content during swipe gestures
- Updated the `.events-drink-row` comment to clarify the overflow behavior:
  - Explains why overflow clipping is disabled by default (to allow unit typeahead dropdown to spill outside the row)
  - Documents that clipping is safe and necessary when a swipe is active, since the dropdown cannot be open during that time

## Implementation Details
The solution leverages the fact that the unit typeahead dropdown and swipe-to-delete gesture are mutually exclusive interactions. By conditionally applying `overflow: hidden` only when `.swipe-delete-active` is present, the component maintains the dropdown's visibility in normal operation while preventing visual artifacts during swipe animations.

https://claude.ai/code/session_016ZL7bWAfTD3e78TPWyjPnE