### PR TITLE
Move Puffer (%) field to the Getränke-verwalten page

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -7,6 +7,7 @@ import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 
 const MIN_DISTRIBUTION_FACTOR = 0.1;
 const MAX_DISTRIBUTION_FACTOR = 2.0;
+const DEFAULT_PUFFER_PROZENT = 25;
 
 const normalizeDistributionFactor = (value) => {
   const parsed = Number(value);
@@ -295,6 +296,7 @@ function EventDrinkSelectionPage({
   customDrinkIds: initialCustomDrinkIds,
   drinkDistributionFactors: initialDrinkDistributionFactors,
   drinkSelectedEinheiten: initialDrinkSelectedEinheiten,
+  pufferProzent: initialPufferProzent,
   recipes,
   onSave,
   onBack,
@@ -310,6 +312,7 @@ function EventDrinkSelectionPage({
   const [drinkSelectedEinheiten, setDrinkSelectedEinheiten] = useState(() =>
     buildInitialSelectedEinheiten(customDrinks, initialCustomDrinkIds, initialDrinkSelectedEinheiten),
   );
+  const [pufferProzent, setPufferProzent] = useState(initialPufferProzent ?? DEFAULT_PUFFER_PROZENT);
   const [drinkToAdd, setDrinkToAdd] = useState('');
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
   const [fabPressed, setFabPressed] = useState(false);
@@ -364,7 +367,7 @@ function EventDrinkSelectionPage({
       }
       return acc;
     }, {});
-    onSave(customDrinkIds, optimizedFactors, optimizedEinheiten);
+    onSave(customDrinkIds, optimizedFactors, optimizedEinheiten, Number(pufferProzent));
   };
 
   const selectedDrinks = customDrinks.filter((d) => customDrinkIds.includes(d.id));
@@ -458,6 +461,17 @@ function EventDrinkSelectionPage({
             {customDrinkIds.length} {customDrinkIds.length === 1 ? 'Getränk' : 'Getränke'} ausgewählt.
           </span>
         </div>
+
+        <label className="events-form-field">
+          <span>Puffer (%)</span>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={pufferProzent}
+            onChange={(e) => setPufferProzent(e.target.value)}
+          />
+        </label>
 
         <div className="events-form-actions">
           <button type="button" className="events-secondary-btn events-save-desktop-only" onClick={onBack}>

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -114,6 +114,7 @@ describe('EventDrinkSelectionPage', () => {
       ['custom-wasser', 'custom-bier'],
       { 'custom-wasser': 1.2 },
       {},
+      25,
     );
   });
 
@@ -245,7 +246,7 @@ describe('EventDrinkSelectionPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
-    expect(onSave).toHaveBeenCalledWith(['custom-wasser', 'custom-bier'], {}, {});
+    expect(onSave).toHaveBeenCalledWith(['custom-wasser', 'custom-bier'], {}, {}, 25);
   });
 
   test('uses default factor 1.0 for invalid values', () => {
@@ -266,7 +267,7 @@ describe('EventDrinkSelectionPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 
-    expect(onSave).toHaveBeenCalledWith(['custom-wasser'], {}, {});
+    expect(onSave).toHaveBeenCalledWith(['custom-wasser'], {}, {}, 25);
   });
 
   test('calls onBack when Abbrechen button is clicked', () => {
@@ -403,6 +404,7 @@ describe('EventDrinkSelectionPage', () => {
       ['custom-bier-multi'],
       {},
       { 'custom-bier-multi': [0, 1] },
+      25,
     );
   });
 
@@ -455,5 +457,50 @@ describe('EventDrinkSelectionPage', () => {
 
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
     expect(screen.getByText('1,0 l (Flasche)')).toBeInTheDocument();
+  });
+
+  test('shows Puffer (%) field with 25 as default', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Puffer (%)')).toHaveValue(25);
+  });
+
+  test('pre-populates Puffer (%) field from pufferProzent prop', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={[]}
+        pufferProzent={10}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Puffer (%)')).toHaveValue(10);
+  });
+
+  test('passes updated Puffer (%) value to onSave', () => {
+    const onSave = jest.fn();
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={['custom-wasser']}
+        pufferProzent={10}
+        onSave={onSave}
+        onBack={jest.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Puffer (%)'), { target: { value: '30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+    expect(onSave).toHaveBeenCalledWith(['custom-wasser'], {}, {}, 30);
   });
 });

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -286,13 +286,15 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         customDrinkIds={customDrinkIds}
         drinkDistributionFactors={drinkDistributionFactors}
         drinkSelectedEinheiten={drinkSelectedEinheiten}
+        pufferProzent={pufferProzent}
         recipes={recipes}
         buttonIcons={buttonIcons}
         isDarkMode={isDarkMode}
-        onSave={(newDrinkIds, newDrinkDistributionFactors, newDrinkSelectedEinheiten) => {
+        onSave={(newDrinkIds, newDrinkDistributionFactors, newDrinkSelectedEinheiten, newPufferProzent) => {
           setCustomDrinkIds(newDrinkIds);
           setDrinkDistributionFactors(newDrinkDistributionFactors || {});
           setDrinkSelectedEinheiten(newDrinkSelectedEinheiten || {});
+          setPufferProzent(newPufferProzent);
           setShowDrinkSelection(false);
         }}
         onBack={() => setShowDrinkSelection(false)}
@@ -404,7 +406,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         <div className="events-form-field">
           <span>Eigene Getränke</span>
           {customDrinks.length > 0 ? (
-            <>
+            <div className="events-form-row events-form-row--guests">
               {customDrinkIds.length > 0 ? (
                 <p className="events-info-text">
                   {customDrinkIds.length} {customDrinkIds.length === 1 ? 'Getränk' : 'Getränke'} ausgewählt
@@ -414,12 +416,25 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
               )}
               <button
                 type="button"
-                className="events-secondary-btn"
+                className="events-secondary-btn events-guests-manage-btn"
                 onClick={() => setShowDrinkSelection(true)}
+                aria-label="Getränke verwalten"
+                title="Getränke verwalten"
               >
-                Getränke verwalten
+                {isBase64Image(getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)) ? (
+                  <img
+                    src={getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)}
+                    alt=""
+                    className="button-icon-image"
+                    draggable="false"
+                  />
+                ) : (
+                  <span className="events-guests-manage-btn-icon">
+                    {getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode)}
+                  </span>
+                )}
               </button>
-            </>
+            </div>
           ) : (
             <p className="events-info-text">
               Noch keine eigenen Getränke angelegt.
@@ -438,17 +453,6 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
             </p>
           )}
         </div>
-
-        <label className="events-form-field">
-          <span>Puffer (%)</span>
-          <input
-            type="number"
-            min="0"
-            max="100"
-            value={pufferProzent}
-            onChange={(e) => setPufferProzent(e.target.value)}
-          />
-        </label>
 
         {error && <p className="events-error-text">{error}</p>}
 

--- a/src/components/EventForm.test.js
+++ b/src/components/EventForm.test.js
@@ -31,14 +31,21 @@ jest.mock('./EventGuestSelectionPage', () => function MockEventGuestSelectionPag
   );
 });
 
