### PR TITLE
fix: privat badge auch für nicht öffentlich veröffentlichte Rezepte anzeigen

### DIFF
--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -2297,7 +2297,7 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
                   )}
                 </button>
                 )}
-                {recipe.isPrivate && (
+                {(recipe.isPrivate || !isRecipePublic) && (
                   <div className="private-badge-button" title="Unveröffentlichtes Rezept" aria-label="Unveröffentlichtes Rezept">
                     {isBase64Image(privateBadgeIcon) ? (
                       <img src={privateBadgeIcon} alt="Privat" className="button-icon-image" draggable="false" />


### PR DESCRIPTION
Das Badge reagierte bisher nur auf das Entwurfs-Flag (isPrivate), nicht
aber auf Rezepte, die zwar kein Entwurf sind, aber noch nicht aus einer
privaten Liste in die öffentliche Liste veröffentlicht wurden
(analog zu menu.privat in der Menüdetailansicht).