### PR TITLE
Sortier-Karussell standardmäßig eingeklappt starten lassen

### DIFF
--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -9,10 +9,6 @@ export const SORT_OPTIONS = [
   { id: 'index', label: 'Nach Relevanz' },
 ];
 
-// How long the carousel stays expanded on first mount, giving the user a
-// glance at all the options before it folds down to just the active pill.
-const MOUNT_COLLAPSE_DELAY_MS = 1400;
-
 // How long it stays expanded after the user picks an option, so the
 // selection is visible for a moment before the pill bar folds away.
 const SELECT_COLLAPSE_DELAY_MS = 900;
@@ -42,9 +38,9 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   const collapseTimer = useRef(null);
   const ignoreScrollTimer = useRef(null);
   const ignoreScroll = useRef(false);
-  // Starts expanded so the user sees all options at a glance, then folds
-  // down to the active pill on its own (see MOUNT_COLLAPSE_DELAY_MS below).
-  const [expanded, setExpanded] = useState(true);
+  // Starts collapsed, showing just the active pill, until the user swipes,
+  // taps, or focuses it (see the expand handlers below).
+  const [expanded, setExpanded] = useState(false);
 
   const activeIndex = SORT_OPTIONS.findIndex((o) => o.id === activeSort);
   const safeIndex = activeIndex >= 0 ? activeIndex : 0;
@@ -98,12 +94,6 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
     },
     [collapseNow]
   );
-
-  // Reveal all options briefly on mount, then fold down to the active pill.
-  useEffect(() => {
-    scheduleCollapse(MOUNT_COLLAPSE_DELAY_MS);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleSelect = useCallback(
     (id) => {

--- a/src/components/SortCarousel.test.js
+++ b/src/components/SortCarousel.test.js
@@ -87,23 +87,13 @@ describe('SortCarousel', () => {
       jest.useRealTimers();
     });
 
-    test('starts expanded, showing all pills, then folds down to the active pill on its own', () => {
+    test('starts collapsed, showing only the active pill', () => {
       render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
-      expect(screen.getByRole('tablist')).toHaveClass('sort-carousel--expanded');
-
-      act(() => {
-        jest.advanceTimersByTime(1400);
-      });
       expect(screen.getByRole('tablist')).not.toHaveClass('sort-carousel--expanded');
     });
 
     test('a native scroll event (the swipe gesture) expands the carousel', () => {
       render(<SortCarousel activeSort="alphabetical" onSortChange={() => {}} />);
-      // Past both the mount collapse (1400ms) and the scroll-suppression
-      // window it triggers (400ms), so this scroll reads as a real swipe.
-      act(() => {
-        jest.advanceTimersByTime(1800);
-      });
       expect(screen.getByRole('tablist')).not.toHaveClass('sort-carousel--expanded');
 
       fireEvent.scroll(screen.getByRole('tablist'));
@@ -113,9 +103,6 @@ describe('SortCarousel', () => {
     test('tapping the active pill toggles the expanded state without selecting', () => {
       const handleChange = jest.fn();
       render(<SortCarousel activeSort="alphabetical" onSortChange={handleChange} />);
-      act(() => {
-        jest.advanceTimersByTime(1400);
-      });
       const activeTab = screen.getByRole('tab', { name: 'Alphabetisch' });
 
       fireEvent.click(activeTab);


### PR DESCRIPTION
Die Sortierwanne (Sort-Karussell) in der Rezeptübersicht startete
bisher aufgeklappt und klappte erst nach 1,4s automatisch ein.
Sie startet jetzt direkt eingeklappt und zeigt nur die aktive Pille,
bis der Nutzer swipet, tippt oder fokussiert.