### PR TITLE
Filternavigation der Rezeptübersicht unabhängig scrollbar machen

### DIFF
--- a/src/components/RecipeFilterSidebar.css
+++ b/src/components/RecipeFilterSidebar.css
@@ -14,6 +14,9 @@
   align-self: flex-start;
   position: sticky;
   top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   transition: width 0.2s ease, padding 0.2s ease;
 }
 


### PR DESCRIPTION
Die Sidebar erhält eine eigene Scroll-Box (max-height + overflow-y),
sodass sie sich unabhängig von der Rezeptliste scrollen lässt, sobald
ihr Inhalt die Viewport-Höhe übersteigt.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TZ7ox4jSRAc9qeSvwAFPc