### PR TITLE
Fix Firestore rules so admin collection-group listeners don't get denied

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -345,6 +345,25 @@ service cloud.firestore {
                     || isAdmin();
     }
 
+    // Collection-group rules: queries via collectionGroup() (subscribeToAllEvents,
+    // subscribeToAllGuestProfiles, subscribeToAllCustomDrinks/getAllCustomDrinks) are only
+    // authorized by a recursive-wildcard match – the path-specific rules above cover direct
+    // get()/collection reads but do NOT extend to collection-group list requests. Without
+    // these, an admin's "Alle Anwender" view (and everyone's shared custom-drinks library)
+    // briefly shows the locally cached snapshot before the live query is permission-denied,
+    // clearing the list again.
+    match /{path=**}/events/{eventId} {
+      allow read: if isAdmin();
+    }
+
+    match /{path=**}/customDrinks/{drinkId} {
+      allow read: if isAnyUser();
+    }
+
+    match /{path=**}/profiles/{guestId} {
+      allow read: if isAdmin();
+    }
+
     // Cuisine proposals collection - tracks user-proposed cuisine types for admin review
     match /cuisineProposals/{proposalId} {
       // Any authenticated user can read proposals


### PR DESCRIPTION
subscribeToAllEvents/subscribeToAllGuestProfiles/subscribeToAllCustomDrinks
use collectionGroup() queries, but firestore.rules only had path-specific
match blocks (e.g. users/{userId}/events/{eventId}). Those don't authorize
collectionGroup list requests, which Firestore requires a recursive
wildcard {path=**} match for. The live query was silently permission-denied
right after an initial cached snapshot rendered, so guests, drinks and
events flashed briefly for admins and then vanished. Add the missing
wildcard rules for events, customDrinks and profiles.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WH51Dt4aA88jJ3zjvRnvKa