### PR TITLE
Add deletion action guidelines documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+## Löschaktionen
+Jede Löschaktion nutzt die Komponente `DeleteRowButton` — niemals ein eigenes ×,
+keinen gefüllten Kreisbutton, kein Icon im Eingabefeld.
+28 × 28, Radius 999, transparent; Rot (#a33a26) auf 12 % Fläche erst bei Hover/Fokus;
+immer am rechten Zeilenrand; Tooltip + aria-label „<Name> entfernen".
+Löschen wirkt sofort + Snackbar „Rückgängig" (6 s, Wiederherstellung an alten Index) —
+kein Bestätigungsdialog außer beim Löschen eines ganzen Rezepts mit Inhalt.
+Spezifikation: design_handoff_pillenkarussell/Löschen Einheitlich.dc.html


### PR DESCRIPTION
## Summary
Added design and implementation guidelines for consistent deletion actions across the application.

## Changes
- Created `CLAUDE.md` documenting standardized deletion action specifications including:
  - Mandatory use of `DeleteRowButton` component for all delete actions
  - Visual specifications (28×28px, radius 999, transparent with red on hover)
  - Positioning requirements (right edge of row)
  - Accessibility requirements (tooltip + aria-label)
  - Interaction behavior (immediate deletion with 6-second undo snackbar)
  - Exception case (confirmation dialog only for recipe deletion with content)
  - Reference to design specification document

## Implementation Details
This documentation establishes a single source of truth for deletion UI patterns, ensuring consistency across the codebase and preventing ad-hoc implementations of delete buttons with custom styling or behavior.

https://claude.ai/code/session_01VR8u6z68j8SvpEC2Gy83ah