### PR TITLE
Hide delete button on mobile in EventForm

### DIFF
--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -466,7 +466,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, ownerId, onManage
 
         <div className="events-form-actions">
           {isEditing && onDelete && (
-            <button type="button" className="events-secondary-btn events-delete-btn" onClick={onDelete} disabled={saving}>
+            <button type="button" className="events-secondary-btn events-delete-btn events-secondary-btn--desktop-only" onClick={onDelete} disabled={saving}>
               Löschen
             </button>
           )}


### PR DESCRIPTION
## Summary
Added a responsive design class to hide the delete button on mobile devices while keeping it visible on desktop.

## Changes
- Added `events-secondary-btn--desktop-only` CSS class to the delete button in the EventForm component
- This ensures the delete action is only accessible on desktop viewports, improving mobile UX by reducing clutter

## Implementation Details
The delete button in the event editing interface now uses the `events-secondary-btn--desktop-only` class alongside existing classes. This class should be defined in the stylesheet to hide the button on mobile devices using media queries (e.g., `display: none` on screens below a certain breakpoint).

https://claude.ai/code/session_01AckCKd19RmPg3KYMqZk8Ly