### PR TITLE
Reveal guest delete button via left-swipe on mobile

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -91,15 +91,32 @@
 }
 
 .events-guest-card {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+}
+
+.events-guest-card-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 16px 20px;
+  background: white;
+  position: relative;
+  z-index: 1;
 }
 
 .events-guest-card .events-card-main {
   flex: 1;
   min-width: 0;
+}
+
+.events-guest-card.swipe-delete-active .swipe-delete-background {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .events-guest-delete-btn {
@@ -116,6 +133,22 @@
   font-size: 1rem;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
+}
+
+/* Mobile: the delete button is only revealed via the left-swipe gesture,
+   mirroring the "Zutat löschen" swipe-to-delete on the recipe edit page. */
+@media (max-width: 768px) {
+  .events-guest-delete-btn {
+    display: none;
+  }
+}
+
+/* Desktop: no touch swipe, so the static delete button stays visible and
+   the swipe reveal background never engages. */
+@media (min-width: 769px) {
+  .events-guest-card .swipe-delete-background {
+    display: none;
+  }
 }
 
 .events-guest-delete-btn:hover {

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -34,6 +34,135 @@ const getPreferenceLabel = (factor) => {
   return 'wird nicht berücksichtigt';
 };
 
+// Matches the "Zutat löschen" swipe-to-delete gesture from the recipe edit page
+// (see SortableIngredient in RecipeForm.js): swiping left reveals the delete
+// button on the right. On desktop the static button next to the card stays
+// visible instead (no touch events to trigger the swipe).
+const SWIPE_DELETE_THRESHOLD = 56;
+const SWIPE_DELETE_MAX_OFFSET = 96;
+const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
+
+function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
+  const touchStartXRef = React.useRef(null);
+  const touchStartYRef = React.useRef(null);
+  const swipeDirectionLockedRef = React.useRef(null);
+  const isSwipingRef = React.useRef(false);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [isDeleteActionVisible, setIsDeleteActionVisible] = useState(false);
+
+  const effectiveSwipeOffset = isDeleteActionVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+  const deleteLabel = `${fullName || 'Gast'} löschen`;
+
+  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
+    touchStartXRef.current = null;
+    touchStartYRef.current = null;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+    setSwipeOffset(0);
+    if (!keepDeleteAction) setIsDeleteActionVisible(false);
+  };
+
+  const handleTouchStart = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch) return;
+    if (isDeleteActionVisible) setIsDeleteActionVisible(false);
+    touchStartXRef.current = touch.clientX;
+    touchStartYRef.current = touch.clientY;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+  };
+
+  const handleTouchMove = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null) return;
+    const deltaX = touch.clientX - touchStartXRef.current;
+    const deltaY = touch.clientY - touchStartYRef.current;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
+      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
+    }
+
+    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
+      isSwipingRef.current = true;
+      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
+      if (e.cancelable) e.preventDefault();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (isSwipingRef.current && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
+      setIsDeleteActionVisible(true);
+      resetSwipe({ keepDeleteAction: true });
+      return;
+    }
+    resetSwipe();
+  };
+
+  const handleContentClick = () => {
+    if (isDeleteActionVisible) {
+      resetSwipe();
+      return;
+    }
+    onOpenEdit();
+  };
+
+  const handleSwipeDeleteClick = (e) => {
+    e.stopPropagation();
+    onDelete();
+    resetSwipe();
+  };
+
+  return (
+    <div className={`events-card events-guest-card${isDeleteActionVisible ? ' swipe-delete-active' : ''}`}>
+      <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
+        {isDeleteActionVisible && (
+          <button
+            type="button"
+            className="swipe-delete-action"
+            onClick={handleSwipeDeleteClick}
+            aria-label={deleteLabel}
+          >
+            {isBase64Image(deleteIcon) ? (
+              <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{deleteIcon}</span>
+            )}
+          </button>
+        )}
+      </div>
+      <div
+        className="events-guest-card-content"
+        style={{ transform: `translateX(${effectiveSwipeOffset}px)`, transition: 'transform 0.15s ease' }}
+        onClick={handleContentClick}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={() => resetSwipe()}
+      >
+        {children}
+        <button
+          type="button"
+          className="events-guest-delete-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          aria-label={deleteLabel}
+          title="Gast löschen"
+        >
+          {isBase64Image(deleteIcon) ? (
+            <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+          ) : (
+            <span className="swipe-delete-icon-text">{deleteIcon}</span>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function GuestManagementPage({ onBack, currentUser, recipes }) {
   const [profiles, setProfiles] = useState([]);
   const [customDrinks, setCustomDrinks] = useState([]);
@@ -555,7 +684,13 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
               const ownerName = getOwnerFirstName(profile.ownerId);
               const guestDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
               return (
-                <div key={`${profile.ownerId}_${profile.id}`} className="events-card events-guest-card" onClick={() => openEdit(profile)}>
+                <GuestCard
+                  key={`${profile.ownerId}_${profile.id}`}
+                  fullName={fullName}
+                  deleteIcon={guestDeleteIcon}
+                  onOpenEdit={() => openEdit(profile)}
+                  onDelete={() => handleDelete(profile)}
+                >
                   <div className="events-card-main">
                     <h3>{fullName || 'Unbenannter Gast'}</h3>
                     {profile.kind === true && <p className="events-info-text">Kind</p>}
@@ -563,23 +698,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
                       <p className="events-card-meta">von {ownerName}</p>
                     )}
                   </div>
-                  <button
-                    type="button"
-                    className="events-guest-delete-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(profile);
-                    }}
-                    aria-label={`${fullName || 'Gast'} löschen`}
-                    title="Gast löschen"
-                  >
-                    {isBase64Image(guestDeleteIcon) ? (
-                      <img src={guestDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-                    ) : (
-                      <span className="swipe-delete-icon-text">{guestDeleteIcon}</span>
-                    )}
-                  </button>
-                </div>
+                </GuestCard>
               );
             })}
           </div>
