### PR TITLE
Improve swipe-to-reveal list button interaction on RecipeCard

### DIFF
--- a/src/components/RecipeCard.js
+++ b/src/components/RecipeCard.js
@@ -62,7 +62,16 @@ function RecipeCard({ recipe, onClick, isFavorite, favoriteActiveIcon, isNew, au
       }
     }
 
-    if (hasSwipeAction && swipeDirectionLocked.current === 'horizontal' && deltaX > SWIPE_HORIZONTAL_THRESHOLD) {
+    if (swipeDirectionLocked.current !== 'horizontal') return;
+
+    if (swipeRevealed) {
+      if (deltaX < -SWIPE_HORIZONTAL_THRESHOLD) {
+        isSwiping.current = true;
+        e.preventDefault();
+        const offset = Math.min(Math.max(MAX_SWIPE_OFFSET + deltaX, 0), MAX_SWIPE_OFFSET);
+        setSwipeOffset(offset);
+      }
+    } else if (hasSwipeAction && deltaX > SWIPE_HORIZONTAL_THRESHOLD) {
       isSwiping.current = true;
       e.preventDefault();
       const offset = Math.min(deltaX, MAX_SWIPE_OFFSET);
@@ -72,9 +81,17 @@ function RecipeCard({ recipe, onClick, isFavorite, favoriteActiveIcon, isNew, au
 
   const handleTouchEnd = () => {
     if (isSwiping.current) {
-      if (swipeOffset >= SWIPE_REVEAL_THRESHOLD) {
+      if (swipeRevealed) {
+        if (swipeOffset <= MAX_SWIPE_OFFSET - SWIPE_REVEAL_THRESHOLD) {
+          setSwipeRevealed(false);
+          setSwipeOffset(0);
+        } else {
+          setSwipeRevealed(true);
+          setSwipeOffset(MAX_SWIPE_OFFSET);
+        }
+      } else if (swipeOffset >= SWIPE_REVEAL_THRESHOLD) {
         setSwipeRevealed(true);
-        setSwipeOffset(0);
+        setSwipeOffset(MAX_SWIPE_OFFSET);
       } else {
         setSwipeRevealed(false);
         setSwipeOffset(0);
@@ -184,7 +201,7 @@ function RecipeCard({ recipe, onClick, isFavorite, favoriteActiveIcon, isNew, au
       <div
         className="recipe-card"
         style={{
-          transform: `translateX(${swipeRevealed ? MAX_SWIPE_OFFSET : swipeOffset}px)`,
+          transform: `translateX(${swipeOffset}px)`,
           transition: isSwiping.current ? 'none' : 'transform 0.2s ease',
         }}
         onClick={handleCardClick}
@@ -210,7 +227,11 @@ function RecipeCard({ recipe, onClick, isFavorite, favoriteActiveIcon, isNew, au
           <div className="new-badge">Neu</div>
         )}
         {hasImages && (
-          <div className="recipe-image" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="recipe-image"
+            onClick={(e) => e.stopPropagation()}
+            style={swipeRevealed ? { pointerEvents: 'none' } : undefined}
+          >
             <RecipeImageCarousel
               key={recipe.id}
               images={orderedImages}

--- a/src/components/RecipeCard.test.js
+++ b/src/components/RecipeCard.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import RecipeCard from './RecipeCard';
 
 const mockRecipeImageCarousel = jest.fn(() => <div data-testid="mock-carousel" />);
@@ -44,5 +44,86 @@ describe('RecipeCard thumbnail handling', () => {
 
     const carouselProps = mockRecipeImageCarousel.mock.calls[0][0];
     expect(carouselProps.images[0].thumbnailUrl).toBe('https://example.com/custom-thumb.jpg');
+  });
+});
+
+describe('RecipeCard swipe-to-reveal list button', () => {
+  const privateLists = [{ id: 'l1', name: 'Meine Liste', recipeIds: [] }];
+
+  const swipe = (card, points) => {
+    fireEvent.touchStart(card, { touches: [{ clientX: points[0].x, clientY: points[0].y }] });
+    points.slice(1).forEach(({ x, y }) => {
+      fireEvent.touchMove(card, { touches: [{ clientX: x, clientY: y }] });
+    });
+    fireEvent.touchEnd(card);
+  };
+
+  test('right swipe past threshold reveals the list button', () => {
+    const { container } = render(
+      <RecipeCard
+        recipe={{ id: 'r1', title: 'Test' }}
+        onClick={jest.fn()}
+        privateLists={privateLists}
+      />
+    );
+    const card = container.querySelector('.recipe-card');
+
+    swipe(card, [{ x: 0, y: 0 }, { x: 60, y: 0 }]);
+
+    expect(card).toHaveStyle('transform: translateX(80px)');
+  });
+
+  test('left swipe past threshold collapses a revealed card back', () => {
+    const { container } = render(
+      <RecipeCard
+        recipe={{ id: 'r1', title: 'Test' }}
+        onClick={jest.fn()}
+        privateLists={privateLists}
+      />
+    );
+    const card = container.querySelector('.recipe-card');
+
+    swipe(card, [{ x: 0, y: 0 }, { x: 60, y: 0 }]);
+    expect(card).toHaveStyle('transform: translateX(80px)');
+
+    swipe(card, [{ x: 200, y: 0 }, { x: 140, y: 0 }]);
+
+    expect(card).toHaveStyle('transform: translateX(0px)');
+  });
+
+  test('small left drag on a revealed card snaps back open', () => {
+    const { container } = render(
+      <RecipeCard
+        recipe={{ id: 'r1', title: 'Test' }}
+        onClick={jest.fn()}
+        privateLists={privateLists}
+      />
+    );
+    const card = container.querySelector('.recipe-card');
+
+    swipe(card, [{ x: 0, y: 0 }, { x: 60, y: 0 }]);
+    expect(card).toHaveStyle('transform: translateX(80px)');
+
+    swipe(card, [{ x: 200, y: 0 }, { x: 185, y: 0 }]);
+
+    expect(card).toHaveStyle('transform: translateX(80px)');
+  });
+
+  test('freezes carousel pointer events while the list button is revealed', () => {
+    const { container } = render(
+      <RecipeCard
+        recipe={{ id: 'r1', title: 'Test', image: 'https://example.com/img.jpg' }}
+        onClick={jest.fn()}
+        privateLists={privateLists}
+      />
+    );
+    const card = container.querySelector('.recipe-card');
+    const imageWrapper = container.querySelector('.recipe-image');
+
+    expect(imageWrapper).not.toHaveStyle('pointer-events: none');
+
+    swipe(card, [{ x: 0, y: 0 }, { x: 60, y: 0 }]);
+
+    expect(imageWrapper).toHaveStyle('pointer-events: none');
   });
 });


### PR DESCRIPTION
## Summary
Enhanced the swipe-to-reveal functionality on RecipeCard to provide better control when the list button is revealed. Users can now swipe left to collapse the revealed button, with smart snapping behavior based on swipe distance.

## Key Changes
- **Bidirectional swipe handling**: Added left swipe detection when the card is already revealed, allowing users to collapse the button by swiping left past a threshold
- **Smart snap-back behavior**: Small left swipes on a revealed card now snap back to the open position instead of closing, improving UX for accidental touches
- **Pointer events blocking**: The image carousel now has `pointer-events: none` applied when the list button is revealed, preventing unintended carousel interactions while the button is visible
- **Improved offset calculation**: Changed from conditional rendering of `MAX_SWIPE_OFFSET` to using `swipeOffset` state directly for more granular control during swipe animations
- **Enhanced touch end logic**: Refactored `handleTouchEnd` to properly handle both reveal and collapse scenarios with threshold-based snapping

## Implementation Details
- The swipe threshold logic now distinguishes between revealing (right swipe) and collapsing (left swipe) actions
- When revealed, left swipes below the threshold snap back to the revealed position (`MAX_SWIPE_OFFSET`), while swipes past the threshold collapse the card
- The transform now uses `swipeOffset` directly instead of a ternary, allowing smooth intermediate states during swiping
- Added comprehensive test coverage for all swipe scenarios including threshold behavior and pointer events freezing

https://claude.ai/code/session_01SEsjcJrFT6seAnVeG2SfMy