### PR TITLE
Deploy Firestore indexes alongside rules in Firebase deploy workflow

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -93,7 +93,7 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Firebase deploy attempt $attempt/$max_attempts"
             set +e
-            deploy_output=$(firebase deploy --only hosting,functions,firestore:rules --project "$firebase_project" --force 2>&1)
+            deploy_output=$(firebase deploy --only hosting,functions,firestore:rules,firestore:indexes --project "$firebase_project" --force 2>&1)
             deploy_exit_code=$?
             set -e
             echo "$deploy_output"


### PR DESCRIPTION
firestore.indexes.json already defines COLLECTION_GROUP field overrides
for events/date, customDrinks/name and profiles/nachname — required by
the collectionGroup() + orderBy() queries behind admins' "Alle Anwender"
view (subscribeToAllEvents/subscribeToAllGuestProfiles/subscribeToAll-
CustomDrinks). But the deploy step only ever ran
`firebase deploy --only hosting,functions,firestore:rules`, so those
indexes were never pushed to production. Without them, the live
collectionGroup queries fail with a "requires an index" error right
after rendering the initial cached snapshot — the same flash-then-
vanish symptom the earlier rules fix (permission-denied) addressed,
just from a different cause. Add firestore:indexes to the deploy target.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FYvZpry3VDUPDXt29Z9RHe