### PR TITLE
Align date/time input height with other event form fields

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -560,6 +560,16 @@
   line-height: 1.4;
 }
 
+.events-form-field input[type="date"],
+.events-form-field input[type="time"] {
+  line-height: normal;
+}
+
+.events-form-field input[type="date"]::-webkit-date-and-time-value,
+.events-form-field input[type="time"]::-webkit-date-and-time-value {
+  text-align: left;
+}
+
 .events-form-field input:focus,
 .events-form-field select:focus,
 .events-guest-search-input:focus {


### PR DESCRIPTION
Chrome renders input[type=date]/type=time] with their own internal
line-height and calendar/clock-icon padding, making them visually
taller than the text/number/select fields at the same declared
height. Normalize line-height and align the native value text.