### PR TITLE
Dokumentation: Mobile-Richtlinien für Löschgesten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,7 @@ immer am rechten Zeilenrand; Tooltip + aria-label „<Name> entfernen".
 Löschen wirkt sofort + Snackbar „Rückgängig" (6 s, Wiederherstellung an alten Index) —
 kein Bestätigungsdialog außer beim Löschen eines ganzen Rezepts mit Inhalt.
 Spezifikation: design_handoff_pillenkarussell/Löschen Einheitlich.dc.html
+
+Diese Spezifikation gilt nur für Desktop. Auf Mobile gilt stattdessen die
+Linksswipe-Geste als Löschalternative — analog zur aktuell z. B. beim
+Event-Löschen verwendeten Interaktion.


### PR DESCRIPTION
## Zusammenfassung
Aktualisierung der Spezifikation für Löschaktionen um Mobile-Richtlinien.

## Änderungen
- Ergänzung der Desktop-spezifischen Natur der `DeleteRowButton`-Spezifikation
- Dokumentation der Mobile-Alternative: Linksswipe-Geste für Löschaktionen
- Verweis auf bestehende Event-Lösch-Implementierung als Referenzmuster

## Details
Die bisherige Spezifikation in CLAUDE.md beschrieb ausschließlich die Desktop-Variante mit dem `DeleteRowButton`. Diese Änderung verdeutlicht, dass diese Richtlinien nur für Desktop gelten, während Mobile-Geräte stattdessen die Linksswipe-Geste als Löschalternative verwenden — konsistent mit bereits implementierten Interaktionen wie dem Event-Löschen.

https://claude.ai/code/session_01PLWnjhEbEGEpeCV2jwfnyM