### PR TITLE
Add swipe-to-delete gesture for event cards

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1831,3 +1831,67 @@
   color: #8b2d21;
   font-size: 0.9rem;
 }
+
+/* ── Swipe-Delete für Event-Karten (gleiches Pattern wie bei Getränken) ── */
+
+.events-card-swipe-wrapper {
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+}
+
+.events-card-swipe-wrapper.swipe-delete-active .events-card-swipe-delete-background {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.events-card-swipe-delete-background {
+  position: absolute;
+  inset: 0;
+  background: #e05245;
+  color: #fff;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 0.85rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+  z-index: 0;
+  border-radius: 10px;
+}
+
+.events-card-swipe-delete-action {
+  border: none;
+  background: transparent;
+  color: inherit;
+  width: 2.5rem;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.events-card-swipe-content {
+  position: relative;
+  z-index: 1;
+  background: white;
+  border-radius: 10px;
+  transition: transform 0.15s ease;
+}
+
+.events-delete-banner {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  margin: 0.35rem 0 0.5rem;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid #f0c5bf;
+  border-radius: 8px;
+  background: #fff5f4;
+  color: #8b2d21;
+  font-size: 0.9rem;
+}

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import './EventsPage.css';
 import { subscribeToEvents, subscribeToAllEvents, deleteEvent, getEvent } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS, EVENT_TYPE_LABELS } from './EventForm';
@@ -18,6 +18,11 @@ const STATUS_LABELS = {
   eingekauft: 'Eingekauft',
   verbrauchErfasst: 'Verbrauch erfasst',
 };
+
+const SWIPE_DELETE_THRESHOLD = 56;
+const SWIPE_DELETE_MAX_OFFSET = 96;
+const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
+const DELETE_BANNER_TIMEOUT_MS = 5000;
 
 const formatDate = (dateStr) => {
   if (!dateStr) return '';
@@ -84,6 +89,115 @@ const formatDrinkSummary = (berechnung) => {
     .join(', ');
 };
 
+function EventCard({ event, ownerName, canManage, onSelect, onDelete, swipeDeleteIcon }) {
+  const touchStartXRef = React.useRef(null);
+  const touchStartYRef = React.useRef(null);
+  const swipeDirectionLockedRef = React.useRef(null);
+  const isSwipingRef = React.useRef(false);
+  const swipeOffsetRef = React.useRef(0);
+  const [swipeOffset, setSwipeOffset] = React.useState(0);
+  const [isDeleteVisible, setIsDeleteVisible] = React.useState(false);
+
+  const effectiveOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+
+  const resetSwipe = ({ keepDelete = false } = {}) => {
+    touchStartXRef.current = null;
+    touchStartYRef.current = null;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+    swipeOffsetRef.current = 0;
+    setSwipeOffset(0);
+    if (!keepDelete) setIsDeleteVisible(false);
+  };
+
+  const handleTouchStart = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch || !canManage) return;
+    if (isDeleteVisible) setIsDeleteVisible(false);
+    touchStartXRef.current = touch.clientX;
+    touchStartYRef.current = touch.clientY;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+  };
+
+  const handleTouchMove = (e) => {
+    const touch = e.touches?.[0];
+    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || !canManage) return;
+
+    const deltaX = touch.clientX - touchStartXRef.current;
+    const deltaY = touch.clientY - touchStartYRef.current;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
+      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
+    }
+
+    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
+      isSwipingRef.current = true;
+      const clamped = Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET);
+      swipeOffsetRef.current = clamped;
+      setSwipeOffset(clamped);
+      if (e.cancelable) e.preventDefault();
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (isSwipingRef.current && Math.abs(swipeOffsetRef.current) >= SWIPE_DELETE_THRESHOLD) {
+      setIsDeleteVisible(true);
+      resetSwipe({ keepDelete: true });
+      return;
+    }
+    resetSwipe();
+  };
+
+  return (
+    <div
+      className={`events-card-swipe-wrapper events-card${effectiveOffset < 0 ? ' swipe-delete-active' : ''}`}
+      style={{ padding: 0 }}
+    >
+      {canManage && (
+        <div className="events-card-swipe-delete-background" aria-hidden={!isDeleteVisible}>
+          {isDeleteVisible && (
+            <button
+              type="button"
+              className="events-card-swipe-delete-action"
+              onClick={() => { onDelete(event); resetSwipe(); }}
+              aria-label={`${event.eventName} löschen`}
+            >
+              {isBase64Image(swipeDeleteIcon) ? (
+                <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+              ) : (
+                <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+      <div
+        className="events-card-swipe-content events-card-main"
+        style={{ transform: `translateX(${effectiveOffset}px)`, padding: '16px 20px', width: '100%' }}
+        onClick={effectiveOffset < 0 || !canManage ? undefined : () => onSelect(event)}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={resetSwipe}
+      >
+        <h3>{event.eventName}</h3>
+        <div className="events-card-meta-row">
+          <p className="events-card-meta">
+            {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
+            {ownerName ? ` · von ${ownerName}` : ''}
+          </p>
+          <span className={`events-status-badge events-status-${event.status}`}>
+            {STATUS_LABELS[event.status] || event.status}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPendingEventReminderHandled, pendingEventDetailRequest, onPendingEventDetailRequestHandled, onCloseLinkedEventDetail }) {
   const [isMobileView, setIsMobileView] = useState(() => window.innerWidth <= 768);
   const [editFabPressed, setEditFabPressed] = useState(false);
@@ -110,6 +224,9 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const [allEvents, setAllEvents] = useState([]);
   const [allEventsLoading, setAllEventsLoading] = useState(true);
   const [allUsers, setAllUsers] = useState([]);
+  const [deleteBanners, setDeleteBanners] = useState([]);
+  const deleteBannerCounterRef = useRef(0);
+  const deleteBannerTimeoutsRef = useRef(new Map());
 
   useEffect(() => {
     const handleResize = () => setIsMobileView(window.innerWidth <= 768);
@@ -157,6 +274,14 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     });
     return unsubscribe;
   }, [isAdmin]);
+
+  useEffect(() => {
+    const timeouts = deleteBannerTimeoutsRef.current;
+    return () => {
+      timeouts.forEach((id) => clearTimeout(id));
+      timeouts.clear();
+    };
+  }, []);
 
   // Deep link from a push notification: jump straight to the consumption form.
   useEffect(() => {
@@ -230,6 +355,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   };
   const editEventIcon = getEffectiveIcon(buttonIcons, 'editRecipe', isDarkMode);
   const eventsCloseIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
+  const swipeDeleteIcon = getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑';
 
   const handleSelectEvent = (event, ownerId = currentUser?.id) => {
     setOpenedFromMenuLink(false);
@@ -256,6 +382,22 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
       setSubView('list');
       setSelectedEventId(null);
       setFallbackEvent(null);
+    } catch (err) {
+      console.error('Error deleting event:', err);
+    }
+  };
+
+  const handleSwipeDelete = async (event) => {
+    try {
+      await deleteEvent(event.ownerId || currentUser.id, event.id);
+      const id = deleteBannerCounterRef.current;
+      deleteBannerCounterRef.current = (id + 1) % 100000;
+      setDeleteBanners((prev) => [...prev, { id, message: `"${event.eventName}" gelöscht.` }]);
+      const timeoutId = setTimeout(() => {
+        setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
+        deleteBannerTimeoutsRef.current.delete(id);
+      }, DELETE_BANNER_TIMEOUT_MS);
+      deleteBannerTimeoutsRef.current.set(id, timeoutId);
     } catch (err) {
       console.error('Error deleting event:', err);
     }
@@ -529,25 +671,17 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
           </div>
         ) : (
           <div className="events-list">
-            {allEvents.map((event) => {
-              const ownerName = getOwnerFirstName(event.ownerId);
-              return (
-                <div key={`${event.ownerId}_${event.id}`} className="events-card" onClick={() => handleSelectEvent(event, event.ownerId)}>
-                  <div className="events-card-main">
-                    <h3>{event.eventName}</h3>
-                    <div className="events-card-meta-row">
-                      <p className="events-card-meta">
-                        {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
-                        {ownerName ? ` · von ${ownerName}` : ''}
-                      </p>
-                      <span className={`events-status-badge events-status-${event.status}`}>
-                        {STATUS_LABELS[event.status] || event.status}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+            {allEvents.map((event) => (
+              <EventCard
+                key={`${event.ownerId}_${event.id}`}
+                event={event}
+                ownerName={getOwnerFirstName(event.ownerId)}
+                canManage
+                onSelect={(e) => handleSelectEvent(e, event.ownerId)}
+                onDelete={handleSwipeDelete}
+                swipeDeleteIcon={swipeDeleteIcon}
+              />
+            ))}
           </div>
         )
       ) : loading ? (
@@ -561,25 +695,23 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         </div>
       ) : (
         <div className="events-list">
-          {events.map((event) => {
-            return (
-              <div key={event.id} className="events-card" onClick={() => handleSelectEvent(event)}>
-                <div className="events-card-main">
-                  <h3>{event.eventName}</h3>
-                  <div className="events-card-meta-row">
-                    <p className="events-card-meta">
-                      {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
-                    </p>
-                    <span className={`events-status-badge events-status-${event.status}`}>
-                      {STATUS_LABELS[event.status] || event.status}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+          {events.map((event) => (
+            <EventCard
+              key={event.id}
+              event={event}
+              canManage
+              onSelect={handleSelectEvent}
+              onDelete={handleSwipeDelete}
+              swipeDeleteIcon={swipeDeleteIcon}
+            />
+          ))}
         </div>
       )}
+      {deleteBanners.map((banner) => (
+        <div key={banner.id} className="events-delete-banner" role="status">
+          <span>{banner.message}</span>
+        </div>
+      ))}
       <OverviewAddFab onClick={() => setSubView('new')} title="Event erstellen" ariaLabel="Event erstellen" />
     </div>
   );

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import EventsPage from './EventsPage';
 
 const mockSubscribeToEvents = jest.fn();
@@ -630,6 +630,73 @@ describe('EventsPage', () => {
 
       fireEvent.click(editButton);
       expect(screen.getByText('EventForm geöffnet')).toBeInTheDocument();
+    });
+  });
+
+  describe('swipe-delete', () => {
+    const createTouchEvent = (clientX, clientY) => ({
+      touches: [{ clientX, clientY }],
+      cancelable: false,
+      preventDefault: jest.fn(),
+    });
+
+    const event = {
+      id: 'e1',
+      eventName: 'Sommerfest',
+      date: '2025-07-01',
+      durationHours: 4,
+      eventType: 'party',
+      status: 'berechnet',
+      guests: { adults: 10, children: 0 },
+      berechnung: { ergebnis: [] },
+    };
+
+    test('swipe-delete button appears after swiping an event card left', async () => {
+      mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+        cb([event]);
+        return jest.fn();
+      });
+
+      render(<EventsPage currentUser={currentUser} />);
+
+      const eventCardContent = screen.getByText('Sommerfest').closest('.events-card-swipe-content');
+      expect(eventCardContent).toBeInTheDocument();
+
+      fireEvent.touchStart(eventCardContent, createTouchEvent(200, 100));
+      fireEvent.touchMove(eventCardContent, createTouchEvent(130, 100));
+      fireEvent.touchEnd(eventCardContent, {});
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Sommerfest löschen' })).toBeInTheDocument();
+      });
+    });
+
+    test('clicking swipe-delete button calls deleteEvent and shows a banner, without opening the event', async () => {
+      mockDeleteEvent.mockResolvedValue(undefined);
+      mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+        cb([event]);
+        return jest.fn();
+      });
+
+      render(<EventsPage currentUser={currentUser} />);
+
+      const eventCardContent = screen.getByText('Sommerfest').closest('.events-card-swipe-content');
+      fireEvent.touchStart(eventCardContent, createTouchEvent(200, 100));
+      fireEvent.touchMove(eventCardContent, createTouchEvent(130, 100));
+      fireEvent.touchEnd(eventCardContent, {});
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Sommerfest löschen' })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Sommerfest löschen' }));
+
+      await waitFor(() => {
+        expect(mockDeleteEvent).toHaveBeenCalledWith(currentUser.id, 'e1');
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('"Sommerfest" gelöscht.');
+      });
     });
   });
 });

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -4176,6 +4176,10 @@
   background: #1e1e1e;
 }
 
