### PR TITLE
Admins können Events, Getränke und Gäste anderer Nutzer bearbeiten und löschen

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -175,20 +175,20 @@ service cloud.firestore {
     }
 
     // Event drink-calculation planning (Menüpunkt "Events").
-    // Admins may additionally read (but not write) any user's events, so they
-    // can see all events across the app.
+    // Admins have full read/write access to any user's events, so they can
+    // see, edit and delete events across the app.
     match /users/{userId}/events/{eventId} {
       allow read: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
-      allow write: if isAuthenticated() && request.auth.uid == userId;
+      allow write: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
     }
 
     // User-defined custom drinks library (reusable across events).
     // Readable by any recognised user – drinks are a shared library visible to
-    // everyone – but only the owner may create/update/delete their own entries,
-    // so existing drinks from other users cannot be edited, only newly added.
+    // everyone. Owners may create/update/delete their own entries; admins may
+    // additionally edit/delete any user's entries.
     match /users/{userId}/customDrinks/{drinkId} {
       allow read: if isAnyUser();
-      allow write: if isAuthenticated() && request.auth.uid == userId;
+      allow write: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
     }
 
     // Reusable guest profiles for drink planning
@@ -199,8 +199,10 @@ service cloud.firestore {
 
     // Guest profiles (new data model):
     // /guests/{userId}/profiles/{guestId}
-    // Reads are limited to the owner, plus admins who may read (but not write)
-    // any user's guest profiles. Writes happen via Cloud Function (Admin SDK).
+    // Reads are limited to the owner, plus admins who may read any user's
+    // guest profiles. All writes happen via the manageGuestProfile Cloud
+    // Function (Admin SDK bypasses these rules), which additionally lets
+    // admins create/update/delete any user's guest profiles.
     match /guests/{userId}/profiles/{guestId} {
       allow read: if isAuthenticated() && (request.auth.uid == userId || isAdmin());
       allow write: if false;

--- a/functions/calculateEventDrinks.js
+++ b/functions/calculateEventDrinks.js
@@ -649,21 +649,33 @@ exports.calculateEventDrinks = onCall({maxInstances: 10}, async (request) => {
     throw new HttpsError('unauthenticated', 'Login erforderlich.');
   }
   const uid = request.auth.uid;
-  const {event, eventId} = request.data || {};
+  const {event, eventId, ownerId} = request.data || {};
 
   if (!event || !event.durationHours || !event.guests) {
     throw new HttpsError('invalid-argument', 'event mit durationHours und guests ist erforderlich.');
   }
 
   const db = admin.firestore();
+
+  // Admins may recalculate/save an event on behalf of another user (full
+  // edit access to all events); everyone else may only act on their own.
+  const targetUid = ownerId || uid;
+  if (targetUid !== uid) {
+    const userSnap = await db.collection('users').doc(uid).get();
+    const role = userSnap.exists ? userSnap.data()?.role : null;
+    if (role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Nur Admins können Events anderer Nutzer bearbeiten.');
+    }
+  }
+
   const [ratesDb, customDrinksMap, childrenRatesDb] = await Promise.all([
-    loadRatesDb(db, uid),
-    loadCustomDrinks(db, uid, event.customDrinkIds),
+    loadRatesDb(db, targetUid),
+    loadCustomDrinks(db, targetUid, event.customDrinkIds),
     loadChildrenDrinkWeightsFromFirestore(db),
   ]);
   const result = calculate(event, ratesDb, customDrinksMap, childrenRatesDb);
 
-  const eventsRef = db.collection('users').doc(uid).collection('events');
+  const eventsRef = db.collection('users').doc(targetUid).collection('events');
   let docRef;
   if (eventId) {
     docRef = eventsRef.doc(eventId);

--- a/functions/manageGuestProfile.js
+++ b/functions/manageGuestProfile.js
@@ -48,12 +48,34 @@ function validateProfile(profile) {
   };
 }
 
-async function requireEditRole(db, uid) {
+async function getUserRole(db, uid) {
   const userSnap = await db.collection('users').doc(uid).get();
-  const role = userSnap.exists ? userSnap.data()?.role : null;
+  return userSnap.exists ? userSnap.data()?.role : null;
+}
+
+/**
+ * Ermittelt, unter welchem Nutzer (targetUid) die Gaeste-Operation ausgefuehrt
+ * werden darf. Standardmaessig wirkt der Aufruf auf die eigenen Gaeste (uid
+ * benoetigt edit-Rechte); wird ein abweichendes ownerId angegeben, darf nur
+ * ein Admin auf die Gaeste eines anderen Nutzers zugreifen.
+ * @param {object} db Firestore-Instanz.
+ * @param {string} uid Firebase-Nutzer-ID des Aufrufers.
+ * @param {string|undefined} ownerId Optionales Ziel-Nutzer-ID (fuer Admin-Zugriff).
+ * @return {Promise<string>} Die Nutzer-ID, deren Gaesteprofile bearbeitet werden.
+ */
+async function resolveTargetUid(db, uid, ownerId) {
+  const role = await getUserRole(db, uid);
+  const targetUid = ownerId || uid;
+  if (targetUid !== uid) {
+    if (role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Nur Admins können Gäste anderer Nutzer verwalten.');
+    }
+    return targetUid;
+  }
   if (!ALLOWED_ROLES.has(role)) {
     throw new HttpsError('permission-denied', 'Nur Benutzer mit edit-Rechten können Gäste verwalten.');
   }
+  return targetUid;
 }
 
 exports.manageGuestProfile = onCall({maxInstances: 10}, async (request) => {
@@ -62,12 +84,12 @@ exports.manageGuestProfile = onCall({maxInstances: 10}, async (request) => {
   }
 
   const uid = request.auth.uid;
-  const {action, profileId, profile} = request.data || {};
+  const {action, profileId, profile, ownerId} = request.data || {};
   const db = admin.firestore();
 
-  await requireEditRole(db, uid);
+  const targetUid = await resolveTargetUid(db, uid, ownerId);
 
-  const guestsRef = db.collection('guests').doc(uid).collection('profiles');
+  const guestsRef = db.collection('guests').doc(targetUid).collection('profiles');
   const now = admin.firestore.FieldValue.serverTimestamp();
 
   if (action === 'delete') {

--- a/functions/submitConsumption.js
+++ b/functions/submitConsumption.js
@@ -103,14 +103,26 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
     throw new HttpsError('unauthenticated', 'Login erforderlich.');
   }
   const uid = request.auth.uid;
-  const {eventId, gebinde, verbrauchGesperrtKategorien} = request.data || {};
+  const {eventId, gebinde, verbrauchGesperrtKategorien, ownerId} = request.data || {};
 
   if (!eventId || !gebinde) {
     throw new HttpsError('invalid-argument', 'eventId und gebinde sind erforderlich.');
   }
 
   const db = admin.firestore();
-  const eventRef = db.collection('users').doc(uid).collection('events').doc(eventId);
+
+  // Admins may record consumption on behalf of another user (full edit
+  // access to all events); everyone else may only act on their own.
+  const targetUid = ownerId || uid;
+  if (targetUid !== uid) {
+    const userSnap = await db.collection('users').doc(uid).get();
+    const role = userSnap.exists ? userSnap.data()?.role : null;
+    if (role !== 'admin') {
+      throw new HttpsError('permission-denied', 'Nur Admins können Events anderer Nutzer bearbeiten.');
+    }
+  }
+
+  const eventRef = db.collection('users').doc(targetUid).collection('events').doc(eventId);
   const eventSnap = await eventRef.get();
   if (!eventSnap.exists) {
     throw new HttpsError('not-found', 'Event nicht gefunden.');
@@ -144,7 +156,7 @@ exports.submitConsumption = onCall({maxInstances: 10}, async (request) => {
       batch.set(snapshotRef, {
         ...snapshot,
         eventId,
-        uid,
+        uid: targetUid,
         erstelltAm: admin.firestore.FieldValue.serverTimestamp(),
       });
     }

--- a/src/components/ConsumptionForm.js
+++ b/src/components/ConsumptionForm.js
@@ -268,7 +268,8 @@ function LockStateIcon({ state }) {
   );
 }
 
-function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
+function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser, ownerId }) {
+  const effectiveOwnerId = ownerId || currentUser?.id;
   const kategorien = (event.berechnung?.ergebnis || []).filter((row) => (row.isCustomDrink || row.isPredefinedDrink) && row.gebindeGroesseLiter);
   const drinkGroups = groupKategorienByDrink(kategorien, recipes);
   const { prefillMap, warnings: prefillWarnings } = getCascadePrefill(drinkGroups);
@@ -294,6 +295,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const einkaufLock = useGroupLock({
     initialLocked: event.einkaufGesperrt,
     currentUser,
+    ownerId: effectiveOwnerId,
     eventId: event.id,
     lockFn: lockEinkaufMengen,
     unlockFn: unlockEinkaufMengen,
@@ -301,6 +303,7 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
   const verbrauchLock = useGroupLock({
     initialLocked: event.verbrauchGesperrt,
     currentUser,
+    ownerId: effectiveOwnerId,
     eventId: event.id,
     lockFn: lockVerbrauchMengen,
     unlockFn: unlockVerbrauchMengen,
@@ -449,14 +452,14 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
       });
       return werteByKategorie;
     });
-    if (!currentUser?.id) return;
+    if (!effectiveOwnerId) return;
     const allLocked = allGroupsLockedIn(nextLocked);
     if (allLocked && event.status === 'berechnet') {
-      setEventStatus(currentUser.id, event.id, 'eingekauft').catch((err) => {
+      setEventStatus(effectiveOwnerId, event.id, 'eingekauft').catch((err) => {
         console.error('Error setting event status to eingekauft:', err);
       });
     } else if (!allLocked && event.status === 'eingekauft') {
-      setEventStatus(currentUser.id, event.id, 'berechnet').catch((err) => {
+      setEventStatus(effectiveOwnerId, event.id, 'berechnet').catch((err) => {
         console.error('Error resetting event status to berechnet:', err);
       });
     }
@@ -497,7 +500,13 @@ function ConsumptionForm({ event, recipes, onDone, onCancel, currentUser }) {
     setError('');
     try {
       const gesperrt = verbrauchGesperrtKategorien || verbrauchLock.lockedKategorien;
-      await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt));
+      // Admin recording consumption for another user's event: pass their
+      // ownerId through so the Cloud Function writes to the right event.
+      if (effectiveOwnerId && effectiveOwnerId !== currentUser?.id) {
+        await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt), effectiveOwnerId);
+      } else {
+        await submitConsumption(event.id, buildGebindePayload(), Array.from(gesperrt));
+      }
       onDone(event.id);
     } catch (err) {
       console.error('Error submitting consumption:', err);

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -196,7 +196,7 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
                   .map((e) => getUnitSizeLabel(e.einheitsgroesse) || String(e.einheitsgroesse))
                   .join(', ')
               : null,
-            !canManage && ownerName ? `von ${ownerName}` : null,
+            ownerName ? `von ${ownerName}` : null,
           ].filter(Boolean).join(' · ')}
         </p>
       </div>
@@ -210,7 +210,9 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editId, setEditId] = useState(null);
+  const [editOwnerId, setEditOwnerId] = useState(null);
   const [isPredefined, setIsPredefined] = useState(false);
+  const isAdmin = currentUser?.isAdmin === true;
   const [form, setForm] = useState(emptyForm());
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -283,6 +285,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
 
   const openNew = () => {
     setEditId(null);
+    setEditOwnerId(null);
     setIsPredefined(false);
     setForm(emptyForm());
     setError('');
@@ -292,6 +295,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
 
   const openEdit = (drink) => {
     setEditId(drink.id);
+    setEditOwnerId(drink.ownerId || null);
     setIsPredefined(Boolean(drink.predefined));
     setForm({
       name: drink.name || '',
@@ -395,15 +399,16 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
           return einheit;
         }),
       };
+      const targetOwnerId = editId ? (editOwnerId || currentUser.id) : currentUser.id;
       if (isPredefined) {
-        await saveCustomDrink(currentUser.id, {
+        await saveCustomDrink(targetOwnerId, {
           ...payload,
           name: form.name.trim(),
           kategorie: form.kategorie || null,
           predefined: true,
         }, editId || undefined);
       } else {
-        await saveCustomDrink(currentUser.id, payload, editId || undefined);
+        await saveCustomDrink(targetOwnerId, payload, editId || undefined);
       }
       setShowForm(false);
     } catch (err) {
@@ -416,7 +421,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
 
   const handleDelete = async (drink) => {
     try {
-      await deleteCustomDrink(currentUser.id, drink.id);
+      await deleteCustomDrink(drink.ownerId || currentUser.id, drink.id);
       const id = deleteBannerCounterRef.current;
       deleteBannerCounterRef.current = (id + 1) % 100000;
       const deletedDisplayName = resolveDrinkDisplay(drink, recipes).displayName;
@@ -746,8 +751,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
                   key={`${drink.ownerId || ''}_${drink.id}`}
                   drink={drink}
                   displayName={resolveDrinkDisplay(drink, recipes).displayName}
-                  ownerName={getOwnerFirstName(drink.ownerId)}
-                  canManage={drink.predefined || !drink.ownerId || drink.ownerId === currentUser?.id}
+                  ownerName={drink.ownerId && drink.ownerId !== currentUser?.id ? getOwnerFirstName(drink.ownerId) : null}
+                  canManage={drink.predefined || !drink.ownerId || drink.ownerId === currentUser?.id || isAdmin}
                   onEdit={openEdit}
                   onDelete={handleDelete}
                   swipeDeleteIcon={swipeDeleteIcon}

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -62,8 +62,9 @@ const todayIsoDate = () => new Date().toISOString().slice(0, 10);
 
 const currentHourStartTime = () => `${String(new Date().getHours()).padStart(2, '0')}:00`;
 
-function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, initialEvent, recipes }) {
+function EventForm({ onSaved, onCancel, onDelete, currentUser, ownerId, onManageDrinks, initialEvent, recipes }) {
   const isEditing = Boolean(initialEvent?.id);
+  const effectiveOwnerId = ownerId || currentUser?.id;
 
   const [eventName, setEventName] = useState(initialEvent?.eventName ?? '');
   const [date, setDate] = useState(initialEvent?.date ?? todayIsoDate());
@@ -91,8 +92,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   const [showDrinkSelection, setShowDrinkSelection] = useState(false);
 
   useEffect(() => {
-    if (!currentUser?.id) return undefined;
-    const unsubGuests = subscribeToGuestProfiles(currentUser.id, setGuests);
+    if (!effectiveOwnerId) return undefined;
+    const unsubGuests = subscribeToGuestProfiles(effectiveOwnerId, setGuests);
     const unsubDrinks = subscribeToAllCustomDrinks((drinks) => {
       setCustomDrinks(drinks);
       // Auto-select only Mineralwasser for new events
@@ -107,7 +108,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
       unsubGuests();
       unsubDrinks();
     };
-  }, [currentUser?.id]);
+  }, [effectiveOwnerId]);
 
   useEffect(() => {
     const loadButtonIcons = async () => {
@@ -134,8 +135,8 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   );
 
   const guestPreferenceMultipliers = useMemo(
-    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks, currentUser?.id), driverGuestIds),
-    [selectedGuests, customDrinks, driverGuestIds, currentUser?.id],
+    () => computeGuestPreferenceMultipliers(selectedGuests, mergePredefinedDrinks(customDrinks, effectiveOwnerId), driverGuestIds),
+    [selectedGuests, customDrinks, driverGuestIds, effectiveOwnerId],
   );
 
   useEffect(() => {
@@ -162,7 +163,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
     setSaving(true);
     setError('');
     try {
-      const allDrinks = mergePredefinedDrinks(customDrinks, currentUser?.id);
+      const allDrinks = mergePredefinedDrinks(customDrinks, effectiveOwnerId);
       const categories = [...new Set(
         customDrinkIds
           .map((drinkId) => allDrinks.find((drink) => drink.id === drinkId)?.kategorie)
@@ -201,7 +202,11 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
         }, {}),
         pufferProzent: Number(pufferProzent),
       };
-      const result = await calculateEventDrinks(event, isEditing ? initialEvent.id : undefined);
+      const result = await calculateEventDrinks(
+        event,
+        isEditing ? initialEvent.id : undefined,
+        effectiveOwnerId !== currentUser?.id ? effectiveOwnerId : undefined,
+      );
 
       // Drinks removed here should disappear from any menu they were also
       // added to, so the menu stays in sync with this event's Getränke.
@@ -217,9 +222,9 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
       const removedRecipeIds = removedDrinkIds
         .map((id) => decodeRecipeLink(allDrinks.find((drink) => drink.id === id)?.name)?.recipeId)
         .filter(Boolean);
-      if (removedDrinkIds.length > 0 && currentUser?.id) {
+      if (removedDrinkIds.length > 0 && effectiveOwnerId) {
         try {
-          const linkedMenus = await getMenusByEventId(currentUser.id, result.eventId);
+          const linkedMenus = await getMenusByEventId(effectiveOwnerId, result.eventId);
           await Promise.all(linkedMenus.map((linkedMenu) => {
             let changed = false;
             const nextSections = (linkedMenu.sections || []).map((section) => {
@@ -261,6 +266,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
     return (
       <EventGuestSelectionPage
         currentUser={currentUser}
+        ownerId={effectiveOwnerId}
         selectedGuestIds={selectedGuestIds}
         driverGuestIds={driverGuestIds}
         buttonIcons={buttonIcons}
@@ -284,7 +290,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, onManageDrinks, i
   if (showDrinkSelection) {
     return (
       <EventDrinkSelectionPage
-        customDrinks={mergePredefinedDrinks(customDrinks, currentUser?.id)}
+        customDrinks={mergePredefinedDrinks(customDrinks, effectiveOwnerId)}
         customDrinkIds={customDrinkIds}
         drinkDistributionFactors={drinkDistributionFactors}
         drinkSelectedEinheiten={drinkSelectedEinheiten}

--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -7,6 +7,7 @@ import { isBase64Image } from '../utils/imageUtils';
 
 function EventGuestSelectionPage({
   currentUser,
+  ownerId,
   selectedGuestIds: initialSelectedGuestIds,
   driverGuestIds: initialDriverGuestIds,
   onSave,
@@ -24,12 +25,13 @@ function EventGuestSelectionPage({
   const searchRef = useRef(null);
   const dropdownRef = useRef(null);
   const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
+  const effectiveOwnerId = ownerId || currentUser?.id;
 
   useEffect(() => {
-    if (!currentUser?.id) return undefined;
-    const unsubGuests = subscribeToGuestProfiles(currentUser.id, setGuests);
+    if (!effectiveOwnerId) return undefined;
+    const unsubGuests = subscribeToGuestProfiles(effectiveOwnerId, setGuests);
     return unsubGuests;
-  }, [currentUser?.id]);
+  }, [effectiveOwnerId]);
 
   useEffect(() => {
     setDriverGuestIds((prev) => prev.filter((guestId) => selectedGuestIds.includes(guestId)));

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -223,6 +223,8 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       || null;
   }, [events, allEvents, selectedEventId, fallbackEvent]);
   const isOwnEvent = selectedEventOwnerId === currentUser?.id;
+  // Admins have full edit/delete access to every user's events, not just their own.
+  const canManageSelectedEvent = isOwnEvent || isAdmin;
   const getOwnerFirstName = (ownerId) => {
     if (!ownerId) return null;
     return allUsers.find((u) => u.id === ownerId)?.vorname || null;
@@ -240,7 +242,10 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
 
   const handleEventSaved = (eventId) => {
     setSelectedEventId(eventId);
-    setSelectedEventOwnerId(currentUser?.id);
+    // When editing, keep the event's existing owner (e.g. an admin editing
+    // another user's event); a newly created event always belongs to the
+    // current user.
+    setSelectedEventOwnerId(subView === 'edit' ? selectedEventOwnerId : currentUser?.id);
     setFallbackEvent(null);
     setSubView('detail');
   };
@@ -248,7 +253,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const handleDelete = async (event) => {
     if (!window.confirm(`Möchtest du "${event.eventName}" wirklich löschen?`)) return;
     try {
-      await deleteEvent(currentUser.id, event.id);
+      await deleteEvent(selectedEventOwnerId || currentUser.id, event.id);
       setSubView('list');
       setSelectedEventId(null);
       setFallbackEvent(null);
@@ -289,13 +294,14 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     );
   }
 
-  if (subView === 'edit' && selectedEvent && isOwnEvent) {
+  if (subView === 'edit' && selectedEvent && canManageSelectedEvent) {
     return (
       <EventForm
         onSaved={handleEventSaved}
         onCancel={() => setSubView('detail')}
         onDelete={() => handleDelete(selectedEvent)}
         currentUser={currentUser}
+        ownerId={selectedEventOwnerId}
         onManageDrinks={() => setSubView('drinks')}
         initialEvent={selectedEvent}
         recipes={recipes}
@@ -303,12 +309,13 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     );
   }
 
-  if (subView === 'consumption' && selectedEvent && isOwnEvent) {
+  if (subView === 'consumption' && selectedEvent && canManageSelectedEvent) {
     return (
       <ConsumptionForm
         event={selectedEvent}
         recipes={recipes}
         currentUser={currentUser}
+        ownerId={selectedEventOwnerId}
         onDone={(eventId) => {
           setSelectedEventId(eventId);
           setFallbackEvent(null);
@@ -425,7 +432,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             </>
           )}
 
-          {isOwnEvent && (
+          {canManageSelectedEvent && (
             <div className="events-form-actions">
               {(selectedEvent.status === 'berechnet' || selectedEvent.status === 'eingekauft') && (
                 <button
@@ -448,7 +455,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
             </div>
           )}
         </div>
-        {isOwnEvent && isMobileView && (
+        {canManageSelectedEvent && isMobileView && (
           <button
             type="button"
             className={`edit-fab-button events-edit-fab-button${editFabPressed ? ' pressed' : ''}`}

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -600,7 +600,7 @@ describe('EventsPage', () => {
       expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
     });
 
-    test('admin can switch to "Alle Anwender" and open another user\'s event read-only', async () => {
+    test('admin can switch to "Alle Anwender" and edit another user\'s event', async () => {
       const othersEvent = {
         id: 'e1',
         eventName: 'Fremdes Fest',
@@ -625,9 +625,12 @@ describe('EventsPage', () => {
       fireEvent.click(screen.getByText('Fremdes Fest'));
 
       expect(await screen.findByRole('heading', { name: 'Fremdes Fest' })).toBeInTheDocument();
-      // Read-only: no edit affordances for another user's event.
-      expect(screen.queryByRole('button', { name: 'Bearbeiten' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Event bearbeiten' })).not.toBeInTheDocument();
+      // Admins have full edit access to every user's events.
+      const editButton = screen.getByRole('button', { name: 'Bearbeiten' });
+      expect(editButton).toBeInTheDocument();
+
+      fireEvent.click(editButton);
+      expect(screen.getByText('EventForm geöffnet')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -40,6 +40,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editId, setEditId] = useState(null);
+  const [editOwnerId, setEditOwnerId] = useState(null);
   const [form, setForm] = useState(emptyForm());
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -131,6 +132,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
 
   const openNew = () => {
     setEditId(null);
+    setEditOwnerId(null);
     setForm(emptyForm());
     setDrinkToAdd('');
     setCategoryToAdd('');
@@ -140,6 +142,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
 
   const openEdit = (profile) => {
     setEditId(profile.id);
+    setEditOwnerId(profile.ownerId || null);
     setForm({
       vorname: profile.vorname || '',
       nachname: profile.nachname || '',
@@ -198,20 +201,23 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     setSaving(true);
     setError('');
     try {
-      await saveGuestProfile(
-        currentUser.id,
-        {
-          vorname: form.vorname.trim(),
-          nachname: form.nachname.trim(),
-          email: form.email.trim(),
-          kind: form.kind === true,
-          alkoholischeGetränke: form.alkoholischeGetraenke,
-          bevorzugteGetränke: form.bevorzugteGetraenke,
-          bevorzugteKategorien: form.bevorzugteKategorien,
-          präferenzFaktor: normalizePreferenceFactor(form.praeferenzFaktor),
-        },
-        editId || undefined,
-      );
+      const payload = {
+        vorname: form.vorname.trim(),
+        nachname: form.nachname.trim(),
+        email: form.email.trim(),
+        kind: form.kind === true,
+        alkoholischeGetränke: form.alkoholischeGetraenke,
+        bevorzugteGetränke: form.bevorzugteGetraenke,
+        bevorzugteKategorien: form.bevorzugteKategorien,
+        präferenzFaktor: normalizePreferenceFactor(form.praeferenzFaktor),
+      };
+      // Admin editing another user's guest: pass their ownerId through so the
+      // manageGuestProfile Cloud Function writes to the right owner's profiles.
+      if (editId && editOwnerId && editOwnerId !== currentUser.id) {
+        await saveGuestProfile(currentUser.id, payload, editId, editOwnerId);
+      } else {
+        await saveGuestProfile(currentUser.id, payload, editId || undefined);
+      }
       setShowForm(false);
     } catch (err) {
       console.error('Error saving guest profile:', err);
@@ -226,7 +232,12 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     const name = getGuestDisplayName(profile) || 'diesen Gast';
     if (!window.confirm(`Möchtest du "${name}" wirklich löschen?`)) return;
     try {
-      await deleteGuestProfile(currentUser.id, profile.id);
+      // Admin deleting another user's guest: pass their ownerId through.
+      if (profile.ownerId && profile.ownerId !== currentUser.id) {
+        await deleteGuestProfile(currentUser.id, profile.id, profile.ownerId);
+      } else {
+        await deleteGuestProfile(currentUser.id, profile.id);
+      }
     } catch (err) {
       console.error('Error deleting guest profile:', err);
     }
@@ -564,8 +575,9 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
             {sortedAllProfiles.map((profile) => {
               const fullName = getGuestDisplayName(profile);
               const ownerName = getOwnerFirstName(profile.ownerId);
+              const guestDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
               return (
-                <div key={`${profile.ownerId}_${profile.id}`} className="events-card events-guest-card">
+                <div key={`${profile.ownerId}_${profile.id}`} className="events-card events-guest-card" onClick={() => openEdit(profile)}>
                   <div className="events-card-main">
                     <h3>{fullName || 'Unbenannter Gast'}</h3>
                     {profile.kind === true && <p className="events-info-text">Kind</p>}
@@ -573,6 +585,22 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
                       <p className="events-card-meta">von {ownerName}</p>
                     )}
                   </div>
+                  <button
+                    type="button"
+                    className="events-guest-delete-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(profile);
+                    }}
+                    aria-label={`${fullName || 'Gast'} löschen`}
+                    title="Gast löschen"
+                  >
+                    {isBase64Image(guestDeleteIcon) ? (
+                      <img src={guestDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+                    ) : (
+                      <span className="swipe-delete-icon-text">{guestDeleteIcon}</span>
+                    )}
+                  </button>
                 </div>
               );
             })}

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -346,10 +346,20 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
     });
 
-    test('admin can switch to "Alle Anwender" and sees another user\'s guest without a delete button', async () => {
+    test('admin can switch to "Alle Anwender" and edit/delete another user\'s guest', async () => {
+      window.confirm = jest.fn(() => true);
       mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
         cb([
-          { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
+          {
+            id: 'g1',
+            vorname: 'Ben',
+            nachname: 'Beispiel',
+            ownerId: 'other-user',
+            alkoholischeGetränke: true,
+            bevorzugteGetränke: [],
+            bevorzugteKategorien: [],
+            präferenzFaktor: 0.5,
+          },
         ]);
         return jest.fn();
       });
@@ -359,7 +369,41 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
 
       expect(await screen.findByText('Ben Beispiel')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: 'Ben Beispiel löschen' })).not.toBeInTheDocument();
+
+      const deleteBtn = screen.getByRole('button', { name: 'Ben Beispiel löschen' });
+      expect(deleteBtn).toBeInTheDocument();
+
+      // Clicking the card opens the edit form for the other user's guest.
+      fireEvent.click(screen.getByText('Ben Beispiel'));
+      expect(screen.getByRole('heading', { level: 2, name: 'Gast bearbeiten' })).toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText('Vorname'), { target: { value: 'Benjamin' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+      await waitFor(() => {
+        expect(mockSaveGuestProfile).toHaveBeenCalledWith(
+          adminUser.id,
+          expect.objectContaining({ vorname: 'Benjamin' }),
+          'g1',
+          'other-user',
+        );
+      });
+    });
+
+    test('admin deleting another user\'s guest passes the owner id through', () => {
+      window.confirm = jest.fn(() => true);
+      mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
+        cb([
+          { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
+        ]);
+        return jest.fn();
+      });
+
+      render(<GuestManagementPage currentUser={adminUser} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Ben Beispiel löschen' }));
+
+      expect(mockDeleteGuestProfile).toHaveBeenCalledWith(adminUser.id, 'g1', 'other-user');
     });
   });
 });

--- a/src/hooks/useGroupLock.js
+++ b/src/hooks/useGroupLock.js
@@ -8,11 +8,13 @@ import { useState } from 'react';
  * @param {Object} options
  * @param {Object} [options.initialLocked] - Bereits gesperrte Werte { kategorie: wert } aus Firestore
  * @param {Object} [options.currentUser] - Aktueller Nutzer ({ id })
+ * @param {string} [options.ownerId] - Event-Eigentuemer, falls abweichend vom Aufrufer (Admin bearbeitet fremdes Event)
  * @param {string} options.eventId - ID des Events
  * @param {Function} options.lockFn - (uid, eventId, werteByKategorie) => Promise
  * @param {Function} options.unlockFn - (uid, eventId, kategorien) => Promise
  */
-export function useGroupLock({ initialLocked, currentUser, eventId, lockFn, unlockFn }) {
+export function useGroupLock({ initialLocked, currentUser, ownerId, eventId, lockFn, unlockFn }) {
+  const targetUid = ownerId || currentUser?.id;
   const [lockedKategorien, setLockedKategorien] = useState(
     () => new Set(Object.keys(initialLocked || {}))
   );
@@ -34,16 +36,16 @@ export function useGroupLock({ initialLocked, currentUser, eventId, lockFn, unlo
     if (isGroupLocked(group)) {
       kategorienKeys.forEach((kategorie) => next.delete(kategorie));
       setLockedKategorien(next);
-      if (currentUser?.id) {
-        unlockFn(currentUser.id, eventId, kategorienKeys).catch((err) => {
+      if (targetUid) {
+        unlockFn(targetUid, eventId, kategorienKeys).catch((err) => {
           console.error('Error unlocking values:', err);
         });
       }
     } else {
       kategorienKeys.forEach((kategorie) => next.add(kategorie));
       setLockedKategorien(next);
-      if (currentUser?.id) {
-        lockFn(currentUser.id, eventId, buildLockPayload(kategorienKeys)).catch((err) => {
+      if (targetUid) {
+        lockFn(targetUid, eventId, buildLockPayload(kategorienKeys)).catch((err) => {
           console.error('Error locking values:', err);
         });
       }

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -148,11 +148,12 @@ export const deleteEvent = async (uid, eventId) => {
  * @param {Object} event - Event parameters (eventName, date, durationHours, guests,
  *   season, eventType, categories, pufferProzent)
  * @param {string} [eventId] - ID of an existing event to recalculate
+ * @param {string} [ownerId] - Owner of the event, if different from the caller (admin editing another user's event)
  * @returns {Promise<Object>} { eventId, ...Berechnungsergebnis }
  */
-export const calculateEventDrinks = async (event, eventId) => {
+export const calculateEventDrinks = async (event, eventId, ownerId) => {
   const fn = httpsCallable(functions, 'calculateEventDrinks');
-  const result = await fn({ event, eventId });
+  const result = await fn({ event, eventId, ownerId });
   return result.data;
 };
 
@@ -242,11 +243,12 @@ export const setEventStatus = async (uid, eventId, status) => {
  * @param {Object} gebinde - { kategorie: { eingekauft, uebrig } } in Gebinde-Einheiten
  * @param {string[]} [verbrauchGesperrtKategorien] - Kategorien, die aktuell (auch
  *   client-seitig noch nicht durchgeschrieben) als "Verbrauch gesperrt" gelten
+ * @param {string} [ownerId] - Owner of the event, if different from the caller (admin editing another user's event)
  * @returns {Promise<Object>} { eventId }
  */
-export const submitConsumption = async (eventId, gebinde, verbrauchGesperrtKategorien) => {
+export const submitConsumption = async (eventId, gebinde, verbrauchGesperrtKategorien, ownerId) => {
   const fn = httpsCallable(functions, 'submitConsumption');
-  const result = await fn({ eventId, gebinde, verbrauchGesperrtKategorien });
+  const result = await fn({ eventId, gebinde, verbrauchGesperrtKategorien, ownerId });
   return result.data;
 };
 
@@ -430,14 +432,16 @@ export const subscribeToAllGuestProfiles = (callback) => {
  * @param {string} uid - Current user ID
  * @param {Object} profile - { name, adults, children }
  * @param {string} [profileId] - If provided, update existing profile
+ * @param {string} [ownerId] - Owner of the profile, if different from the caller (admin editing another user's guest)
  * @returns {Promise<string>} The profile ID
  */
-export const saveGuestProfile = async (_uid, profile, profileId) => {
+export const saveGuestProfile = async (_uid, profile, profileId, ownerId) => {
   const fn = httpsCallable(functions, 'manageGuestProfile');
   const result = await fn({
     action: profileId ? 'update' : 'create',
     profileId: profileId || null,
     profile,
+    ownerId,
   });
   return result?.data?.id || profileId;
 };
@@ -446,14 +450,16 @@ export const saveGuestProfile = async (_uid, profile, profileId) => {
  * Delete a guest profile.
  * @param {string} uid - Current user ID
  * @param {string} profileId - ID of the profile to delete
+ * @param {string} [ownerId] - Owner of the profile, if different from the caller (admin deleting another user's guest)
  * @returns {Promise<void>}
  */
-export const deleteGuestProfile = async (_uid, profileId) => {
+export const deleteGuestProfile = async (_uid, profileId, ownerId) => {
   try {
     const fn = httpsCallable(functions, 'manageGuestProfile');
     await fn({
       action: 'delete',
       profileId,
+      ownerId,
     });
   } catch (error) {
     console.error('Error deleting guestProfile:', error);


### PR DESCRIPTION
- Firestore-Regeln: Admins dürfen jetzt auch schreibend auf Events und
  Getränke aller Nutzer zugreifen (bisher nur lesend bzw. nur eigene).
- calculateEventDrinks, submitConsumption und manageGuestProfile (Cloud
  Functions) akzeptieren ein optionales ownerId und lassen Admins damit
  Events/Verbrauch/Gästeprofile anderer Nutzer anlegen, ändern und löschen;
  für alle anderen bleibt der Zugriff auf die eigenen Daten beschränkt.
- Events-, Getränke- und Gästeverwaltung: der "Alle Anwender"-Admin-Blick
  ist nicht mehr read-only – Bearbeiten/Löschen wirkt jetzt auf den
  jeweiligen Eigentümer statt immer auf den angemeldeten Nutzer.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LzqQmGQenzqn9X9LQFpnyd