### PR TITLE
Improve factor input UX with intermediate value support and blur normalization

### DIFF
--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -138,6 +138,7 @@ function DrinkRow({
   const swipeDirectionLockedRef = useRef(null);
   const isSwipingRef = useRef(false);
   const [swipeOffset, setSwipeOffset] = useState(0);
+  const [factorInput, setFactorInput] = useState(factor.toFixed(2));
 
   const effectiveSwipeOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
 
@@ -277,11 +278,16 @@ function DrinkRow({
           <div className="events-drink-row-factor">
             <input
               type="number"
+              inputMode="decimal"
               min={minFactor}
               max={maxFactor}
               step="0.01"
-              value={factor.toFixed(2)}
-              onChange={(e) => onUpdateFactor(e.target.value)}
+              value={factorInput}
+              onChange={(e) => {
+                setFactorInput(e.target.value);
+                onUpdateFactor(e.target.value);
+              }}
+              onBlur={() => setFactorInput(factor.toFixed(2))}
               aria-label={`${displayName} Faktor`}
             />
           </div>

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -270,6 +270,49 @@ describe('EventDrinkSelectionPage', () => {
     expect(onSave).toHaveBeenCalledWith(['custom-wasser'], {}, {}, 25);
   });
 
+  test('allows typing intermediate partial values into the factor field without resetting to default', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={['custom-wasser']}
+        guestPreferenceMultipliers={{}}
+        selectedGuestIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton', { name: 'Wasser (eigen) Faktor' });
+    // Typing "0.5" goes through intermediate states that are out of the
+    // valid 0.1–2.0 range or not yet parseable ("0", "0."). The field must
+    // keep showing what was typed instead of snapping back to "1.00".
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(input).toHaveValue(0);
+    fireEvent.change(input, { target: { value: '0.' } });
+    expect(input).toHaveValue(null);
+    fireEvent.change(input, { target: { value: '0.5' } });
+    expect(input).toHaveValue(0.5);
+  });
+
+  test('reformats the factor field to the normalized value on blur', () => {
+    render(
+      <EventDrinkSelectionPage
+        customDrinks={customDrinks}
+        customDrinkIds={['custom-wasser']}
+        guestPreferenceMultipliers={{}}
+        selectedGuestIds={[]}
+        onSave={jest.fn()}
+        onBack={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton', { name: 'Wasser (eigen) Faktor' });
+    fireEvent.change(input, { target: { value: '4' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue(1);
+  });
+
   test('calls onBack when Abbrechen button is clicked', () => {
     const onBack = jest.fn();
     render(

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1652,7 +1652,7 @@
   padding: 8px 10px;
   border: 1px solid #ddd;
   border-radius: 8px;
-  font-size: 15px;
+  font-size: 16px;
   font-family: inherit;
   color: #333;
   text-align: right;


### PR DESCRIPTION
## Summary
This PR improves the user experience of the drink factor input field by allowing users to type intermediate partial values without the field resetting to defaults, and normalizing the value when focus is lost.

## Key Changes
- **Factor input state management**: Added local state (`factorInput`) to track the raw user input separately from the normalized factor value, allowing intermediate states like "0" or "0." to be displayed without snapping back to the default
- **Blur normalization**: Implemented `onBlur` handler that reformats the input to the normalized value (e.g., "4" becomes "1.00") when the user leaves the field, ensuring invalid values are corrected
- **Input mode enhancement**: Added `inputMode="decimal"` to the number input for better mobile keyboard experience
- **Font size adjustment**: Increased factor input font size from 15px to 16px for better readability and consistency with mobile accessibility standards

## Implementation Details
- The `factorInput` state is initialized with the formatted factor value and updated on every change
- The `onChange` handler updates both the local state and calls `onUpdateFactor` to propagate changes
- The `onBlur` handler resets the input to the normalized factor value, clamping out-of-range values to valid bounds
- Tests verify that intermediate values are preserved during typing and that invalid values are corrected on blur

https://claude.ai/code/session_01AhC9dpoHzeb9i1s4MJGkVx