-jest.mock('./EventDrinkSelectionPage', () => function MockEventDrinkSelectionPage({ onSave, onBack }) {
+jest.mock('./EventDrinkSelectionPage', () => function MockEventDrinkSelectionPage({ onSave, onBack, pufferProzent }) {
   return (
     <div>
+      <span>Puffer-Weiterleitung: {pufferProzent}</span>
       <button
         type="button"
-        onClick={() => onSave(['custom-wasser'], { 'custom-wasser': 1.4 })}
+        onClick={() => onSave(['custom-wasser'], { 'custom-wasser': 1.4 }, undefined, pufferProzent)}
       >
         Getränke speichern
+      </button>
+      <button
+        type="button"
+        onClick={() => onSave(['custom-wasser'], {}, undefined, 50)}
+      >
+        Getränke mit neuem Puffer speichern
       </button>
       <button type="button" onClick={onBack}>Getränke abbrechen</button>
     </div>
@@ -214,10 +221,18 @@ describe('EventForm', () => {
     expect(screen.queryByRole('button', { name: 'Getränke verwalten' })).not.toBeInTheDocument();
   });
 
-  test('uses 25 percent as default puffer for new events', () => {
+  test('no longer shows the Puffer (%) field on the main event form', () => {
     render(<EventForm onSaved={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'u1' }} />);
 
-    expect(screen.getByLabelText('Puffer (%)')).toHaveValue(25);
+    expect(screen.queryByLabelText('Puffer (%)')).not.toBeInTheDocument();
+  });
+
+  test('passes default puffer of 25 percent to the Getränke verwalten sub-page for new events', () => {
+    render(<EventForm onSaved={jest.fn()} onCancel={jest.fn()} currentUser={{ id: 'u1' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Getränke verwalten' }));
+
+    expect(screen.getByText('Puffer-Weiterleitung: 25')).toBeInTheDocument();
   });
 
   test('shows mobile FAB buttons on the new event page', () => {
@@ -321,7 +336,9 @@ describe('EventForm', () => {
     expect(screen.getByLabelText('Startuhrzeit')).toHaveValue('14:30');
     expect(screen.getByLabelText('Erwachsene')).toHaveValue(8);
     expect(screen.getByLabelText('Kinder')).toHaveValue(2);
-    expect(screen.getByLabelText('Puffer (%)')).toHaveValue(10);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Getränke verwalten' }));
+    expect(screen.getByText('Puffer-Weiterleitung: 10')).toBeInTheDocument();
   });
 
   test('passes eventId to calculateEventDrinks when editing', async () => {
@@ -463,6 +480,21 @@ describe('EventForm', () => {
     const [event] = mockCalculateEventDrinks.mock.calls[0];
     expect(event.customDrinkIds).toEqual(['custom-wasser']);
     expect(event.drinkDistributionFactors).toEqual({ 'custom-wasser': 1.4 });
+  });
+
+  test('submits the puffer percent returned from the Getränke verwalten sub-page', async () => {
+    const onSaved = jest.fn();
+    render(<EventForm onSaved={onSaved} onCancel={jest.fn()} currentUser={{ id: 'u1' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Getränke verwalten' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Getränke mit neuem Puffer speichern' }));
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Sommerfest' } });
+    fireEvent.click(getInlineCalculateButton());
+
+    await waitFor(() => expect(mockCalculateEventDrinks).toHaveBeenCalledTimes(1));
+    const [event] = mockCalculateEventDrinks.mock.calls[0];
+    expect(event.pufferProzent).toBe(50);
   });
 
   test('removes a deleted drink from linked menus\' drinkIds on save', async () => {


### PR DESCRIPTION
The buffer percentage now lives on the per-event drink management
sub-page instead of the main event form, and the "Getränke verwalten"
button that opens it now matches the "Gäste verwalten" button's
icon-only, dark-mode-aware configuration.