### PR TITLE
Fix checkbox styling in events form

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -595,7 +595,7 @@
   color: #333;
 }
 
-.events-form-field input,
+.events-form-field input:not([type="checkbox"]),
 .events-form-field select {
   height: 44px;
   padding: 8px 16px;


### PR DESCRIPTION
## Summary
Updated the events form field styling to exclude checkboxes from the standard input height and padding rules.

## Key Changes
- Modified `.events-form-field input` selector to `.events-form-field input:not([type="checkbox"])` in EventsPage.css
- This prevents checkboxes from inheriting the 44px height and 8px 16px padding intended for text inputs and other input types

## Implementation Details
The CSS selector now uses the `:not([type="checkbox"])` pseudo-class to target only non-checkbox input elements. This ensures that checkboxes maintain their default size and appearance while text inputs, number inputs, and other input types continue to receive the intended styling (44px height with 8px vertical and 16px horizontal padding).

https://claude.ai/code/session_01XnchSMKDFHYk5Fh5A89gD8