### PR TITLE
Admin sieht alle Events/Gäste/Getränke; Getränke-Bibliothek für alle sichtbar

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,5 +9,36 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "events",
+      "fieldPath": "date",
+      "indexes": [
+        {"order": "ASCENDING", "queryScope": "COLLECTION"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION"},
+        {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION_GROUP"}
+      ]
+    },
+    {
+      "collectionGroup": "customDrinks",
+      "fieldPath": "name",
+      "indexes": [
+        {"order": "ASCENDING", "queryScope": "COLLECTION"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION"},
+        {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION_GROUP"}
+      ]
+    },
+    {
+      "collectionGroup": "profiles",
+      "fieldPath": "nachname",
+      "indexes": [
+        {"order": "ASCENDING", "queryScope": "COLLECTION"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION"},
+        {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION_GROUP"}
+      ]
+    }
+  ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -174,14 +174,21 @@ service cloud.firestore {
       allow read, write: if isAuthenticated() && request.auth.uid == userId;
     }
 
-    // Event drink-calculation planning (Menüpunkt "Events")
+    // Event drink-calculation planning (Menüpunkt "Events").
+    // Admins may additionally read (but not write) any user's events, so they
+    // can see all events across the app.
     match /users/{userId}/events/{eventId} {
-      allow read, write: if isAuthenticated() && request.auth.uid == userId;
+      allow read: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
+      allow write: if isAuthenticated() && request.auth.uid == userId;
     }
 
-    // User-defined custom drinks library (reusable across events)
+    // User-defined custom drinks library (reusable across events).
+    // Readable by any recognised user – drinks are a shared library visible to
+    // everyone – but only the owner may create/update/delete their own entries,
+    // so existing drinks from other users cannot be edited, only newly added.
     match /users/{userId}/customDrinks/{drinkId} {
-      allow read, write: if isAuthenticated() && request.auth.uid == userId;
+      allow read: if isAnyUser();
+      allow write: if isAuthenticated() && request.auth.uid == userId;
     }
 
     // Reusable guest profiles for drink planning
@@ -192,9 +199,10 @@ service cloud.firestore {
 
     // Guest profiles (new data model):
     // /guests/{userId}/profiles/{guestId}
-    // Reads are limited to the owner; writes happen via Cloud Function (Admin SDK).
+    // Reads are limited to the owner, plus admins who may read (but not write)
+    // any user's guest profiles. Writes happen via Cloud Function (Admin SDK).
     match /guests/{userId}/profiles/{guestId} {
-      allow read: if isAuthenticated() && request.auth.uid == userId;
+      allow read: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
       allow write: if false;
     }
 

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import './EventsPage.css';
-import { subscribeToCustomDrinks, saveCustomDrink, deleteCustomDrink } from '../utils/eventsFirestore';
+import { subscribeToAllCustomDrinks, saveCustomDrink, deleteCustomDrink } from '../utils/eventsFirestore';
 import OverviewAddFab from './OverviewAddFab';
 import RecipeTypeahead from './RecipeTypeahead';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel, mergePredefinedDrinks } from '../utils/drinkCategories';
 import { getCustomLists, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
+import { getUsers } from '../utils/userManagement';
 import { isBase64Image } from '../utils/imageUtils';
 import { encodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
@@ -92,7 +93,7 @@ const emptyForm = () => ({
   einheiten: [emptyEinheit()],
 });
 
-function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
+function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, swipeDeleteIcon }) {
   const touchStartXRef = React.useRef(null);
   const touchStartYRef = React.useRef(null);
   const swipeDirectionLockedRef = React.useRef(null);
@@ -115,7 +116,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
 
   const handleTouchStart = (e) => {
     const touch = e.touches?.[0];
-    if (!touch || drink.predefined) return;
+    if (!touch || drink.predefined || !canManage) return;
     if (isDeleteVisible) setIsDeleteVisible(false);
     touchStartXRef.current = touch.clientX;
     touchStartYRef.current = touch.clientY;
@@ -125,7 +126,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
 
   const handleTouchMove = (e) => {
     const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || drink.predefined) return;
+    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || drink.predefined || !canManage) return;
 
     const deltaX = touch.clientX - touchStartXRef.current;
     const deltaY = touch.clientY - touchStartYRef.current;
@@ -159,7 +160,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
       className={`drink-list-item events-card${effectiveOffset < 0 ? ' swipe-delete-active' : ''}`}
       style={{ padding: 0 }}
     >
-      {!drink.predefined && (
+      {!drink.predefined && canManage && (
         <div className="drink-swipe-delete-background" aria-hidden={!isDeleteVisible}>
           {isDeleteVisible && (
             <button
@@ -180,7 +181,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
       <div
         className="drink-swipe-content events-card-main"
         style={{ transform: `translateX(${effectiveOffset}px)`, padding: '16px 20px', width: '100%' }}
-        onClick={effectiveOffset < 0 ? undefined : () => onEdit(drink)}
+        onClick={effectiveOffset < 0 || !canManage ? undefined : () => onEdit(drink)}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
@@ -195,6 +196,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
                   .map((e) => getUnitSizeLabel(e.einheitsgroesse) || String(e.einheitsgroesse))
                   .join(', ')
               : null,
+            !canManage && ownerName ? `von ${ownerName}` : null,
           ].filter(Boolean).join(' · ')}
         </p>
       </div>
@@ -204,6 +206,7 @@ function DrinkRow({ drink, displayName, onEdit, onDelete, swipeDeleteIcon }) {
 
 function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [drinks, setDrinks] = useState([]);
+  const [allUsers, setAllUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editId, setEditId] = useState(null);
@@ -243,13 +246,16 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   }, []);
 
   useEffect(() => {
-    if (!currentUser?.id) return undefined;
-    const unsubscribe = subscribeToCustomDrinks(currentUser.id, (loaded) => {
+    getUsers().then(setAllUsers).catch(() => setAllUsers([]));
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAllCustomDrinks((loaded) => {
       setDrinks(loaded);
       setLoading(false);
     });
     return unsubscribe;
-  }, [currentUser?.id]);
+  }, []);
 
   useEffect(() => {
     const timeouts = deleteBannerTimeoutsRef.current;
@@ -263,8 +269,15 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     () => (Array.isArray(recipes) ? recipes.filter(isDrinkRecipe) : []),
     [recipes]
   );
-  const allDrinks = useMemo(() => mergePredefinedDrinks(drinks), [drinks]);
+  const allDrinks = useMemo(
+    () => mergePredefinedDrinks(drinks, currentUser?.id),
+    [drinks, currentUser?.id]
+  );
   const groupedDrinks = useMemo(() => groupDrinksByCategory(allDrinks, recipes), [allDrinks, recipes]);
+  const getOwnerFirstName = (ownerId) => {
+    if (!ownerId) return null;
+    return allUsers.find((u) => u.id === ownerId)?.vorname || null;
+  };
 
   const nameDrinkDisplay = resolveDrinkDisplay(form.name, recipes);
 
@@ -730,9 +743,11 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
               <h3 className="drink-category-group-header">{group.label}</h3>
               {group.drinks.map((drink) => (
                 <DrinkRow
-                  key={drink.id}
+                  key={`${drink.ownerId || ''}_${drink.id}`}
                   drink={drink}
                   displayName={resolveDrinkDisplay(drink, recipes).displayName}
+                  ownerName={getOwnerFirstName(drink.ownerId)}
+                  canManage={drink.predefined || !drink.ownerId || drink.ownerId === currentUser?.id}
                   onEdit={openEdit}
                   onDelete={handleDelete}
                   swipeDeleteIcon={swipeDeleteIcon}
@@ -741,7 +756,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             </div>
           ))}
           {drinks.length === 0 && (
-            <p className="events-info-text">Noch keine eigenen Getränke angelegt.</p>
+            <p className="events-info-text">Noch keine Getränke angelegt.</p>
           )}
         </div>
       )}

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -2,16 +2,20 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import DrinkManagementPage from './DrinkManagementPage';
 
-const mockSubscribeToCustomDrinks = jest.fn();
+const mockSubscribeToAllCustomDrinks = jest.fn();
 const mockSaveCustomDrink = jest.fn();
 const mockDeleteCustomDrink = jest.fn();
 const mockGetCustomLists = jest.fn();
 const mockUpdateRecipe = jest.fn();
 
 jest.mock('../utils/eventsFirestore', () => ({
-  subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
+  subscribeToAllCustomDrinks: (...args) => mockSubscribeToAllCustomDrinks(...args),
   saveCustomDrink: (...args) => mockSaveCustomDrink(...args),
   deleteCustomDrink: (...args) => mockDeleteCustomDrink(...args),
+}));
+
+jest.mock('../utils/userManagement', () => ({
+  getUsers: () => Promise.resolve([]),
 }));
 
 jest.mock('../utils/recipeFirestore', () => ({
@@ -35,7 +39,7 @@ describe('DrinkManagementPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([]);
       return jest.fn();
     });
@@ -96,7 +100,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('displays Weißwein subcategory label in drink list', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'd1', name: 'Riesling', kategorie: 'wein_weisswein' }]);
       return jest.fn();
     });
@@ -107,7 +111,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('displays Kölsch subcategory label in drink list', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'd2', name: 'Dom Kölsch', kategorie: 'bier_koelsch' }]);
       return jest.fn();
     });
@@ -118,7 +122,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('drink list is grouped by category and sorted by name within each group', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([
         { id: 'd1', name: 'Cola', kategorie: 'softdrinks' },
         { id: 'd2', name: 'Rotwein Trocken', kategorie: 'wein_rotwein' },
@@ -146,7 +150,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('drinks without a category are grouped under "Ohne Kategorie"', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'd1', name: 'Mystery Drink', kategorie: '' }]);
       return jest.fn();
     });
@@ -314,7 +318,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('displays einheiten info in the drink list card', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{
         id: 'd1',
         name: 'Craft-Bier',
@@ -472,7 +476,7 @@ describe('DrinkManagementPage', () => {
   });
 
   test('predefined Mineralwasser row uses persisted data when a custom document exists', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{
         id: 'predefined_mineralwasser',
         name: 'Mineralwasser',
@@ -608,7 +612,7 @@ describe('DrinkManagementPage', () => {
     });
 
     test('the drink list shows the linked recipe name instead of the raw link', () => {
-      mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
         return jest.fn();
       });
@@ -634,7 +638,7 @@ describe('DrinkManagementPage', () => {
       ];
 
       test('shows the ingredients of the linked recipe with amount and unit', () => {
-        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+        mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
           cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
           return jest.fn();
         });
@@ -652,7 +656,7 @@ describe('DrinkManagementPage', () => {
       });
 
       test('does not show an ingredient list for a normal (non-recipe) drink', () => {
-        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+        mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
           cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
           return jest.fn();
         });
@@ -665,7 +669,7 @@ describe('DrinkManagementPage', () => {
       });
 
       test('toggling an ingredient persists includedInCalculation on the recipe document', async () => {
-        mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+        mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
           cb([{ id: 'd1', name: '#recipe:r1:Mojito', kategorie: 'longdrink', einheiten: [] }]);
           return jest.fn();
         });
@@ -713,7 +717,7 @@ describe('DrinkManagementPage', () => {
     });
 
     test('swipe-delete button appears after swiping a custom drink left', async () => {
-      mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
         return jest.fn();
       });
@@ -734,7 +738,7 @@ describe('DrinkManagementPage', () => {
 
     test('clicking swipe-delete button calls deleteCustomDrink', async () => {
       mockDeleteCustomDrink.mockResolvedValue(undefined);
-      mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
         return jest.fn();
       });
@@ -759,7 +763,7 @@ describe('DrinkManagementPage', () => {
 
     test('delete banner appears after deleting a drink', async () => {
       mockDeleteCustomDrink.mockResolvedValue(undefined);
-      mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
         return jest.fn();
       });
@@ -783,6 +787,39 @@ describe('DrinkManagementPage', () => {
       render(<DrinkManagementPage currentUser={currentUser} />);
 
       expect(screen.queryByRole('button', { name: /Mineralwasser löschen/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('shared library across users', () => {
+    test('shows drinks from other users but does not allow editing or deleting them', () => {
+      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
+        cb([
+          { id: 'd1', name: 'Eigenes Bier', kategorie: 'bier', einheiten: [], ownerId: 'u1' },
+          { id: 'd2', name: 'Papas Wein', kategorie: 'wein', einheiten: [], ownerId: 'u2' },
+        ]);
+        return jest.fn();
+      });
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+
+      expect(screen.getByText('Eigenes Bier')).toBeInTheDocument();
+      expect(screen.getByText('Papas Wein')).toBeInTheDocument();
+
+      // Own drink stays editable.
+      fireEvent.click(screen.getByText('Eigenes Bier'));
+      expect(screen.getByRole('heading', { level: 2, name: 'Getränk bearbeiten' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
+
+      // Someone else's drink is not clickable into the edit form.
+      fireEvent.click(screen.getByText('Papas Wein'));
+      expect(screen.queryByRole('heading', { level: 2, name: 'Getränk bearbeiten' })).not.toBeInTheDocument();
+
+      // Someone else's drink can't be swiped open for deletion either.
+      const othersDrinkContent = screen.getByText('Papas Wein').closest('.drink-swipe-content');
+      fireEvent.touchStart(othersDrinkContent, { touches: [{ clientX: 200, clientY: 100 }], cancelable: false, preventDefault: jest.fn() });
+      fireEvent.touchMove(othersDrinkContent, { touches: [{ clientX: 130, clientY: 100 }], cancelable: false, preventDefault: jest.fn() });
+      fireEvent.touchEnd(othersDrinkContent, {});
+      expect(screen.queryByRole('button', { name: 'Papas Wein löschen' })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -4,7 +4,7 @@ import {
   EVENT_TYPES,
   deriveSeason,
   calculateEventDrinks,
-  subscribeToCustomDrinks,
+  subscribeToAllCustomDrinks,
   subscribeToGuestProfiles,
 } from '../utils/eventsFirestore';
 import { getMenusByEventId, updateMenu } from '../utils/menuFirestore';
@@ -93,7 +93,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   useEffect(() => {
     if (!currentUser?.id) return undefined;
     const unsubGuests = subscribeToGuestProfiles(currentUser.id, setGuests);
-    const unsubDrinks = subscribeToCustomDrinks(currentUser.id, (drinks) => {
+    const unsubDrinks = subscribeToAllCustomDrinks((drinks) => {
       setCustomDrinks(drinks);
       // Auto-select only Mineralwasser for new events
       setCustomDrinkIds((prev) => {
@@ -134,8 +134,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   );
 
   const guestPreferenceMultipliers = useMemo(
-    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks), driverGuestIds),
-    [selectedGuests, customDrinks, driverGuestIds],
+    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks, currentUser?.id), driverGuestIds),
+    [selectedGuests, customDrinks, driverGuestIds, currentUser?.id],
   );
 
   useEffect(() => {
@@ -162,7 +162,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
     setSaving(true);
     setError('');
     try {
-      const allDrinks = mergePredefinedDrinks(customDrinks);
+      const allDrinks = mergePredefinedDrinks(customDrinks, currentUser?.id);
       const categories = [...new Set(
         customDrinkIds
           .map((drinkId) => allDrinks.find((drink) => drink.id === drinkId)?.kategorie)
@@ -284,7 +284,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   if (showDrinkSelection) {
     return (
       <EventDrinkSelectionPage
-        customDrinks={mergePredefinedDrinks(customDrinks)}
+        customDrinks={mergePredefinedDrinks(customDrinks, currentUser?.id)}
         customDrinkIds={customDrinkIds}
         drinkDistributionFactors={drinkDistributionFactors}
         drinkSelectedEinheiten={drinkSelectedEinheiten}

--- a/src/components/EventForm.test.js
+++ b/src/components/EventForm.test.js
@@ -4,7 +4,7 @@ import EventForm from './EventForm';
 
 const mockCalculateEventDrinks = jest.fn();
 const mockSubscribeToGuestProfiles = jest.fn();
-const mockSubscribeToCustomDrinks = jest.fn();
+const mockSubscribeToAllCustomDrinks = jest.fn();
 const mockGetMenusByEventId = jest.fn();
 const mockUpdateMenu = jest.fn();
 
@@ -13,7 +13,7 @@ jest.mock('../utils/eventsFirestore', () => ({
   deriveSeason: jest.fn(() => 'sommer'),
   calculateEventDrinks: (...args) => mockCalculateEventDrinks(...args),
   subscribeToGuestProfiles: (...args) => mockSubscribeToGuestProfiles(...args),
-  subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
+  subscribeToAllCustomDrinks: (...args) => mockSubscribeToAllCustomDrinks(...args),
 }));
 
 jest.mock('../utils/menuFirestore', () => ({
@@ -82,7 +82,7 @@ describe('EventForm', () => {
       ]);
       return jest.fn();
     });
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([
         { id: 'custom-wasser', name: 'Wasser (eigen)', kategorie: 'wasser' },
         { id: 'custom-bier', name: 'Bier (eigen)', kategorie: 'bier_alkoholfrei' },
@@ -177,7 +177,7 @@ describe('EventForm', () => {
   });
 
   test('shows Getränke verwalten link when no custom drinks and onManageDrinks is provided', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([]);
       return jest.fn();
     });
@@ -212,7 +212,7 @@ describe('EventForm', () => {
   });
 
   test('does not show Getränke verwalten link when onManageDrinks is not provided', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([]);
       return jest.fn();
     });
@@ -542,7 +542,7 @@ describe('EventForm', () => {
 
   test('removes a deleted drink recipe from linked menus\' recipeIds on save', async () => {
     const onSaved = jest.fn();
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([
         { id: 'custom-wasser', name: 'Wasser (eigen)', kategorie: 'wasser' },
         { id: 'custom-bier-rezept', name: '#recipe:recipe-1:Craft Bier', kategorie: 'bier' },

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import './EventsPage.css';
-import { subscribeToEvents, deleteEvent, getEvent } from '../utils/eventsFirestore';
+import { subscribeToEvents, subscribeToAllEvents, deleteEvent, getEvent } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS, EVENT_TYPE_LABELS } from './EventForm';
 import EventForm from './EventForm';
 import ConsumptionForm from './ConsumptionForm';
 import DrinkManagementPage from './DrinkManagementPage';
 import GuestManagementPage from './GuestManagementPage';
 import OverviewAddFab from './OverviewAddFab';
-import { canEditRecipes } from '../utils/userManagement';
+import { canEditRecipes, getUsers } from '../utils/userManagement';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
@@ -103,7 +103,14 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   // Drinks section, so closing it can return to that menu instead of the events list.
   const [openedFromMenuLink, setOpenedFromMenuLink] = useState(() => !!pendingEventDetailRequest?.eventId);
   const [selectedEventId, setSelectedEventId] = useState(null);
+  const [selectedEventOwnerId, setSelectedEventOwnerId] = useState(currentUser?.id ?? null);
   const [fallbackEvent, setFallbackEvent] = useState(null); // used right after calculation, before onSnapshot syncs
+  // Admin-only: browse all users' events instead of just the current user's own.
+  const isAdmin = currentUser?.isAdmin === true;
+  const [showAllEvents, setShowAllEvents] = useState(false);
+  const [allEvents, setAllEvents] = useState([]);
+  const [allEventsLoading, setAllEventsLoading] = useState(true);
+  const [allUsers, setAllUsers] = useState([]);
 
   useEffect(() => {
     const handleResize = () => setIsMobileView(window.innerWidth <= 768);
@@ -138,6 +145,20 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     return unsubscribe;
   }, [currentUser?.id]);
 
+  useEffect(() => {
+    if (!isAdmin) return;
+    getUsers().then(setAllUsers).catch(() => setAllUsers([]));
+  }, [isAdmin]);
+
+  useEffect(() => {
+    if (!isAdmin || !showAllEvents) return undefined;
+    const unsubscribe = subscribeToAllEvents((loadedEvents) => {
+      setAllEvents(loadedEvents);
+      setAllEventsLoading(false);
+    });
+    return unsubscribe;
+  }, [isAdmin, showAllEvents]);
+
   // Deep link from a push notification: jump straight to the consumption form.
   useEffect(() => {
     if (!pendingEventReminderId || !currentUser?.id) return;
@@ -150,6 +171,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       }
       setFallbackEvent(event);
       setSelectedEventId(event.id);
+      setSelectedEventOwnerId(currentUser.id);
       setSubView('consumption');
     });
     onPendingEventReminderHandled?.();
@@ -177,6 +199,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       } else {
         setFallbackEvent(event);
         setSelectedEventId(event.id);
+        setSelectedEventOwnerId(ownerId);
         setSubView('detail');
       }
       // Clearing the request (via the parent's state) is deferred until here,
@@ -194,20 +217,30 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   }, [pendingEventDetailRequest]);
 
   const selectedEvent = useMemo(() => {
-    return events.find((e) => e.id === selectedEventId) || fallbackEvent || null;
-  }, [events, selectedEventId, fallbackEvent]);
+    return events.find((e) => e.id === selectedEventId)
+      || allEvents.find((e) => e.id === selectedEventId)
+      || fallbackEvent
+      || null;
+  }, [events, allEvents, selectedEventId, fallbackEvent]);
+  const isOwnEvent = selectedEventOwnerId === currentUser?.id;
+  const getOwnerFirstName = (ownerId) => {
+    if (!ownerId) return null;
+    return allUsers.find((u) => u.id === ownerId)?.vorname || null;
+  };
   const editEventIcon = getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode);
   const eventsCloseIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
-  const handleSelectEvent = (event) => {
+  const handleSelectEvent = (event, ownerId = currentUser?.id) => {
     setOpenedFromMenuLink(false);
     setSelectedEventId(event.id);
+    setSelectedEventOwnerId(ownerId);
     setFallbackEvent(event);
     setSubView('detail');
   };
 
   const handleEventSaved = (eventId) => {
     setSelectedEventId(eventId);
+    setSelectedEventOwnerId(currentUser?.id);
     setFallbackEvent(null);
     setSubView('detail');
   };
@@ -256,7 +289,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     );
   }
 
-  if (subView === 'edit' && selectedEvent) {
+  if (subView === 'edit' && selectedEvent && isOwnEvent) {
     return (
       <EventForm
         onSaved={handleEventSaved}
@@ -270,7 +303,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     );
   }
 
-  if (subView === 'consumption' && selectedEvent) {
+  if (subView === 'consumption' && selectedEvent && isOwnEvent) {
     return (
       <ConsumptionForm
         event={selectedEvent}
@@ -333,6 +366,9 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             {driverGuestIds.length > 0 && (
               <span>Fahrer: {driverNames.join(', ')}</span>
             )}
+            {!isOwnEvent && getOwnerFirstName(selectedEventOwnerId) && (
+              <span>von {getOwnerFirstName(selectedEventOwnerId)}</span>
+            )}
           </div>
 
           {berechnung?.warnungen?.length > 0 && (
@@ -389,28 +425,30 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             </>
           )}
 
-          <div className="events-form-actions">
-            {(selectedEvent.status === 'berechnet' || selectedEvent.status === 'eingekauft') && (
-              <button
-                type="button"
-                className="events-primary-btn"
-                onClick={() => setSubView('consumption')}
-              >
-                Einkauf & Verbrauch
-              </button>
-            )}
-            {!isMobileView && (
-              <button
-                type="button"
-                className="events-secondary-btn"
-                onClick={() => setSubView('edit')}
-              >
-                Bearbeiten
-              </button>
-            )}
-          </div>
+          {isOwnEvent && (
+            <div className="events-form-actions">
+              {(selectedEvent.status === 'berechnet' || selectedEvent.status === 'eingekauft') && (
+                <button
+                  type="button"
+                  className="events-primary-btn"
+                  onClick={() => setSubView('consumption')}
+                >
+                  Einkauf & Verbrauch
+                </button>
+              )}
+              {!isMobileView && (
+                <button
+                  type="button"
+                  className="events-secondary-btn"
+                  onClick={() => setSubView('edit')}
+                >
+                  Bearbeiten
+                </button>
+              )}
+            </div>
+          )}
         </div>
-        {isMobileView && (
+        {isOwnEvent && isMobileView && (
           <button
             type="button"
             className={`edit-fab-button events-edit-fab-button${editFabPressed ? ' pressed' : ''}`}
@@ -476,7 +514,58 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         )}
       </div>
 
-      {loading ? (
+      {isAdmin && (
+        <div className="events-manage-links">
+          <button
+            type="button"
+            className="events-manage-link-btn"
+            aria-pressed={!showAllEvents}
+            onClick={() => setShowAllEvents(false)}
+          >
+            Meine Events
+          </button>
+          <button
+            type="button"
+            className="events-manage-link-btn"
+            aria-pressed={showAllEvents}
+            onClick={() => setShowAllEvents(true)}
+          >
+            Alle Anwender
+          </button>
+        </div>
+      )}
+
+      {showAllEvents && isAdmin ? (
+        allEventsLoading ? (
+          <div className="events-empty-state">Laden...</div>
+        ) : allEvents.length === 0 ? (
+          <div className="events-empty-state">
+            <p>Keine Events vorhanden.</p>
+          </div>
+        ) : (
+          <div className="events-list">
+            {allEvents.map((event) => {
+              const ownerName = getOwnerFirstName(event.ownerId);
+              return (
+                <div key={`${event.ownerId}_${event.id}`} className="events-card" onClick={() => handleSelectEvent(event, event.ownerId)}>
+                  <div className="events-card-main">
+                    <h3>{event.eventName}</h3>
+                    <div className="events-card-meta-row">
+                      <p className="events-card-meta">
+                        {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
+                        {ownerName ? ` · von ${ownerName}` : ''}
+                      </p>
+                      <span className={`events-status-badge events-status-${event.status}`}>
+                        {STATUS_LABELS[event.status] || event.status}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )
+      ) : loading ? (
         <div className="events-empty-state">Laden...</div>
       ) : events.length === 0 ? (
         <div className="events-empty-state">

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -3,11 +3,13 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import EventsPage from './EventsPage';
 
 const mockSubscribeToEvents = jest.fn();
+const mockSubscribeToAllEvents = jest.fn();
 const mockDeleteEvent = jest.fn();
 const mockGetEvent = jest.fn();
 
 jest.mock('../utils/eventsFirestore', () => ({
   subscribeToEvents: (...args) => mockSubscribeToEvents(...args),
+  subscribeToAllEvents: (...args) => mockSubscribeToAllEvents(...args),
   deleteEvent: (...args) => mockDeleteEvent(...args),
   getEvent: (...args) => mockGetEvent(...args),
 }));
@@ -40,6 +42,7 @@ jest.mock('./GuestManagementPage', () => function MockGuestManagementPage() {
 
 jest.mock('../utils/userManagement', () => ({
   canEditRecipes: () => true,
+  getUsers: () => Promise.resolve([]),
 }));
 
 jest.mock('../utils/customLists', () => ({
@@ -65,6 +68,10 @@ describe('EventsPage', () => {
       return jest.fn();
     });
     mockGetEvent.mockResolvedValue(null);
+    mockSubscribeToAllEvents.mockImplementation((cb) => {
+      cb([]);
+      return jest.fn();
+    });
   });
 
   afterAll(() => {
@@ -583,5 +590,44 @@ describe('EventsPage', () => {
 
     expect(screen.getAllByText('Craft Bier')).toHaveLength(2);
     expect(screen.getByText('15,5 l')).toBeInTheDocument();
+  });
+
+  describe('admin cross-user event visibility', () => {
+    const adminUser = { id: 'admin1', isAdmin: true };
+
+    test('non-admins do not see the "Alle Anwender" toggle', () => {
+      render(<EventsPage currentUser={currentUser} />);
+      expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
+    });
+
+    test('admin can switch to "Alle Anwender" and open another user\'s event read-only', async () => {
+      const othersEvent = {
+        id: 'e1',
+        eventName: 'Fremdes Fest',
+        date: '2025-07-01',
+        durationHours: 4,
+        eventType: 'party',
+        status: 'berechnet',
+        guests: { adults: 10, children: 0 },
+        berechnung: { ergebnis: [] },
+        ownerId: 'other-user',
+      };
+      mockSubscribeToAllEvents.mockImplementation((cb) => {
+        cb([othersEvent]);
+        return jest.fn();
+      });
+
+      render(<EventsPage currentUser={adminUser} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
+      expect(await screen.findByText('Fremdes Fest')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Fremdes Fest'));
+
+      expect(await screen.findByRole('heading', { name: 'Fremdes Fest' })).toBeInTheDocument();
+      // Read-only: no edit affordances for another user's event.
+      expect(screen.queryByRole('button', { name: 'Bearbeiten' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Event bearbeiten' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -3,11 +3,12 @@ import './EventsPage.css';
 import OverviewAddFab from './OverviewAddFab';
 import {
   subscribeToGuestProfiles,
+  subscribeToAllGuestProfiles,
   saveGuestProfile,
   deleteGuestProfile,
-  subscribeToCustomDrinks,
+  subscribeToAllCustomDrinks,
 } from '../utils/eventsFirestore';
-import { canEditRecipes } from '../utils/userManagement';
+import { canEditRecipes, getUsers } from '../utils/userManagement';
 import { getGuestDisplayName, normalizePreferenceFactor } from '../utils/guestPreferences';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel } from '../utils/drinkCategories';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
@@ -53,6 +54,32 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   const canManageGuests = canEditRecipes(currentUser);
   const closeIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
+  // Admin-only: browse all users' guest profiles instead of just the current user's own.
+  const isAdmin = currentUser?.isAdmin === true;
+  const [showAllGuests, setShowAllGuests] = useState(false);
+  const [allProfiles, setAllProfiles] = useState([]);
+  const [allProfilesLoading, setAllProfilesLoading] = useState(true);
+  const [allUsers, setAllUsers] = useState([]);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    getUsers().then(setAllUsers).catch(() => setAllUsers([]));
+  }, [isAdmin]);
+
+  useEffect(() => {
+    if (!isAdmin || !showAllGuests) return undefined;
+    const unsubscribe = subscribeToAllGuestProfiles((loaded) => {
+      setAllProfiles(loaded);
+      setAllProfilesLoading(false);
+    });
+    return unsubscribe;
+  }, [isAdmin, showAllGuests]);
+
+  const getOwnerFirstName = (ownerId) => {
+    if (!ownerId) return null;
+    return allUsers.find((u) => u.id === ownerId)?.vorname || null;
+  };
+
   useEffect(() => {
     const loadIcons = async () => {
       const icons = await getButtonIcons();
@@ -73,7 +100,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
       setProfiles(loaded);
       setLoading(false);
     });
-    const unsubscribeDrinks = subscribeToCustomDrinks(currentUser.id, setCustomDrinks);
+    const unsubscribeDrinks = subscribeToAllCustomDrinks(setCustomDrinks);
     return () => {
       unsubscribeProfiles();
       unsubscribeDrinks();
@@ -81,16 +108,26 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   }, [currentUser?.id]);
 
   const availableDrinks = useMemo(() => {
-    return customDrinks.map((drink) => ({ id: drink.id, label: resolveDrinkDisplay(drink, recipes).displayName || drink.id }));
-  }, [customDrinks, recipes]);
+    // Predefined drinks can be overridden per-owner but share the same fixed
+    // id, so when drinks from multiple owners are present, only keep the
+    // current user's own entry for a given id to avoid duplicate options.
+    const byId = new Map();
+    customDrinks.forEach((drink) => {
+      if (!byId.has(drink.id) || drink.ownerId === currentUser?.id) byId.set(drink.id, drink);
+    });
+    return [...byId.values()].map((drink) => ({ id: drink.id, label: resolveDrinkDisplay(drink, recipes).displayName || drink.id }));
+  }, [customDrinks, recipes, currentUser?.id]);
 
-  const sortedProfiles = useMemo(() => {
-    return [...profiles].sort((a, b) => {
+  const sortByName = (list) => {
+    return [...list].sort((a, b) => {
       const nachnameDiff = (a.nachname || '').localeCompare(b.nachname || '', 'de', { sensitivity: 'base' });
       if (nachnameDiff !== 0) return nachnameDiff;
       return (a.vorname || '').localeCompare(b.vorname || '', 'de', { sensitivity: 'base' });
     });
-  }, [profiles]);
+  };
+
+  const sortedProfiles = useMemo(() => sortByName(profiles), [profiles]);
+  const sortedAllProfiles = useMemo(() => sortByName(allProfiles), [allProfiles]);
 
   const openNew = () => {
     setEditId(null);
@@ -494,7 +531,54 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         )}
       </div>
 
-      {loading ? (
+      {isAdmin && (
+        <div className="events-manage-links">
+          <button
+            type="button"
+            className="events-manage-link-btn"
+            aria-pressed={!showAllGuests}
+            onClick={() => setShowAllGuests(false)}
+          >
+            Meine Gäste
+          </button>
+          <button
+            type="button"
+            className="events-manage-link-btn"
+            aria-pressed={showAllGuests}
+            onClick={() => setShowAllGuests(true)}
+          >
+            Alle Anwender
+          </button>
+        </div>
+      )}
+
+      {showAllGuests && isAdmin ? (
+        allProfilesLoading ? (
+          <div className="events-empty-state">Laden...</div>
+        ) : sortedAllProfiles.length === 0 ? (
+          <div className="events-empty-state">
+            <p>Keine Gäste vorhanden.</p>
+          </div>
+        ) : (
+          <div className="events-list">
+            {sortedAllProfiles.map((profile) => {
+              const fullName = getGuestDisplayName(profile);
+              const ownerName = getOwnerFirstName(profile.ownerId);
+              return (
+                <div key={`${profile.ownerId}_${profile.id}`} className="events-card events-guest-card">
+                  <div className="events-card-main">
+                    <h3>{fullName || 'Unbenannter Gast'}</h3>
+                    {profile.kind === true && <p className="events-info-text">Kind</p>}
+                    {ownerName && (
+                      <p className="events-card-meta">von {ownerName}</p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )
+      ) : loading ? (
         <div className="events-empty-state">Laden...</div>
       ) : profiles.length === 0 ? (
         <div className="events-empty-state">

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -3,19 +3,22 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import GuestManagementPage from './GuestManagementPage';
 
 const mockSubscribeToGuestProfiles = jest.fn();
-const mockSubscribeToCustomDrinks = jest.fn();
+const mockSubscribeToAllGuestProfiles = jest.fn();
+const mockSubscribeToAllCustomDrinks = jest.fn();
 const mockSaveGuestProfile = jest.fn();
 const mockDeleteGuestProfile = jest.fn();
 
 jest.mock('../utils/eventsFirestore', () => ({
   subscribeToGuestProfiles: (...args) => mockSubscribeToGuestProfiles(...args),
-  subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
+  subscribeToAllGuestProfiles: (...args) => mockSubscribeToAllGuestProfiles(...args),
+  subscribeToAllCustomDrinks: (...args) => mockSubscribeToAllCustomDrinks(...args),
   saveGuestProfile: (...args) => mockSaveGuestProfile(...args),
   deleteGuestProfile: (...args) => mockDeleteGuestProfile(...args),
 }));
 
 jest.mock('../utils/userManagement', () => ({
   canEditRecipes: () => true,
+  getUsers: () => Promise.resolve([]),
 }));
 
 jest.mock('../utils/customLists', () => ({
@@ -40,7 +43,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       cb([]);
       return jest.fn();
     });
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([]);
       return jest.fn();
     });
@@ -75,7 +78,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
   });
 
   test('adding a drink creates a chip and removes it from the dropdown', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'mineral-wasser', name: 'Mineral Wasser' }]);
       return jest.fn();
     });
@@ -97,7 +100,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
   });
 
   test('removing a chip via × button makes drink available in dropdown again', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'craft-bier', name: 'Craft Bier' }]);
       return jest.fn();
     });
@@ -116,7 +119,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
   });
 
   test('editing an existing guest shows pre-selected custom drinks as chips', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'hauswein', name: 'Hauswein' }]);
       return jest.fn();
     });
@@ -144,7 +147,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
   });
 
   test('custom drinks appear in the dropdown', () => {
-    mockSubscribeToCustomDrinks.mockImplementation((_uid, cb) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
       cb([{ id: 'craft-ipa', name: 'Craft IPA' }]);
       return jest.fn();
     });
@@ -333,5 +336,30 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
 
     expect(screen.queryByRole('heading', { name: 'Gast bearbeiten' })).not.toBeInTheDocument();
+  });
+
+  describe('admin cross-user guest visibility', () => {
+    const adminUser = { id: 'admin1', isAdmin: true };
+
+    test('non-admins do not see the "Alle Anwender" toggle', () => {
+      render(<GuestManagementPage currentUser={currentUser} />);
+      expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
+    });
+
+    test('admin can switch to "Alle Anwender" and sees another user\'s guest without a delete button', async () => {
+      mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
+        cb([
+          { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
+        ]);
+        return jest.fn();
+      });
+
+      render(<GuestManagementPage currentUser={adminUser} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
+
+      expect(await screen.findByText('Ben Beispiel')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Ben Beispiel löschen' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/MenuDetail.js
+++ b/src/components/MenuDetail.js
@@ -10,7 +10,7 @@ import { enableMenuSharing, disableMenuSharing } from '../utils/menuFirestore';
 import { scaleIngredient, combineIngredients, convertIngredientUnits, isWaterIngredient } from '../utils/ingredientUtils';
 import { decodeRecipeLink } from '../utils/recipeLinks';
 import { getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
-import { subscribeToEvent, subscribeToCustomDrinks, getCustomDrinks } from '../utils/eventsFirestore';
+import { subscribeToEvent, subscribeToCustomDrinks, getAllCustomDrinks } from '../utils/eventsFirestore';
 import { mergePredefinedDrinks } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { getImageForCategory } from '../utils/categoryImages';
@@ -197,7 +197,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
       return undefined;
     }
     let cancelled = false;
-    getCustomDrinks(currentUser.id).then((drinks) => {
+    getAllCustomDrinks().then((drinks) => {
       if (!cancelled) setManualDrinkCatalog(drinks);
     });
     return () => {
@@ -207,7 +207,7 @@ function MenuDetail({ menu: initialMenu, recipes, onBack, onEdit, onDelete, onPu
 
   const resolveManualDrinks = (drinkIds) => {
     if (!Array.isArray(drinkIds) || drinkIds.length === 0) return [];
-    const allDrinks = mergePredefinedDrinks(manualDrinkCatalog);
+    const allDrinks = mergePredefinedDrinks(manualDrinkCatalog, currentUser?.id);
     return drinkIds.map((drinkId) => {
       const drink = allDrinks.find((d) => d.id === drinkId);
       const display = resolveDrinkDisplay(drink || drinkId, recipes);

--- a/src/components/MenuDetail.test.js
+++ b/src/components/MenuDetail.test.js
@@ -60,7 +60,7 @@ jest.mock('../utils/categoryImages', () => ({
   getImageForCategory: () => Promise.resolve(null),
 }));
 
-const mockGetCustomDrinks = jest.fn(() => Promise.resolve([]));
+const mockGetAllCustomDrinks = jest.fn(() => Promise.resolve([]));
 // CRA's jest config resets mock implementations (including the one passed to
 // jest.fn()) before every test, so these fall back to a no-op unsubscribe
 // whenever a test hasn't set its own mockImplementation.
@@ -68,7 +68,7 @@ const mockSubscribeToEvent = jest.fn();
 const mockSubscribeToCustomDrinks = jest.fn();
 jest.mock('../utils/eventsFirestore', () => ({
   getEvent: jest.fn(() => Promise.resolve(null)),
-  getCustomDrinks: (...args) => mockGetCustomDrinks(...args),
+  getAllCustomDrinks: (...args) => mockGetAllCustomDrinks(...args),
   subscribeToEvent: (...args) => mockSubscribeToEvent(...args) || (() => {}),
   subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args) || (() => {}),
 }));
@@ -419,7 +419,7 @@ describe('MenuDetail - Metadata before Description', () => {
 
 describe('MenuDetail - Manually added drinks in the Drinks section', () => {
   beforeEach(() => {
-    mockGetCustomDrinks.mockReset();
+    mockGetAllCustomDrinks.mockReset();
   });
 
   const menuWithManualDrinks = {
@@ -432,7 +432,7 @@ describe('MenuDetail - Manually added drinks in the Drinks section', () => {
   };
 
   test('renders a manually added drink as a recipe-style card', async () => {
-    mockGetCustomDrinks.mockResolvedValue([
+    mockGetAllCustomDrinks.mockResolvedValue([
       { id: 'drink-cola', name: 'Cola', kategorie: 'softdrinks', einheiten: [{ einheitsgroesse: 0.5 }] },
     ]);
 
@@ -472,7 +472,7 @@ describe('MenuDetail - Manually added drinks in the Drinks section', () => {
       />
     );
 
-    expect(mockGetCustomDrinks).not.toHaveBeenCalled();
+    expect(mockGetAllCustomDrinks).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -8,7 +8,7 @@ import { fileToBase64, compressImage, selectMenuGridImages, buildMenuGridImage, 
 import { uploadMenuGridImage, uploadMenuGridImageDark, deleteMenuGridImage, deleteMenuGridImageDark, isStorageUrl } from '../utils/storageUtils';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference, getButtonIcons } from '../utils/customLists';
 import { getCategoryImages } from '../utils/categoryImages';
-import { subscribeToEvent, subscribeToEvents, subscribeToCustomDrinks, saveCustomDrink, calculateEventDrinks } from '../utils/eventsFirestore';
+import { subscribeToEvent, subscribeToEvents, subscribeToCustomDrinks, subscribeToAllCustomDrinks, saveCustomDrink, calculateEventDrinks } from '../utils/eventsFirestore';
 import { mergePredefinedDrinks, getDrinkParentCategoryId, categoryHasOwnBudget } from '../utils/drinkCategories';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { encodeRecipeLink, decodeRecipeLink } from '../utils/recipeLinks';
@@ -616,11 +616,14 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       setUserCustomDrinks([]);
       return undefined;
     }
-    const unsubscribe = subscribeToCustomDrinks(currentUser.id, setUserCustomDrinks);
+    const unsubscribe = subscribeToAllCustomDrinks(setUserCustomDrinks);
     return unsubscribe;
   }, [currentUser?.id]);
 
-  const allDrinks = useMemo(() => mergePredefinedDrinks(userCustomDrinks), [userCustomDrinks]);
+  const allDrinks = useMemo(
+    () => mergePredefinedDrinks(userCustomDrinks, currentUser?.id),
+    [userCustomDrinks, currentUser?.id]
+  );
 
   const getDrinkDisplayName = (drinkId) => {
     const drink = allDrinks.find((d) => d.id === drinkId);

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import MenuForm from './MenuForm';
 
 const mockSubscribeToCustomDrinks = jest.fn();
+const mockSubscribeToAllCustomDrinks = jest.fn();
 const mockSubscribeToEvents = jest.fn();
 const mockSubscribeToEvent = jest.fn();
 const mockSaveCustomDrink = jest.fn();
@@ -52,6 +53,7 @@ jest.mock('../utils/eventsFirestore', () => ({
   subscribeToEvent: (...args) => mockSubscribeToEvent(...args),
   subscribeToEvents: (...args) => mockSubscribeToEvents(...args),
   subscribeToCustomDrinks: (...args) => mockSubscribeToCustomDrinks(...args),
+  subscribeToAllCustomDrinks: (...args) => mockSubscribeToAllCustomDrinks(...args),
   saveCustomDrink: (...args) => mockSaveCustomDrink(...args),
   calculateEventDrinks: (...args) => mockCalculateEventDrinks(...args),
 }));
@@ -125,6 +127,10 @@ beforeEach(() => {
   mockSortableContextItemsCalls.length = 0;
   capturedEventFormProps = null;
   mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+    callback(customDrinks);
+    return () => {};
+  });
+  mockSubscribeToAllCustomDrinks.mockImplementation((callback) => {
     callback(customDrinks);
     return () => {};
   });
@@ -312,7 +318,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
       kategorie: null,
       einheiten: [{ einheitsgroesse: 0.3 }],
     };
-    mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((callback) => {
       callback([...customDrinks, existingLinkedDrink]);
       return () => {};
     });
@@ -353,7 +359,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
       kategorie: null,
       einheiten: [{ einheitsgroesse: 0.3 }],
     };
-    mockSubscribeToCustomDrinks.mockImplementation((uid, callback) => {
+    mockSubscribeToAllCustomDrinks.mockImplementation((callback) => {
       callback([...customDrinks, existingLinkedDrink]);
       return () => {};
     });

--- a/src/utils/drinkCategories.js
+++ b/src/utils/drinkCategories.js
@@ -48,8 +48,21 @@ export const PREDEFINED_DRINKS = [
   },
 ];
 
-export const mergePredefinedDrinks = (customDrinks = []) => {
-  const customById = new Map((Array.isArray(customDrinks) ? customDrinks : []).map((drink) => [drink.id, drink]));
+/**
+ * @param {Array} customDrinks - Custom drinks, possibly from multiple owners
+ *   (a shared library) when each entry carries an `ownerId`.
+ * @param {string} [currentUserId] - When drinks from multiple owners can be
+ *   present, only this user's own override of a predefined drink is merged
+ *   into its slot; other owners' overrides of the same predefined id are
+ *   ignored so they don't collide on the predefined drink's fixed id.
+ */
+export const mergePredefinedDrinks = (customDrinks = [], currentUserId = null) => {
+  const list = Array.isArray(customDrinks) ? customDrinks : [];
+  const predefinedIds = new Set(PREDEFINED_DRINKS.map((drink) => drink.id));
+  const relevant = currentUserId
+    ? list.filter((drink) => !predefinedIds.has(drink.id) || !drink.ownerId || drink.ownerId === currentUserId)
+    : list;
+  const customById = new Map(relevant.map((drink) => [drink.id, drink]));
 
   const mergedPredefined = PREDEFINED_DRINKS.map((predefinedDrink) => {
     const customDrink = customById.get(predefinedDrink.id);

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -6,6 +6,7 @@
 import { db, functions } from '../firebase';
 import {
   collection,
+  collectionGroup,
   doc,
   getDoc,
   getDocs,
@@ -79,6 +80,30 @@ export const subscribeToEvent = (uid, eventId, callback) => {
   }, (error) => {
     console.error('Error subscribing to event:', error);
     callback(null);
+  });
+};
+
+/**
+ * Set up a real-time listener across ALL users' events, newest/next first.
+ * Intended for admins, who may read (but not write) any user's events – see
+ * firestore.rules. Each event is annotated with `ownerId` (derived from its
+ * document path) so callers can tell whose event it is.
+ * @param {Function} callback - Receives the array of events
+ * @returns {Function} Unsubscribe function
+ */
+export const subscribeToAllEvents = (callback) => {
+  const eventsRef = collectionGroup(db, 'events');
+  const eventsQuery = query(eventsRef, orderBy('date', 'desc'));
+
+  return onSnapshot(eventsQuery, (snapshot) => {
+    const events = [];
+    snapshot.forEach((docSnap) => {
+      events.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
+    });
+    callback(events);
+  }, (error) => {
+    console.error('Error subscribing to all events:', error);
+    callback([]);
   });
 };
 
@@ -251,6 +276,51 @@ export const subscribeToCustomDrinks = (uid, callback) => {
 };
 
 /**
+ * Set up a real-time listener across ALL users' custom drinks, ordered by
+ * name. Drinks are a shared library visible to everyone; each drink is
+ * annotated with `ownerId` (derived from its document path) so callers can
+ * tell who added it and gate editing/deletion to that owner.
+ * @param {Function} callback - Receives the array of custom drinks
+ * @returns {Function} Unsubscribe function
+ */
+export const subscribeToAllCustomDrinks = (callback) => {
+  const ref = collectionGroup(db, 'customDrinks');
+  const q = query(ref, orderBy('name', 'asc'));
+  return onSnapshot(q, (snapshot) => {
+    const drinks = [];
+    snapshot.forEach((docSnap) => {
+      drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
+    });
+    callback(drinks);
+  }, (error) => {
+    console.error('Error subscribing to all customDrinks:', error);
+    callback([]);
+  });
+};
+
+/**
+ * Get ALL users' custom drinks (one-time fetch, ordered by name). Drinks are
+ * a shared library visible to everyone; each drink is annotated with
+ * `ownerId` (derived from its document path).
+ * @returns {Promise<Array>} The custom drinks
+ */
+export const getAllCustomDrinks = async () => {
+  try {
+    const ref = collectionGroup(db, 'customDrinks');
+    const q = query(ref, orderBy('name', 'asc'));
+    const snapshot = await getDocs(q);
+    const drinks = [];
+    snapshot.forEach((docSnap) => {
+      drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
+    });
+    return drinks;
+  } catch (error) {
+    console.error('Error getting all customDrinks:', error);
+    return [];
+  }
+};
+
+/**
  * Get a user's custom drinks (one-time fetch, ordered by name).
  * @param {string} uid - Current user ID
  * @returns {Promise<Array>} The custom drinks
@@ -327,6 +397,30 @@ export const subscribeToGuestProfiles = (uid, callback) => {
     callback(profiles);
   }, (error) => {
     console.error('Error subscribing to guestProfiles:', error);
+    callback([]);
+  });
+};
+
+/**
+ * Set up a real-time listener across ALL users' guest profiles, ordered by
+ * last name. Intended for admins, who may read (but not write) any user's
+ * guest profiles – see firestore.rules. Each profile is annotated with
+ * `ownerId` (derived from its document path) so callers can tell whose
+ * guest it is.
+ * @param {Function} callback - Receives the array of guest profiles
+ * @returns {Function} Unsubscribe function
+ */
+export const subscribeToAllGuestProfiles = (callback) => {
+  const ref = collectionGroup(db, 'profiles');
+  const q = query(ref, orderBy('nachname', 'asc'));
+  return onSnapshot(q, (snapshot) => {
+    const profiles = [];
+    snapshot.forEach((docSnap) => {
+      profiles.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
+    });
+    callback(profiles);
+  }, (error) => {
+    console.error('Error subscribing to all guestProfiles:', error);
     callback([]);
   });
 };


### PR DESCRIPTION
- Firestore-Regeln: Admins dürfen (lesend) Events und Gästeprofile aller
  Anwender einsehen; das Getränke-Sortiment ist jetzt für alle
  angemeldeten Nutzer lesbar statt nur für den jeweiligen Besitzer.
  Schreibrechte bleiben unverändert beim Eigentümer.
- Neue collectionGroup-Abfragen (subscribeToAllEvents,
  subscribeToAllCustomDrinks, subscribeToAllGuestProfiles,
  getAllCustomDrinks) liefern die Daten aller Nutzer inkl. ownerId.
- Getränkeverwaltung, Event- und Menüformulare nutzen jetzt die geteilte
  Getränke-Bibliothek; eigene Getränke bleiben editierbar/löschbar, fremde
  nur sichtbar. Neu angelegte Getränke gehören automatisch dem Ersteller.
- Events- und Gästeverwaltung bekommen für Admins einen "Alle Anwender"-
  Umschalter mit schreibgeschützter Ansicht der Daten anderer Nutzer.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QJNPbUt9GosVoBrknrR63N