### PR TITLE
Fix jump when collapsing the sort carousel, make active pill white

### DIFF
--- a/src/components/SortCarousel.css
+++ b/src/components/SortCarousel.css
@@ -105,7 +105,7 @@
 }
 
 .sort-carousel-item--active {
-  background: rgba(255, 252, 249, 0.72);
+  background: #fff;
   backdrop-filter: blur(18px) saturate(200%);
   -webkit-backdrop-filter: blur(18px) saturate(200%);
   border-color: rgba(255, 240, 228, 0.45);

--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -37,6 +37,7 @@ const IGNORE_SCROLL_MS = 400;
 // unlike the previous long-press + drag gesture carousel, whose
 // reimplemented touch physics reacted unpredictably.
 function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
+  const containerRef = useRef(null);
   const itemRefs = useRef([]);
   const collapseTimer = useRef(null);
   const ignoreScrollTimer = useRef(null);
@@ -75,8 +76,18 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   // Collapsing itself can trigger a spurious scroll event (see
   // IGNORE_SCROLL_MS above), so every path that collapses the carousel
   // goes through here rather than calling setExpanded(false) directly.
+  //
+  // Once collapsed, only the active pill remains (the rest shrink to
+  // max-width: 0), so the container's scroll position always ends up at
+  // 0. Left to itself the browser only clamps scrollLeft once the
+  // shrinking content can no longer contain it, and that clamp is an
+  // instant jump, not part of the width transition — most jarring for a
+  // pill that was scrolled deep into the middle (e.g. "Neue Rezepte",
+  // "Nach Bewertung"), since it has the furthest to snap back. Animating
+  // scrollLeft to 0 in step with the collapse avoids that jump.
   const collapseNow = useCallback(() => {
     suppressScroll();
+    containerRef.current?.scrollTo({ left: 0, behavior: 'smooth' });
     setExpanded(false);
   }, [suppressScroll]);
 
@@ -154,6 +165,7 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
 
   return (
     <div
+      ref={containerRef}
       className={`sort-carousel${expanded ? ' sort-carousel--expanded' : ''}`}
       role="tablist"
       aria-label="Sortierung"

--- a/src/components/SortCarousel.test.js
+++ b/src/components/SortCarousel.test.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import SortCarousel, { SORT_OPTIONS } from './SortCarousel';
 
-// JSDOM does not implement scrollIntoView — provide a no-op mock.
+// JSDOM does not implement scrollIntoView or scrollTo — provide no-op mocks.
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
+  Element.prototype.scrollTo = jest.fn();
 });
 
 describe('SortCarousel', () => {


### PR DESCRIPTION
Collapsing the carousel shrinks the inactive pills' max-width to 0,
which shrinks the scroll container's content until the browser
force-clamps scrollLeft back into range. That clamp is an instant
jump rather than part of the width transition, and it's worst for a
pill scrolled deep into the middle (e.g. "Neue Rezepte", "Nach
Bewertung"), since it has the furthest to snap back. Animate
scrollLeft to 0 in step with the collapse instead of leaving it to
the browser's abrupt correction.

Also give the active pill a fully white background instead of a
translucent one.