### PR TITLE
Gäste-verwalten-Button: nur Icon, Zeile erzwingt Einzeiligkeit

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -397,7 +397,6 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
                   {getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)}
                 </span>
               )}
-              Gäste verwalten
             </button>
           )}
         </div>

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -346,13 +346,20 @@
 
 .events-form-row--guests {
   align-items: flex-end;
+  flex-wrap: nowrap;
+}
+
+.events-form-row--guests .events-form-field {
+  min-width: 0;
 }
 
 .events-guests-manage-btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
   margin-left: auto;
+  padding: 12px;
+  flex: 0 0 auto;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Der Button zeigt jetzt nur noch das Icon (Text entfernt, aria-label/title
bleiben als zugänglicher Name erhalten). Die Reihe mit Erwachsene, Kinder
und dem Button bleibt per flex-wrap: nowrap immer einzeilig.