### PR TITLE
Simplify checkbox styling using native accent-color

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -704,37 +704,13 @@
 
 .events-category-checkbox input[type="checkbox"],
 .events-driver-checkbox {
-  -webkit-appearance: none;
-  appearance: none;
   width: 18px;
   height: 18px;
   margin: 0;
-  border: 1.5px solid #ccc;
-  border-radius: 4px;
-  background: #fff;
+  padding: 0;
   cursor: pointer;
   flex-shrink: 0;
-  box-sizing: border-box;
-  position: relative;
-}
-
-.events-category-checkbox input[type="checkbox"]:checked,
-.events-driver-checkbox:checked {
-  background-color: #2F5D50;
-  border-color: #2F5D50;
-}
-
-.events-category-checkbox input[type="checkbox"]:checked::after,
-.events-driver-checkbox:checked::after {
-  content: '';
-  position: absolute;
-  left: 5px;
-  top: 1px;
-  width: 5px;
-  height: 9px;
-  border: solid #fff;
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
+  accent-color: #2F5D50;
 }
 
 .events-preferred-drinks-list {


### PR DESCRIPTION
## Summary
Refactored checkbox styling in the EventsPage component to use the native CSS `accent-color` property instead of custom styling with pseudo-elements. This simplifies the codebase and improves maintainability.

## Key Changes
- Removed custom checkbox appearance overrides (`-webkit-appearance` and `appearance: none`)
- Removed custom border, border-radius, and background styling
- Removed custom checked state styling with `::after` pseudo-element for checkmark rendering
- Replaced custom styling with native `accent-color: #2F5D50` property
- Added `padding: 0` to maintain consistent spacing
- Removed unnecessary `box-sizing` and `position` properties

## Implementation Details
The change leverages the modern `accent-color` CSS property to style checkboxes with the brand color (#2F5D50) while preserving the browser's native checkbox appearance and behavior. This approach:
- Reduces CSS code by ~24 lines
- Eliminates the need for pseudo-element manipulation
- Maintains consistent styling across browsers that support `accent-color`
- Improves accessibility by using native form controls

https://claude.ai/code/session_01DUhv2YRELrdUWg7Sz2TLW2