### PR TITLE
Privat-Badge: Rahmenfarbe an Favoritenbutton angleichen, Touch veröffentlicht

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -274,12 +274,26 @@
   flex-shrink: 0;
 
   background: rgba(64, 44, 28, 0.9);
-  border: none !important;
+  border: 1px solid #DF7A00 !important;
   border-radius: 12px !important;
   color: #fff;
 
   line-height: 1;
   font-size: 1.4rem;
+}
+
+button.private-badge-button {
+  cursor: pointer;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.15s ease,
+    opacity 0.2s ease;
+}
+
+button.private-badge-button:active {
+  transform: scale(1.1);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  opacity: 0.2;
 }
 
 .private-badge-button .button-icon-image {

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -601,15 +601,29 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
               )
             )}
           </button>
-          {menu.privat && (
-            <div className="private-badge-button" title="Privates Menü" aria-label="Privates Menü">
-              {isBase64Image(privateBadgeIcon) ? (
-                <img src={privateBadgeIcon} alt="Privat" className="button-icon-image" draggable="false" />
-              ) : (
-                privateBadgeIcon
-              )}
-            </div>
-          )}
+          {menu.privat && (() => {
+            const badgeIcon = isBase64Image(privateBadgeIcon) ? (
+              <img src={privateBadgeIcon} alt="Privat" className="button-icon-image" draggable="false" />
+            ) : (
+              privateBadgeIcon
+            );
+            return canEdit && onPublish ? (
+              <button
+                type="button"
+                className="private-badge-button"
+                onClick={handlePublish}
+                disabled={publishLoading}
+                title="Menü veröffentlichen"
+                aria-label="Menü veröffentlichen"
+              >
+                {badgeIcon}
+              </button>
+            ) : (
+              <div className="private-badge-button" title="Privates Menü" aria-label="Privates Menü">
+                {badgeIcon}
+              </div>
+            );
+          })()}
           <button
             className="shopping-list-trigger-button"
             onClick={handleShoppingListClick}

--- a/src/components/RecipeDetail.css
+++ b/src/components/RecipeDetail.css
@@ -296,11 +296,25 @@
   flex-shrink: 0;
 
   background: #fff;
-  border: 1px solid #f0f0f0 !important;
+  border: 1px solid #DF7A00 !important;
   border-radius: 12px !important;
 
   line-height: 1;
   font-size: 1.4rem;
+}
+
+button.private-badge-button {
+  cursor: pointer;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.15s ease,
+    opacity 0.2s ease;
+}
+
+button.private-badge-button:active {
+  transform: scale(1.1);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  opacity: 0.2;
 }
 
 .private-badge-button .button-icon-image {

--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -2297,15 +2297,29 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
                   )}
                 </button>
                 )}
-                {(recipe.isPrivate || !isRecipePublic) && (
-                  <div className="private-badge-button" title="Unveröffentlichtes Rezept" aria-label="Unveröffentlichtes Rezept">
-                    {isBase64Image(privateBadgeIcon) ? (
-                      <img src={privateBadgeIcon} alt="Privat" className="button-icon-image" draggable="false" />
-                    ) : (
-                      privateBadgeIcon
-                    )}
-                  </div>
-                )}
+                {(recipe.isPrivate || !isRecipePublic) && (() => {
+                  const badgeIcon = isBase64Image(privateBadgeIcon) ? (
+                    <img src={privateBadgeIcon} alt="Privat" className="button-icon-image" draggable="false" />
+                  ) : (
+                    privateBadgeIcon
+                  );
+                  return userCanPublish && onPublish ? (
+                    <button
+                      type="button"
+                      className="private-badge-button"
+                      onClick={handlePublish}
+                      disabled={publishLoading}
+                      title="Rezept veröffentlichen"
+                      aria-label="Rezept veröffentlichen"
+                    >
+                      {badgeIcon}
+                    </button>
+                  ) : (
+                    <div className="private-badge-button" title="Unveröffentlichtes Rezept" aria-label="Unveröffentlichtes Rezept">
+                      {badgeIcon}
+                    </div>
+                  );
+                })()}
                 <button
                   className="shopping-list-trigger-button"
                   onClick={handleShoppingListClick}


### PR DESCRIPTION
Das Privat-Badge in Rezept- und Menüdetailansicht bekommt die Akzentfarbe
des aktiven Favoritenbuttons als Rahmenfarbe. Außerdem wird das Badge zum
Button: bei Berechtigung zum Veröffentlichen löst ein Touch/Klick darauf
den bestehenden Veröffentlichen-Flow aus.