### PR TITLE
Fix swipe-delete button on Gäste-Seite to reveal while dragging

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -114,7 +114,12 @@
   min-width: 0;
 }
 
-.events-guest-card.swipe-delete-active .swipe-delete-background {
+/* Unlike the opacity-gated reveal used elsewhere (e.g. RecipeForm's
+   ingredient rows), the guest card's delete background stays fully opaque
+   at all times. It's already hidden behind the opaque content row (z-index
+   1) at rest, so this lets it slide into view together with the content as
+   the user drags instead of only popping in once the swipe gesture ends. */
+.events-guest-card .swipe-delete-background {
   opacity: 1;
   pointer-events: auto;
 }

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -116,21 +116,20 @@ function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
 
   return (
     <div className={`events-card events-guest-card${isDeleteActionVisible ? ' swipe-delete-active' : ''}`}>
-      <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
-        {isDeleteActionVisible && (
-          <button
-            type="button"
-            className="swipe-delete-action"
-            onClick={handleSwipeDeleteClick}
-            aria-label={deleteLabel}
-          >
-            {isBase64Image(deleteIcon) ? (
-              <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-            ) : (
-              <span className="swipe-delete-icon-text">{deleteIcon}</span>
-            )}
-          </button>
-        )}
+      <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible && effectiveSwipeOffset === 0}>
+        <button
+          type="button"
+          className="swipe-delete-action"
+          onClick={handleSwipeDeleteClick}
+          aria-label={deleteLabel}
+          tabIndex={isDeleteActionVisible ? 0 : -1}
+        >
+          {isBase64Image(deleteIcon) ? (
+            <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+          ) : (
+            <span className="swipe-delete-icon-text">{deleteIcon}</span>
+          )}
+        </button>
       </div>
       <div
         className="events-guest-card-content"


### PR DESCRIPTION
The delete background/button only got opacity 1 once isDeleteActionVisible
flipped true on touch-end, so during the actual swipe gesture it stayed
invisible and then popped in abruptly after release instead of sliding in
with the finger. It's already fully hidden behind the opaque guest card
content at rest, so keeping it at opacity 1 lets translateX reveal it
progressively as the user drags.