### PR TITLE
Vereinheitliche Feldhöhe der Event-Formularfelder

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -544,11 +544,13 @@
 
 .events-form-field input,
 .events-form-field select {
+  height: 44px;
   padding: 8px 16px;
   border: 1px solid #e2e2e2;
   border-radius: 8px;
   font-size: 16px;
   font-family: inherit;
+  line-height: 1.4;
 }
 
 .events-form-field input:focus,


### PR DESCRIPTION
Setzt eine feste Höhe (44px) für input- und select-Elemente im Eventformular, damit Text-, Datums-, Zeit-, Zahlen- und Auswahlfelder gleich hoch dargestellt werden.