### PR TITLE
Add "own drinks only" filter to drink selection and management

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -224,6 +224,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
   const [deleteBanners, setDeleteBanners] = useState([]);
+  const [showOwnOnly, setShowOwnOnly] = useState(true);
   const deleteBannerCounterRef = useRef(0);
   const deleteBannerTimeoutsRef = useRef(new Map());
   const formRef = useRef(null);
@@ -271,10 +272,11 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     () => (Array.isArray(recipes) ? recipes.filter(isDrinkRecipe) : []),
     [recipes]
   );
-  const allDrinks = useMemo(
-    () => mergePredefinedDrinks(drinks, currentUser?.id),
-    [drinks, currentUser?.id]
-  );
+  const allDrinks = useMemo(() => {
+    const merged = mergePredefinedDrinks(drinks, currentUser?.id);
+    if (!showOwnOnly) return merged;
+    return merged.filter((drink) => !drink.ownerId || drink.ownerId === currentUser?.id);
+  }, [drinks, currentUser?.id, showOwnOnly]);
   const groupedDrinks = useMemo(() => groupDrinksByCategory(allDrinks, recipes), [allDrinks, recipes]);
   const getOwnerFirstName = (ownerId) => {
     if (!ownerId) return null;
@@ -737,6 +739,21 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             )}
           </button>
         )}
