### PR TITLE
Fix guests-manage button background still showing gray

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -362,6 +362,9 @@
   flex: 0 0 auto;
   white-space: nowrap;
   height: 44px;
+}
+
+.events-secondary-btn.events-guests-manage-btn {
   background: transparent;
   border: 1px solid transparent;
 }


### PR DESCRIPTION
.events-secondary-btn (defined later in the stylesheet) was winning the
cascade over .events-guests-manage-btn since both had equal specificity.
Raise specificity with a combined selector so transparent bg/border wins.