@@ -608,7 +727,13 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
             const preferredSummary = [...preferredDrinkNames, ...preferredCategoryNames];
             const guestDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
             return (
-              <div key={profile.id} className="events-card events-guest-card" onClick={() => openEdit(profile)}>
+              <GuestCard
+                key={profile.id}
+                fullName={fullName}
+                deleteIcon={guestDeleteIcon}
+                onOpenEdit={() => openEdit(profile)}
+                onDelete={() => handleDelete(profile)}
+              >
                 <div className="events-card-main">
                   <h3>{fullName || 'Unbenannter Gast'}</h3>
                   {profile.kind === true && <p className="events-info-text">Kind</p>}
@@ -618,23 +743,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
                     </p>
                   )}
                 </div>
-                <button
-                  type="button"
-                  className="events-guest-delete-btn"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDelete(profile);
-                  }}
-                  aria-label={`${fullName || 'Gast'} löschen`}
-                  title="Gast löschen"
-                >
-                  {isBase64Image(guestDeleteIcon) ? (
-                    <img src={guestDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-                  ) : (
-                    <span className="swipe-delete-icon-text">{guestDeleteIcon}</span>
-                  )}
-                </button>
-              </div>
+              </GuestCard>
             );
           })}
         </div>

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3951,6 +3951,10 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.45);
 }
 
+[data-theme="dark"] .events-guest-card-content {
+  background: #1e1e1e;
+}
+
 [data-theme="dark"] .events-guest-delete-btn {
   background: #2a2a2a;
   border-color: #555;


### PR DESCRIPTION
On mobile the guest card's delete button is now hidden by default and
revealed by swiping the card left, reusing the "Zutat löschen" swipe
gesture and button design from the recipe edit page. Desktop keeps the
static always-visible delete button since there is no touch swipe there.