### PR TITLE
Strip native appearance from Event date/time inputs

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -566,6 +566,8 @@
 .events-form-field input[type="date"],
 .events-form-field input[type="time"] {
   line-height: normal;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .events-form-field input[type="date"]::-webkit-date-and-time-value,


### PR DESCRIPTION
Safari renders input[type=date]/[type=time] with its platform-native
field control, which ignores the author height/padding and stays
taller than the other event form fields regardless of line-height
tweaks. appearance: none drops that native control so the fields fall
back to the same box model as the text/number inputs.