### PR TITLE
Privat-Badge: grauen Rahmen statt Orange in Rezept- und Menüdetailansicht

### DIFF
--- a/src/components/MenuDetail.css
+++ b/src/components/MenuDetail.css
@@ -274,7 +274,7 @@
   flex-shrink: 0;
 
   background: rgba(64, 44, 28, 0.9);
-  border: 1px solid #DF7A00 !important;
+  border: 1px solid #f0f0f0 !important;
   border-radius: 12px !important;
   color: #fff;
 

--- a/src/components/RecipeDetail.css
+++ b/src/components/RecipeDetail.css
@@ -296,7 +296,7 @@
   flex-shrink: 0;
 
   background: #fff;
-  border: 1px solid #DF7A00 !important;
+  border: 1px solid #f0f0f0 !important;
   border-radius: 12px !important;
 
   line-height: 1;


### PR DESCRIPTION
Der Rahmen des Privat-Badges wurde zuvor auf die Akzentfarbe des aktiven
Favoritenbuttons (Orange) gesetzt. Jetzt verwendet er denselben grauen
Rahmen wie der (inaktive) Favoritenbutton.