### PR TITLE
Add border-radius to event guest cards for rounded corners

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -107,6 +107,7 @@
   background: white;
   position: relative;
   z-index: 1;
+  border-radius: 10px;
 }
 
 .events-guest-card .events-card-main {
@@ -122,6 +123,7 @@
 .events-guest-card .swipe-delete-background {
   opacity: 1;
   pointer-events: auto;
+  border-radius: 10px;
 }
 
 .events-guest-delete-btn {


### PR DESCRIPTION
## Summary
This PR adds rounded corners to the event guest card components by applying a `border-radius` of 10px to both the main card container and the swipe delete background overlay.

## Key Changes
- Added `border-radius: 10px` to `.events-guest-card` to round the corners of the main card container
- Added `border-radius: 10px` to `.events-guest-card .swipe-delete-background` to ensure the delete action background matches the card's rounded appearance

## Implementation Details
These CSS changes ensure visual consistency when users interact with the swipe-to-delete functionality on event guest cards. The matching border-radius on both the card and its delete background prevents visual clipping or misalignment during the swipe animation.

https://claude.ai/code/session_01AGgbAzb56aN98nCwRKrdCn