### PR TITLE
Set 15-minute step on event start time picker

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -343,6 +343,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
               value={startTime}
               onChange={(e) => setStartTime(e.target.value)}
               aria-label="Startuhrzeit"
+              step="900"
             />
           </label>
           <label className="events-form-field">


### PR DESCRIPTION
Adds step="900" to the Startuhrzeit input so the native time picker
snaps to quarter-hour increments instead of every minute.