### PR TITLE
Add "Create New" buttons to Drink and Guest management headers

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -725,20 +725,30 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     <div className="events-page-container">
       <div className="events-page-header">
         <h2>Getränke verwalten</h2>
-        {onBack && (
+        <div className="events-page-header-actions">
           <button
-            className="app-close-button"
-            onClick={onBack}
-            aria-label="Getränke verwalten schließen"
-            title="Getränke verwalten schließen"
+            type="button"
+            className="events-primary-btn events-header-add-btn"
+            onClick={openNew}
+            aria-label="Neues Getränk anlegen"
           >
-            {isBase64Image(closeIcon) ? (
-              <img src={closeIcon} alt="Getränke verwalten schließen" className="app-close-button-icon-img" />
-            ) : (
-              closeIcon || '×'
-            )}
+            + Getränk
           </button>
-        )}
+          {onBack && (
+            <button
+              className="app-close-button"
+              onClick={onBack}
+              aria-label="Getränke verwalten schließen"
+              title="Getränke verwalten schließen"
+            >
+              {isBase64Image(closeIcon) ? (
+                <img src={closeIcon} alt="Getränke verwalten schließen" className="app-close-button-icon-img" />
+              ) : (
+                closeIcon || '×'
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="drink-own-filter-row">

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -21,6 +21,17 @@
   text-align: left;
 }
 
+.events-page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.events-header-add-btn {
+  display: inline-flex;
+  white-space: nowrap;
+}
+
 .events-close-btn {
   background: none;
   border: none;
@@ -1446,6 +1457,10 @@
 
 @media (max-width: 768px) {
   .events-save-desktop-only {
+    display: none;
+  }
+
+  .events-header-add-btn {
     display: none;
   }
 

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -653,20 +653,30 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     <div className="events-page-container">
       <div className="events-page-header">
         <h2>Gäste verwalten</h2>
-        {onBack && (
+        <div className="events-page-header-actions">
           <button
-            className="app-close-button"
-            onClick={onBack}
-            aria-label="Gäste verwalten schließen"
-            title="Gäste verwalten schließen"
+            type="button"
+            className="events-primary-btn events-header-add-btn"
+            onClick={openNew}
+            aria-label="Neuen Gast anlegen"
           >
-            {isBase64Image(closeIcon) ? (
-              <img src={closeIcon} alt="Gäste verwalten schließen" className="app-close-button-icon-img" />
-            ) : (
-              closeIcon || '×'
-            )}
+            + Gast
           </button>
-        )}
+          {onBack && (
+            <button
+              className="app-close-button"
+              onClick={onBack}
+              aria-label="Gäste verwalten schließen"
+              title="Gäste verwalten schließen"
+            >
+              {isBase64Image(closeIcon) ? (
+                <img src={closeIcon} alt="Gäste verwalten schließen" className="app-close-button-icon-img" />
+              ) : (
+                closeIcon || '×'
+              )}
+            </button>
+          )}
+        </div>
       </div>
 
       {isAdmin ? (


### PR DESCRIPTION
## Summary
Restructured the page headers in DrinkManagementPage and GuestManagementPage to include "Create New" action buttons alongside the existing close buttons. This improves UX by providing quick access to create new items directly from the management page headers.

## Changes
- **DrinkManagementPage & GuestManagementPage**: Wrapped header action buttons in a new `.events-page-header-actions` container to organize multiple header actions
- **Added "Create New" buttons**: Introduced primary action buttons ("+ Getränk" and "+ Gast") that trigger the `openNew` function, positioned before the close button
- **Updated styling**: 
  - New `.events-page-header-actions` class with flexbox layout for horizontal button alignment with 10px gap
  - New `.events-header-add-btn` class for consistent styling of the add buttons
  - Mobile responsiveness: Add buttons hidden on small screens via media query

## Implementation Details
- Both management pages now follow a consistent header pattern with action buttons grouped together
- The close button remains conditionally rendered based on the `onBack` prop
- Buttons maintain proper accessibility with `aria-label` attributes
- Mobile layout hides the add buttons to preserve screen space on smaller devices

https://claude.ai/code/session_01V83Rm1n3q8ujtgkKrCJta7