### PR TITLE
fix: open menu detail view scrolled to top

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1307,6 +1307,9 @@ function App() {
   // Menu handlers
   const handleSelectMenu = (menu) => {
     setSelectedMenu(menu);
+    // Always open the menu detail view at the top, regardless of how far
+    // the menu overview had been scrolled.
+    window.scrollTo(0, 0);
   };
 
   const handleBackToMenuList = () => {


### PR DESCRIPTION
Selecting a menu from the overview reused the page's scroll position,
so opening a detail view after scrolling down in the list left the
detail view scrolled down too instead of starting at the top.