+      </div>
+
+      <div className="drink-own-filter-row">
+        <label className="drink-own-filter-label">
+          <span>Eigene Getränke</span>
+          <span className="drink-own-filter-toggle">
+            <input
+              type="checkbox"
+              checked={showOwnOnly}
+              onChange={(e) => setShowOwnOnly(e.target.checked)}
+              aria-label="Nur eigene Getränke anzeigen"
+            />
+            <span className="drink-own-filter-toggle-slider" aria-hidden="true" />
+          </span>
+        </label>
       </div>
 
       {loading ? (

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -791,7 +791,7 @@ describe('DrinkManagementPage', () => {
   });
 
   describe('shared library across users', () => {
-    test('shows drinks from other users but does not allow editing or deleting them', () => {
+    const mockOtherUsersDrinks = () => {
       mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([
           { id: 'd1', name: 'Eigenes Bier', kategorie: 'bier', einheiten: [], ownerId: 'u1' },
@@ -799,8 +799,24 @@ describe('DrinkManagementPage', () => {
         ]);
         return jest.fn();
       });
+    };
+
+    test('"Eigene Getränke" is enabled by default and hides other users\' drinks', () => {
+      mockOtherUsersDrinks();
 
       render(<DrinkManagementPage currentUser={currentUser} />);
+
+      expect(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' })).toBeChecked();
+      expect(screen.getByText('Eigenes Bier')).toBeInTheDocument();
+      expect(screen.queryByText('Papas Wein')).not.toBeInTheDocument();
+    });
+
+    test('disabling "Eigene Getränke" shows drinks from other users but does not allow editing or deleting them', () => {
+      mockOtherUsersDrinks();
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' }));
 
       expect(screen.getByText('Eigenes Bier')).toBeInTheDocument();
       expect(screen.getByText('Papas Wein')).toBeInTheDocument();
@@ -820,6 +836,14 @@ describe('DrinkManagementPage', () => {
       fireEvent.touchMove(othersDrinkContent, { touches: [{ clientX: 130, clientY: 100 }], cancelable: false, preventDefault: jest.fn() });
       fireEvent.touchEnd(othersDrinkContent, {});
       expect(screen.queryByRole('button', { name: 'Papas Wein löschen' })).not.toBeInTheDocument();
+    });
+
+    test('predefined drinks stay visible while "Eigene Getränke" is enabled', () => {
+      mockOtherUsersDrinks();
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+
+      expect(screen.getByText('Mineralwasser')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -302,6 +302,7 @@ function EventDrinkSelectionPage({
   onBack,
   buttonIcons,
   isDarkMode,
+  currentUserId,
 }) {
   const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
   const swipeDeleteIcon = getEffectiveIcon(effectiveButtonIcons, 'swipeDelete', isDarkMode) || '🗑';
@@ -314,6 +315,7 @@ function EventDrinkSelectionPage({
   );
   const [pufferProzent, setPufferProzent] = useState(initialPufferProzent ?? DEFAULT_PUFFER_PROZENT);
   const [drinkToAdd, setDrinkToAdd] = useState('');
+  const [showOwnOnly, setShowOwnOnly] = useState(true);
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
@@ -403,6 +405,7 @@ function EventDrinkSelectionPage({
                   <option value="">Getränk auswählen …</option>
                   {customDrinks
                     .filter((d) => !customDrinkIds.includes(d.id))
+                    .filter((d) => !showOwnOnly || !d.ownerId || d.ownerId === currentUserId)
                     .map((drink) => (
                       <option key={drink.id} value={drink.id}>{resolveDrinkDisplay(drink, recipes).displayName}</option>
                     ))}
@@ -421,6 +424,21 @@ function EventDrinkSelectionPage({
                 >
                   Hinzufügen
                 </button>
+              </div>
+
+              <div className="drink-own-filter-row">
+                <label className="drink-own-filter-label">
+                  <span>Eigene Getränke</span>
+                  <span className="drink-own-filter-toggle">
+                    <input
+                      type="checkbox"
+                      checked={showOwnOnly}
+                      onChange={(e) => setShowOwnOnly(e.target.checked)}
+                      aria-label="Nur eigene Getränke in der Auswahl anzeigen"
+                    />
+                    <span className="drink-own-filter-toggle-slider" aria-hidden="true" />
+                  </span>
+                </label>
               </div>
 
               {selectedDrinks.length > 0 && (

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import EventDrinkSelectionPage from './EventDrinkSelectionPage';
 
 const customDrinks = [
@@ -336,6 +336,52 @@ describe('EventDrinkSelectionPage', () => {
     expect(options).toContain('Bier (eigen)');
   });
 
+  describe('"Eigene Getränke" filter on the add dropdown', () => {
+    const sharedCustomDrinks = [
+      { id: 'own-wasser', name: 'Eigenes Wasser', kategorie: 'wasser', ownerId: 'u1' },
+      { id: 'other-bier', name: 'Fremdes Bier', kategorie: 'bier', ownerId: 'u2' },
+      { id: 'unowned-saft', name: 'Saft ohne Owner', kategorie: 'saft' },
+    ];
+
+    test('is enabled by default and hides other users\' drinks from the dropdown', () => {
+      render(
+        <EventDrinkSelectionPage
+          customDrinks={sharedCustomDrinks}
+          customDrinkIds={[]}
+          currentUserId="u1"
+          onSave={jest.fn()}
+          onBack={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('checkbox', { name: 'Nur eigene Getränke in der Auswahl anzeigen' })).toBeChecked();
+
+      const select = screen.getByRole('combobox', { name: 'Getränk auswählen' });
+      const options = Array.from(select.options).map((o) => o.text);
+      expect(options).toContain('Eigenes Wasser');
+      expect(options).toContain('Saft ohne Owner');
+      expect(options).not.toContain('Fremdes Bier');
+    });
+
+    test('disabling the filter shows drinks from other users in the dropdown', () => {
+      render(
+        <EventDrinkSelectionPage
+          customDrinks={sharedCustomDrinks}
+          customDrinkIds={[]}
+          currentUserId="u1"
+          onSave={jest.fn()}
+          onBack={jest.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke in der Auswahl anzeigen' }));
+
+      const select = screen.getByRole('combobox', { name: 'Getränk auswählen' });
+      const options = Array.from(select.options).map((o) => o.text);
+      expect(options).toContain('Fremdes Bier');
+    });
+  });
+
   const drinksWithMultipleEinheiten = [
     {
       id: 'custom-bier-multi',
@@ -455,7 +501,8 @@ describe('EventDrinkSelectionPage', () => {
       />,
     );
 
-    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    const drinkRow = screen.getByText('Saft').closest('.events-drink-row');
+    expect(within(drinkRow).queryByRole('checkbox')).not.toBeInTheDocument();
     expect(screen.getByText('1,0 l (Flasche)')).toBeInTheDocument();
   });
 

--- a/src/components/EventForm.js
+++ b/src/components/EventForm.js
@@ -298,6 +298,7 @@ function EventForm({ onSaved, onCancel, onDelete, currentUser, ownerId, onManage
         recipes={recipes}
         buttonIcons={buttonIcons}
         isDarkMode={isDarkMode}
+        currentUserId={effectiveOwnerId}
         onSave={(newDrinkIds, newDrinkDistributionFactors, newDrinkSelectedEinheiten, newPufferProzent) => {
           setCustomDrinkIds(newDrinkIds);
           setDrinkDistributionFactors(newDrinkDistributionFactors || {});

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -847,6 +847,68 @@
   box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.3);
 }
 
+.drink-own-filter-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+.drink-own-filter-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+}
+
+.drink-own-filter-toggle {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.drink-own-filter-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.drink-own-filter-toggle-slider {
+  position: absolute;
+  inset: 0;
+  background-color: #ccc;
+  border-radius: 22px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.drink-own-filter-toggle-slider::before {
+  content: "";
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.15s ease;
+}
+
+.drink-own-filter-toggle input:checked + .drink-own-filter-toggle-slider {
+  background-color: #2F5D50;
+}
+
+.drink-own-filter-toggle input:checked + .drink-own-filter-toggle-slider::before {
+  transform: translateX(18px);
+}
+
+.drink-own-filter-toggle input:focus-visible + .drink-own-filter-toggle-slider {
+  box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.3);
+}
+
 .events-drink-selector {
   display: flex;
   gap: 8px;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -4019,6 +4019,14 @@
   background-color: #555;
 }
 
+[data-theme="dark"] .drink-own-filter-label {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .drink-own-filter-toggle-slider {
+  background-color: #555;
+}
+
 [data-theme="dark"] .events-delete-btn {
   background: #4a2323;
   color: #f0a0a0;


### PR DESCRIPTION
## Summary
This PR adds a toggle filter to both the drink management and event drink selection pages that allows users to show only their own drinks by default, while still being able to view drinks from other users when needed.

## Key Changes
- **New filter UI component**: Added a styled toggle switch (`.drink-own-filter-toggle`) with accompanying label and row styling to both DrinkManagementPage and EventDrinkSelectionPage
- **DrinkManagementPage**: 
  - Added `showOwnOnly` state (enabled by default)
  - Filters the merged drink list to show only drinks owned by the current user or drinks without an owner (predefined drinks)
  - Predefined drinks remain visible when the filter is enabled
- **EventDrinkSelectionPage**:
  - Added `showOwnOnly` state (enabled by default)
  - Filters the drink dropdown to exclude drinks owned by other users
  - Requires `currentUserId` prop to determine ownership
- **Dark mode support**: Added dark mode styling for the new filter components
- **Test coverage**: Updated existing tests and added new test cases to verify:
  - Filter is enabled by default and hides other users' drinks
  - Disabling the filter shows all available drinks
  - Predefined drinks remain visible when filter is enabled
  - Existing checkbox queries are scoped to avoid conflicts with the new filter checkbox

## Implementation Details
- The filter uses a custom checkbox-based toggle switch styled to match the existing design system
- Filter state is local to each component and doesn't persist across navigation
- The filter respects drink ownership via the `ownerId` field; drinks without an owner are always shown
- Accessibility: Filter toggle includes proper `aria-label` attributes and supports focus-visible styling

https://claude.ai/code/session_011isQ3wFNsqEwAJtP58rrJh