### PR TITLE
Privat-Badge sofort ausblenden statt auf Firestore-Antwort zu warten

### DIFF
--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -311,6 +311,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
     if (!onPublish) return;
     if (window.confirm(`Möchten Sie "${menu.name}" in der Liste "Öffentlich" veröffentlichen?`)) {
       setPublishLoading(true);
+      setMenu(prev => ({ ...prev, privat: false }));
       try {
         await onPublish(menu.id);
       } finally {

--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -727,6 +727,7 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
     if (!onPublish) return;
     if (window.confirm(`Möchten Sie "${recipe.title}" in der Liste "Öffentlich" veröffentlichen?`)) {
       setPublishLoading(true);
+      setSelectedRecipe(prev => ({ ...prev, publishedToPublic: true }));
       try {
         await onPublish(recipe.id);
       } finally {


### PR DESCRIPTION
Beim Antippen des Privat-Badges/Veröffentlichen-FAB wird der lokale
Rezept-/Menü-Status jetzt optimistisch aktualisiert, sodass Badge und
FAB sofort verschwinden statt erst nach dem Firestore-Roundtrip.