### PR TITLE
Admins always see all users' guests, remove view toggle

### DIFF
--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -55,9 +55,8 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   const canManageGuests = canEditRecipes(currentUser);
   const closeIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
 
-  // Admin-only: browse all users' guest profiles instead of just the current user's own.
+  // Admin: always browse all users' guest profiles instead of just the current user's own.
   const isAdmin = currentUser?.isAdmin === true;
-  const [showAllGuests, setShowAllGuests] = useState(false);
   const [allProfiles, setAllProfiles] = useState([]);
   const [allProfilesLoading, setAllProfilesLoading] = useState(true);
   const [allUsers, setAllUsers] = useState([]);
@@ -68,13 +67,13 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   }, [isAdmin]);
 
   useEffect(() => {
-    if (!isAdmin || !showAllGuests) return undefined;
+    if (!isAdmin) return undefined;
     const unsubscribe = subscribeToAllGuestProfiles((loaded) => {
       setAllProfiles(loaded);
       setAllProfilesLoading(false);
     });
     return unsubscribe;
-  }, [isAdmin, showAllGuests]);
+  }, [isAdmin]);
 
   const getOwnerFirstName = (ownerId) => {
     if (!ownerId) return null;
@@ -542,28 +541,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         )}
       </div>
 
-      {isAdmin && (
-        <div className="events-manage-links">
-          <button
-            type="button"
-            className="events-manage-link-btn"
-            aria-pressed={!showAllGuests}
-            onClick={() => setShowAllGuests(false)}
-          >
-            Meine Gäste
-          </button>
-          <button
-            type="button"
-            className="events-manage-link-btn"
-            aria-pressed={showAllGuests}
-            onClick={() => setShowAllGuests(true)}
-          >
-            Alle Anwender
-          </button>
-        </div>
-      )}
-
-      {showAllGuests && isAdmin ? (
+      {isAdmin ? (
         allProfilesLoading ? (
           <div className="events-empty-state">Laden...</div>
         ) : sortedAllProfiles.length === 0 ? (

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -341,12 +341,23 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
   describe('admin cross-user guest visibility', () => {
     const adminUser = { id: 'admin1', isAdmin: true };
 
-    test('non-admins do not see the "Alle Anwender" toggle', () => {
+    test('non-admins do not see the "Meine Gäste"/"Alle Anwender" toggle', () => {
       render(<GuestManagementPage currentUser={currentUser} />);
       expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Meine Gäste' })).not.toBeInTheDocument();
     });
 
-    test('admin can switch to "Alle Anwender" and edit/delete another user\'s guest', async () => {
+    test('admin does not see the "Meine Gäste"/"Alle Anwender" toggle either', () => {
+      mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
+        cb([]);
+        return jest.fn();
+      });
+      render(<GuestManagementPage currentUser={adminUser} />);
+      expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Meine Gäste' })).not.toBeInTheDocument();
+    });
+
+    test('admin immediately sees all users\' guests and can edit/delete another user\'s guest', async () => {
       window.confirm = jest.fn(() => true);
       mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
         cb([
@@ -365,8 +376,6 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       });
 
       render(<GuestManagementPage currentUser={adminUser} />);
-
-      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
 
       expect(await screen.findByText('Ben Beispiel')).toBeInTheDocument();
 
@@ -389,7 +398,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       });
     });
 
-    test('admin deleting another user\'s guest passes the owner id through', () => {
+    test('admin deleting another user\'s guest passes the owner id through', async () => {
       window.confirm = jest.fn(() => true);
       mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
         cb([
@@ -399,9 +408,8 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
       });
 
       render(<GuestManagementPage currentUser={adminUser} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
 
-      fireEvent.click(screen.getByRole('button', { name: 'Ben Beispiel löschen' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Ben Beispiel löschen' }));
 
       expect(mockDeleteGuestProfile).toHaveBeenCalledWith(adminUser.id, 'g1', 'other-user');
     });


### PR DESCRIPTION
Guest management no longer shows "Meine Gäste"/"Alle Anwender" buttons
for admins; admins now always see every user's guest profiles.