### PR TITLE
Replace guest checkbox removal with swipe-to-delete in event guest selection

### DIFF
--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -5,6 +5,149 @@ import { getGuestDisplayName } from '../utils/guestPreferences';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 
+// Matches the swipe-to-delete gesture and delete button behavior used for
+// drinks (see DrinkRow in EventDrinkSelectionPage.js): swiping left reveals
+// the delete button on the right; on desktop the static button next to the
+// row stays visible instead (no touch events to trigger the swipe).
+const SWIPE_DELETE_THRESHOLD = 56;
+const SWIPE_DELETE_MAX_OFFSET = 96;
+const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
+
+function GuestRow({
+  fullName,
+  isDriver,
+  isDeleteVisible,
+  onToggleDriver,
+  onRemove,
+  onSwipeDeleteVisible,
+  onSwipeDeleteHidden,
+  swipeDeleteIcon,
+}) {
+  const touchStartXRef = useRef(null);
+  const touchStartYRef = useRef(null);
+  const swipeDirectionLockedRef = useRef(null);
+  const isSwipingRef = useRef(false);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+
+  const effectiveSwipeOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+
+  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
+    touchStartXRef.current = null;
+    touchStartYRef.current = null;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+    setSwipeOffset(0);
+    if (!keepDeleteAction) {
+      onSwipeDeleteHidden();
+    }
+  };
+
+  const handleTouchStart = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch) return;
+    if (isDeleteVisible) onSwipeDeleteHidden();
+    touchStartXRef.current = touch.clientX;
+    touchStartYRef.current = touch.clientY;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+  };
+
+  const handleTouchMove = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null) return;
+
+    const deltaX = touch.clientX - touchStartXRef.current;
+    const deltaY = touch.clientY - touchStartYRef.current;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
+      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
+    }
+
+    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
+      isSwipingRef.current = true;
+      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
+      if (e.cancelable) e.preventDefault();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (isSwipingRef.current && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
+      onSwipeDeleteVisible();
+      resetSwipe({ keepDeleteAction: true });
+      return;
+    }
+    resetSwipe();
+  };
+
+  const handleSwipeDeleteClick = () => {
+    onRemove();
+    resetSwipe();
+  };
+
+  const swipeContentStyle = {
+    transform: `translateX(${effectiveSwipeOffset}px)`,
+    transition: 'transform 0.15s ease',
+  };
+
+  return (
+    <div className={`events-guest-row${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}>
+      <div className="events-guest-row-swipe-background" aria-hidden={!isDeleteVisible}>
+        {isDeleteVisible && (
+          <button
+            type="button"
+            className="events-guest-row-swipe-action"
+            onClick={handleSwipeDeleteClick}
+            aria-label={`${fullName} entfernen`}
+          >
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
+          </button>
+        )}
+      </div>
+      <div
+        className="events-guest-row-content"
+        style={swipeContentStyle}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={resetSwipe}
+      >
+        <div className="events-guest-row-header">
+          <div className="events-guest-row-name">{fullName}</div>
+          <button
+            type="button"
+            className="events-guest-row-delete-btn"
+            onClick={onRemove}
+            aria-label={`${fullName} löschen`}
+            title="Gast entfernen"
+          >
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
+          </button>
+        </div>
+        <label className="events-guest-row-driver">
+          <input
+            type="checkbox"
+            className="events-driver-checkbox"
+            checked={isDriver}
+            onChange={onToggleDriver}
+            aria-label={`${fullName} als Fahrer markieren`}
+          />
+          <span>Fahrer</span>
+        </label>
+      </div>
+    </div>
+  );
+}
+
 function EventGuestSelectionPage({
   currentUser,
   ownerId,
@@ -22,10 +165,12 @@ function EventGuestSelectionPage({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
+  const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
   const searchRef = useRef(null);
   const dropdownRef = useRef(null);
   const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
   const effectiveOwnerId = ownerId || currentUser?.id;
+  const swipeDeleteIcon = getEffectiveIcon(effectiveButtonIcons, 'swipeDelete', isDarkMode) || '🗑';
 
   useEffect(() => {
     if (!effectiveOwnerId) return undefined;
@@ -145,44 +290,26 @@ function EventGuestSelectionPage({
           </div>
 
           {selectedGuests.length > 0 && (
-            <div className="events-table-container">
-              <table className="events-table">
-                <thead>
-                  <tr>
-                    <th>Gast</th>
-                    <th>Fahrer</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {selectedGuests.map((guest) => {
-                    const fullName = getGuestDisplayName(guest) || 'Unbenannter Gast';
-                    return (
-                      <tr key={guest.id}>
-                        <td>
-                          <label className="events-category-checkbox">
-                            <input
-                              type="checkbox"
-                              checked
-                              onChange={() => toggleGuest(guest.id)}
-                              aria-label={`${fullName} als Gast auswählen`}
-                            />
-                            <span>{fullName}</span>
-                          </label>
-                        </td>
-                        <td>
-                          <input
-                            type="checkbox"
-                            className="events-driver-checkbox"
-                            checked={driverGuestIds.includes(guest.id)}
-                            onChange={() => toggleDriverGuest(guest.id)}
-                            aria-label={`${fullName} als Fahrer markieren`}
-                          />
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+            <div className="events-guest-list">
+              {selectedGuests.map((guest) => {
+                const fullName = getGuestDisplayName(guest) || 'Unbenannter Gast';
+                const isDeleteVisible = swipeDeleteVisibleId === guest.id;
+                return (
+                  <GuestRow
+                    key={guest.id}
+                    fullName={fullName}
+                    isDriver={driverGuestIds.includes(guest.id)}
+                    isDeleteVisible={isDeleteVisible}
+                    onToggleDriver={() => toggleDriverGuest(guest.id)}
+                    onRemove={() => toggleGuest(guest.id)}
+                    onSwipeDeleteVisible={() => setSwipeDeleteVisibleId(guest.id)}
+                    onSwipeDeleteHidden={() =>
+                      setSwipeDeleteVisibleId((prev) => (prev === guest.id ? null : prev))
+                    }
+                    swipeDeleteIcon={swipeDeleteIcon}
+                  />
+                );
+              })}
             </div>
           )}
 

--- a/src/components/EventGuestSelectionPage.test.js
+++ b/src/components/EventGuestSelectionPage.test.js
@@ -101,7 +101,7 @@ describe('EventGuestSelectionPage', () => {
     expect(screen.getByText('Keine Gäste gefunden.')).toBeInTheDocument();
   });
 
-  test('selecting a guest from the dropdown adds them to the selection table', () => {
+  test('selecting a guest from the dropdown adds them to the selection list', () => {
     render(
       <EventGuestSelectionPage
         currentUser={currentUser}
@@ -119,8 +119,7 @@ describe('EventGuestSelectionPage', () => {
     fireEvent.mouseDown(option);
 
     expect(screen.getByText('1 Gast ausgewählt.')).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: 'Gast' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Anna Beispiel als Gast auswählen')).toBeInTheDocument();
+    expect(screen.getByText('Anna Beispiel', { selector: '.events-guest-row-name' })).toBeInTheDocument();
   });
 
   test('search input is cleared after selecting a guest', () => {
@@ -158,7 +157,7 @@ describe('EventGuestSelectionPage', () => {
     expect(screen.queryByRole('option', { name: 'Anna Beispiel' })).not.toBeInTheDocument();
   });
 
-  test('shows selected guests table with Gast and Fahrer columns', () => {
+  test('shows selected guests as rows with a Fahrer checkbox', () => {
     render(
       <EventGuestSelectionPage
         currentUser={currentUser}
@@ -169,12 +168,11 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    expect(screen.getByRole('columnheader', { name: 'Gast' })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: 'Fahrer' })).toBeInTheDocument();
     expect(screen.getByText('Anna Beispiel')).toBeInTheDocument();
+    expect(screen.getByLabelText('Anna Beispiel als Fahrer markieren')).toBeInTheDocument();
   });
 
-  test('deselecting a guest in the table removes them from the selection', () => {
+  test('removes a guest when swiped left and delete button is clicked', () => {
     render(
       <EventGuestSelectionPage
         currentUser={currentUser}
@@ -185,10 +183,31 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText('Anna Beispiel als Gast auswählen'));
+    const annaRowContent = screen.getByText('Anna Beispiel').closest('.events-guest-row-content');
+    fireEvent.touchStart(annaRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
+    fireEvent.touchMove(annaRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
+    fireEvent.touchEnd(annaRowContent);
+    fireEvent.click(screen.getByLabelText('Anna Beispiel entfernen'));
 
     expect(screen.getByText('0 Gäste ausgewählt.')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Anna Beispiel als Gast auswählen')).not.toBeInTheDocument();
+    expect(screen.queryByText('Anna Beispiel', { selector: '.events-guest-row-name' })).not.toBeInTheDocument();
+  });
+
+  test('removes a guest via the always-visible desktop delete button, without swiping', () => {
+    render(
+      <EventGuestSelectionPage
+        currentUser={currentUser}
+        selectedGuestIds={['g1']}
+        driverGuestIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Anna Beispiel löschen'));
+
+    expect(screen.getByText('0 Gäste ausgewählt.')).toBeInTheDocument();
+    expect(screen.queryByText('Anna Beispiel', { selector: '.events-guest-row-name' })).not.toBeInTheDocument();
   });
 
   test('toggles driver when checkbox is clicked', () => {
@@ -255,7 +274,7 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText('Anna Beispiel als Gast auswählen'));
+    fireEvent.click(screen.getByLabelText('Anna Beispiel löschen'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1646,6 +1646,126 @@
   border-color: #2F5D50;
 }
 
+/* Guest row two-line structure with swipe-to-delete, matching .events-drink-row */
+.events-guest-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.events-guest-row {
+  position: relative;
+  border-radius: 10px;
+  background: white;
+  border: 1px solid #e8e8e8;
+  box-shadow: none;
+}
+
+.events-guest-row.swipe-delete-active {
+  overflow: hidden;
+}
+
+.events-guest-row-swipe-background {
+  position: absolute;
+  inset: 0;
+  border-radius: 10px;
+  background: #e05245;
+  color: #fff;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 0.85rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.events-guest-row.swipe-delete-active .events-guest-row-swipe-background {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.events-guest-row-swipe-action {
+  -webkit-appearance: none;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: inherit;
+  width: 2.5rem;
+  height: 100%;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.events-guest-row-content {
+  position: relative;
+  z-index: 1;
+  padding: 16px;
+  background: white;
+  border-radius: 10px;
+}
+
+.events-guest-row-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.events-guest-row-name {
+  font-weight: 600;
+  color: #2F5D50;
+}
+
+/* Delete button for desktop, where left-swipe-to-delete isn't available. */
+.events-guest-row-delete-btn {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #ececec;
+  background: white;
+  color: #b3261e;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.events-guest-row-delete-btn:hover {
+  background: #fdecea;
+  border-color: #f3b7b1;
+}
+
+.events-guest-row-delete-btn .swipe-delete-icon-image {
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}
+
+@media (min-width: 769px) {
+  .events-guest-row-delete-btn {
+    display: flex;
+  }
+}
+
+.events-guest-row-driver {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: #666;
+}
+
 /* ── Swipe-Delete für Getränke-Zeilen ───────────────────────────────────── */
 
 .drink-list-item {

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -4243,6 +4243,35 @@
   border-color: #4f9a80;
 }
 
+[data-theme="dark"] .events-guest-row {
+  background: #1e1e1e;
+  border-color: #3d3d3d;
+  box-shadow: none;
+}
+
+[data-theme="dark"] .events-guest-row-content {
+  background: #1e1e1e;
+}
+
+[data-theme="dark"] .events-guest-row-name {
+  color: #7fb8a3;
+}
+
+[data-theme="dark"] .events-guest-row-delete-btn {
+  background: #2a2a2a;
+  border-color: #555;
+  color: #e8837a;
+}
+
+[data-theme="dark"] .events-guest-row-delete-btn:hover {
+  background: #3a2323;
+  border-color: #6b3a35;
+}
+
+[data-theme="dark"] .events-guest-row-driver {
+  color: #ccc;
+}
+
 [data-theme="dark"] .events-drink-add-btn {
   background: transparent;
   color: #ccc;


### PR DESCRIPTION
Guests selected for an event now render as swipeable rows matching the
drink selection page: swiping left reveals a delete action, and a static
delete button stays visible on desktop. Removing a guest deselects them
from the event the same way it already worked, just via the same gesture
and delete-button behavior used for drinks.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HahyWEbzPMfRa1KV1CYP3p