### PR TITLE
fix: update recipe publish status immediately in detail view

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1075,6 +1075,9 @@ function App() {
 
     try {
       await updateRecipeInFirestore(recipeId, { publishedToPublic: true, publishedAt: serverTimestamp() });
+      if (selectedRecipe && selectedRecipe.id === recipeId) {
+        setSelectedRecipe({ ...selectedRecipe, publishedToPublic: true });
+      }
     } catch (error) {
       console.error('Error publishing recipe:', error);
       alert('Fehler beim Veröffentlichen des Rezepts. Bitte versuchen Sie es erneut.');


### PR DESCRIPTION
handlePublishRecipe only wrote publishedToPublic to Firestore without
updating the local selectedRecipe state, so the private badge in
RecipeDetail stayed visible until the detail view was reopened. Mirror
the existing handlePublishMenu pattern by updating selectedRecipe
right after the Firestore write.