### PR TITLE
Move guest management button into adults/children row on event edit

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -358,28 +358,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
           </label>
         </div>
 
-        {guests.length > 0 && (
-          <div className="events-form-field">
-            <span>Gäste</span>
-            {selectedGuestIds.length > 0 ? (
-              <p className="events-info-text">
-                {selectedGuestIds.length} {selectedGuestIds.length === 1 ? 'Gast' : 'Gäste'} ausgewählt
-                {driverGuestIds.length > 0 ? `, ${driverGuestIds.length} Fahrer markiert` : ''}.
-              </p>
-            ) : (
-              <p className="events-info-text">Keine Gäste ausgewählt.</p>
-            )}
-            <button
-              type="button"
-              className="events-secondary-btn"
-              onClick={() => setShowGuestSelection(true)}
-            >
-              Gäste verwalten
-            </button>
-          </div>
-        )}
-
-        <div className="events-form-row">
+        <div className="events-form-row events-form-row--guests">
           <label className="events-form-field">
             <span>Erwachsene</span>
             <input
@@ -398,6 +377,29 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
               onChange={(e) => setChildren(e.target.value)}
             />
           </label>
+          {guests.length > 0 && (
+            <button
+              type="button"
+              className="events-secondary-btn events-guests-manage-btn"
+              onClick={() => setShowGuestSelection(true)}
+              aria-label="Gäste verwalten"
+              title="Gäste verwalten"
+            >
+              {isBase64Image(getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)) ? (
+                <img
+                  src={getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)}
+                  alt=""
+                  className="button-icon-image"
+                  draggable="false"
+                />
+              ) : (
+                <span className="events-guests-manage-btn-icon">
+                  {getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)}
+                </span>
+              )}
+              Gäste verwalten
+            </button>
+          )}
         </div>
 
         <div className="events-form-field">

--- a/src/components/EventForm.test.js
+++ b/src/components/EventForm.test.js
@@ -137,16 +137,6 @@ describe('EventForm', () => {
     expect(screen.queryByRole('button', { name: 'Gäste speichern' })).not.toBeInTheDocument();
   });
 
-  test('shows guest count summary after selecting guests', () => {
-    render(<EventForm onSaved={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'u1' }} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Gäste verwalten' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Gäste speichern' }));
-
-    expect(screen.getByText(/1 Gast ausgewählt/)).toBeInTheDocument();
-    expect(screen.getByText(/1 Fahrer markiert/)).toBeInTheDocument();
-  });
-
   test('counts child guests separately from adults after guest assignment', async () => {
     render(<EventForm onSaved={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'u1' }} />);
 

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -344,6 +344,29 @@
   min-width: 140px;
 }
 
+.events-form-row--guests {
+  align-items: flex-end;
+}
+
+.events-guests-manage-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.events-guests-manage-btn .button-icon-image {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+.events-guests-manage-btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
 .events-einheit-group {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Removes the "x Gäste ausgewählt" summary text from the event edit
form and relocates the "Gäste verwalten" button so it appears
right-aligned in the same row as the Erwachsene/Kinder quantity
fields, with the same edit icon used by the FAB edit button.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015RMGG1a3VLDBKgecBpmBHV