### PR TITLE
Add desktop delete button for drinks in event drink selection

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -228,7 +228,22 @@ function DrinkRow({
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <div className="events-drink-row-name">{displayName}</div>
+        <div className="events-drink-row-header">
+          <div className="events-drink-row-name">{displayName}</div>
+          <button
+            type="button"
+            className="events-drink-row-delete-btn"
+            onClick={onRemove}
+            aria-label={`${displayName} löschen`}
+            title="Getränk entfernen"
+          >
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
+          </button>
+        </div>
         <div className="events-drink-row-details">
           <div className="events-drink-row-einheiten">
             {einheiten.length > 1 ? (

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -139,6 +139,24 @@ describe('EventDrinkSelectionPage', () => {
     expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
   });
 
+  test('removes a drink via the always-visible desktop delete button, without swiping', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={['custom-wasser', 'custom-bier']}
+        guestPreferenceMultipliers={{}}
+        selectedGuestIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Wasser (eigen) löschen'));
+
+    expect(screen.queryByText('Wasser (eigen)', { selector: '.events-drink-row-name' })).not.toBeInTheDocument();
+    expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
+  });
+
   test('deletes drink when delete button receives touchstart before click (regression: touchend hid the button before click landed)', () => {
     render(
       <EventDrinkSelectionPage

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1366,10 +1366,51 @@
   padding: 16px;
 }
 
+.events-drink-row-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
 .events-drink-row-name {
   font-weight: 600;
-  margin-bottom: 8px;
   color: #2F5D50;
+}
+
+/* Delete button for desktop, where left-swipe-to-delete isn't available. */
+.events-drink-row-delete-btn {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #ececec;
+  background: white;
+  color: #b3261e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.events-drink-row-delete-btn:hover {
+  background: #fdecea;
+  border-color: #f3b7b1;
+}
+
+.events-drink-row-delete-btn .swipe-delete-icon-image {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}
+
+@media (min-width: 769px) {
+  .events-drink-row-delete-btn {
+    display: flex;
+  }
 }
 
 /* Grid (not flex) so the Mengen-input column has a fixed width and stays in

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -4172,6 +4172,17 @@
   color: #7fb8a3;
 }
 
+[data-theme="dark"] .events-drink-row-delete-btn {
+  background: #2a2a2a;
+  border-color: #555;
+  color: #e8837a;
+}
+
+[data-theme="dark"] .events-drink-row-delete-btn:hover {
+  background: #3a2323;
+  border-color: #6b3a35;
+}
+
 [data-theme="dark"] .events-drink-row-empty-label,
 [data-theme="dark"] .events-drink-row-single-unit {
   color: #999;


### PR DESCRIPTION
Left-swipe-to-delete only works via touch, leaving no way to remove a
drink in the desktop view. Add an always-visible delete button next to
each drink name, shown above the 768px breakpoint where swipe isn't
available.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X8qzbQG1KkNeGA9fLHhZch