### PR TITLE
Fix label-input spacing inconsistency in event form

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1201,10 +1201,6 @@
     font-size: 16px;
   }
 
-  .events-form-row .events-form-field > span:first-child {
-    min-height: 2.4em;
-  }
-
   .events-category-checkbox {
     font-size: 16px;
   }


### PR DESCRIPTION
Remove mobile-only min-height on row field labels that made the gap
between label and input larger for Datum, Startuhrzeit, Dauer,
Erwachsene, and Kinder than for the Anlass field.