+[data-theme="dark"] .events-card-swipe-content {
+  background: #1e1e1e;
+}
+
 [data-theme="dark"] .events-drink-row-name {
   color: #7fb8a3;
 }


### PR DESCRIPTION
## Summary
Implements a swipe-to-delete gesture for event cards in the EventsPage, allowing users to swipe left on an event to reveal a delete button. This mirrors the existing swipe-delete pattern used elsewhere in the application.

## Key Changes
- **New EventCard component**: Extracted event card rendering into a reusable component with built-in touch gesture handling
  - Manages swipe state with refs for touch coordinates, direction locking, and offset tracking
  - Implements horizontal swipe detection with direction locking to prevent accidental triggers on vertical scrolls
  - Reveals delete button when swipe threshold (56px) is exceeded, with max offset of 96px
  
- **Swipe delete functionality**:
  - Added `handleSwipeDelete` method to delete events and display confirmation banners
  - Integrated delete banner system with 5-second auto-dismiss timeout
  - Uses counter-based ID system to manage multiple simultaneous delete banners
  
- **UI/UX enhancements**:
  - Delete button appears with red background (#e05245) on swipe
  - Supports both emoji (🗑) and custom icon images for delete button
  - Smooth CSS transitions for swipe animations
  - Touch events properly prevented during horizontal swipes
  
- **Styling**:
  - Added `.events-card-swipe-wrapper`, `.events-card-swipe-content`, and `.events-card-swipe-delete-background` classes
  - Added `.events-delete-banner` for confirmation messages
  - Dark mode support for swipe-delete components
  
- **Testing**: Added comprehensive test cases for swipe gesture detection and delete functionality

## Implementation Details
- Direction locking threshold of 6px prevents accidental horizontal swipes during vertical scrolling
- Touch state is reset after swipe completes or when user touches elsewhere
- Delete banners use a Map-based timeout tracking system to properly clean up on unmount
- Event cards remain clickable when not swiped (offset = 0)

https://claude.ai/code/session_01TnPaMM2hHnk18b8CG2RcdW