### PR TITLE
Shrink oversized checkboxes on guest management page

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -671,6 +671,14 @@
   accent-color: #2F5D50;
 }
 
+.events-category-checkbox input[type="checkbox"],
+.events-driver-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
 .events-preferred-drinks-list {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
The guest and driver checkboxes had no explicit width/height, so they
rendered at the browser's unconstrained default size instead of the
16-20px size used by checkboxes elsewhere in the app.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QR1aas9MqNJsJRWyM1u8x3