### PR TITLE
Admins always see all users' events in Events

### DIFF
--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -105,9 +105,8 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const [selectedEventId, setSelectedEventId] = useState(null);
   const [selectedEventOwnerId, setSelectedEventOwnerId] = useState(currentUser?.id ?? null);
   const [fallbackEvent, setFallbackEvent] = useState(null); // used right after calculation, before onSnapshot syncs
-  // Admin-only: browse all users' events instead of just the current user's own.
+  // Admins always see every user's events instead of just their own.
   const isAdmin = currentUser?.isAdmin === true;
-  const [showAllEvents, setShowAllEvents] = useState(false);
   const [allEvents, setAllEvents] = useState([]);
   const [allEventsLoading, setAllEventsLoading] = useState(true);
   const [allUsers, setAllUsers] = useState([]);
@@ -151,13 +150,13 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   }, [isAdmin]);
 
   useEffect(() => {
-    if (!isAdmin || !showAllEvents) return undefined;
+    if (!isAdmin) return undefined;
     const unsubscribe = subscribeToAllEvents((loadedEvents) => {
       setAllEvents(loadedEvents);
       setAllEventsLoading(false);
     });
     return unsubscribe;
-  }, [isAdmin, showAllEvents]);
+  }, [isAdmin]);
 
   // Deep link from a push notification: jump straight to the consumption form.
   useEffect(() => {
@@ -521,28 +520,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         )}
       </div>
 
-      {isAdmin && (
-        <div className="events-manage-links">
-          <button
-            type="button"
-            className="events-manage-link-btn"
-            aria-pressed={!showAllEvents}
-            onClick={() => setShowAllEvents(false)}
-          >
-            Meine Events
-          </button>
-          <button
-            type="button"
-            className="events-manage-link-btn"
-            aria-pressed={showAllEvents}
-            onClick={() => setShowAllEvents(true)}
-          >
-            Alle Anwender
-          </button>
-        </div>
-      )}
-
-      {showAllEvents && isAdmin ? (
+      {isAdmin ? (
         allEventsLoading ? (
           <div className="events-empty-state">Laden...</div>
         ) : allEvents.length === 0 ? (

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -595,12 +595,12 @@ describe('EventsPage', () => {
   describe('admin cross-user event visibility', () => {
     const adminUser = { id: 'admin1', isAdmin: true };
 
-    test('non-admins do not see the "Alle Anwender" toggle', () => {
+    test('non-admins do not see events from other users', () => {
       render(<EventsPage currentUser={currentUser} />);
-      expect(screen.queryByRole('button', { name: 'Alle Anwender' })).not.toBeInTheDocument();
+      expect(mockSubscribeToAllEvents).not.toHaveBeenCalled();
     });
 
-    test('admin can switch to "Alle Anwender" and edit another user\'s event', async () => {
+    test('admins always see all users\' events and can edit another user\'s event', async () => {
       const othersEvent = {
         id: 'e1',
         eventName: 'Fremdes Fest',
@@ -619,7 +619,6 @@ describe('EventsPage', () => {
 
       render(<EventsPage currentUser={adminUser} />);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Alle Anwender' }));
       expect(await screen.findByText('Fremdes Fest')).toBeInTheDocument();
 
       fireEvent.click(screen.getByText('Fremdes Fest'));


### PR DESCRIPTION
Removes the "Meine Events" / "Alle Anwender" toggle for admins; the
events overview now always subscribes to and shows every user's events
when the current user is an admin, instead of requiring an extra click.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YTWpajtKKwGWiQpUqQ2qKy