### PR TITLE
Fix carousel and sidebar animation/layout issues

### DIFF
--- a/src/components/MenuFilterSidebar.css
+++ b/src/components/MenuFilterSidebar.css
@@ -17,11 +17,12 @@
   align-self: flex-start;
   position: sticky;
   top: 1rem;
+  overflow-x: hidden;
   transition: width 0.2s ease, padding 0.2s ease;
 }
 
 .menu-filter-sidebar--collapsed {
-  width: auto;
+  width: 64px;
   gap: 0;
   padding: 1rem 0.6rem;
   align-items: center;

--- a/src/components/RecipeFilterSidebar.css
+++ b/src/components/RecipeFilterSidebar.css
@@ -15,13 +15,14 @@
   position: sticky;
   top: 1rem;
   max-height: calc(100vh - 2rem);
+  overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
   transition: width 0.2s ease, padding 0.2s ease;
 }
 
 .recipe-filter-sidebar--collapsed {
-  width: auto;
+  width: 64px;
   gap: 0;
   padding: 1rem 0.6rem;
   align-items: center;

--- a/src/components/SortCarousel.css
+++ b/src/components/SortCarousel.css
@@ -43,9 +43,14 @@
 
   /* Expanded: the track grows to the full row width so all pills fit
      (or can be swiped through); collapsed, it shrinks back to fit just
-     the active pill via the max-width transition above. */
+     the active pill via the max-width transition above. Only max-width
+     changes here — width stays fit-content (see the base rule) so the
+     track's growth is driven entirely by the transitioning max-width.
+     Setting width: 100% here as well used to make the track snap
+     instantly to its old max-width cap (200px) the moment this class
+     was added, before the max-width transition had animated past that
+     same value, producing a visible jump right as the carousel opened. */
   .sort-carousel--expanded {
-    width: 100%;
     max-width: 100%;
   }
 }

--- a/src/components/SortCarousel.js
+++ b/src/components/SortCarousel.js
@@ -138,7 +138,10 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   // This only works cleanly if scrollLeft is already flush with the
   // active pill's left edge (see swipeActiveToTarget below) *before* this
   // runs — otherwise the pill both shrinks into view and slides sideways
-  // at once, which is the "hop" this used to produce.
+  // at once, which is the "hop" this used to produce. It also needs to
+  // start on the same frame as the CSS transition it's shadowing (see the
+  // rAF scheduling in shrinkTrack below), or the two still drift apart for
+  // their first few frames even with matching duration/easing.
   const animateScrollToStart = useCallback(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -163,8 +166,18 @@ function SortCarousel({ activeSort = 'alphabetical', onSortChange }) {
   // only place that calls setExpanded(false).
   const shrinkTrack = useCallback(() => {
     suppressScroll();
-    animateScrollToStart();
     setExpanded(false);
+    // animateScrollToStart must begin on the exact same frame the CSS
+    // max-width transition (triggered by the class change above) visually
+    // starts, or the two drift apart for their first few frames and the
+    // active pill wobbles as shrinking siblings briefly peek back into
+    // view. React only commits the class removal — and the browser only
+    // starts transitioning from the old value — after this frame paints,
+    // so wait two rAFs (commit, then paint) before starting the scrollLeft
+    // animation to line its start up with that.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(animateScrollToStart);
+    });
   }, [suppressScroll, animateScrollToStart]);
 
   // Phase 1: before touching any widths, bring the active pill to the


### PR DESCRIPTION
## Summary
This PR fixes several animation synchronization and layout issues in the SortCarousel and filter sidebars to prevent visual glitches during expand/collapse transitions.

## Key Changes

**SortCarousel Animation Sync**
- Added double `requestAnimationFrame` scheduling in `shrinkTrack()` to synchronize the scroll animation with the CSS max-width transition. The scroll animation now starts on the same frame the CSS transition visually begins, preventing the active pill from wobbling as siblings briefly peek back into view.
- Updated comments to explain the timing requirements for animation synchronization.

**SortCarousel CSS Fix**
- Removed `width: 100%` from `.sort-carousel--expanded` class, keeping only `max-width: 100%`. This prevents the track from snapping to its old 200px max-width cap before the max-width transition completes, which was causing a visible jump when the carousel opened.
- Added detailed comments explaining why width should remain `fit-content` during expansion.

**Filter Sidebar Layout Fixes**
- Changed `.menu-filter-sidebar--collapsed` and `.recipe-filter-sidebar--collapsed` from `width: auto` to `width: 64px` to provide a fixed collapsed width instead of relying on content-based sizing.
- Added `overflow-x: hidden` to both sidebar base styles to prevent horizontal overflow during transitions.

## Implementation Details
The carousel fix uses a two-frame delay (`requestAnimationFrame` called twice) to account for React's commit phase and the browser's paint phase, ensuring the scroll animation and CSS transition start in sync. The sidebar changes provide explicit sizing and overflow handling to create smooth, predictable collapse animations without layout shifts.

https://claude.ai/code/session_01W2PXixfaSMe4xAZiYjAWZ6