### PR TITLE
Unify delete actions with DeleteRowButton & UndoSnackbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17054,6 +17054,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -18376,7 +18377,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/components/DeleteRowButton.css
+++ b/src/components/DeleteRowButton.css
@@ -1,0 +1,96 @@
+/* Unified row-delete button (see DeleteRowButton.js).
+   Resting state stays quiet on purpose - red is reserved for hover/focus. */
+.delete-row-button {
+  position: relative;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(74, 52, 34, 0.38);
+  cursor: pointer;
+  transition: background 0.16s ease, color 0.16s ease;
+}
+
+/* Hit area >= 32px without growing the visible circle. */
+.delete-row-button::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .delete-row-button::before {
+    inset: -8px;
+  }
+}
+
+/* The row the button lives in should add this class to its hoverable
+   container so it gets the row tint and the icon darkens with it. */
+.delete-row-hover-target:hover,
+.delete-row-hover-target:focus-within {
+  background: rgba(120, 84, 52, 0.07);
+}
+
+.delete-row-hover-target:hover .delete-row-button:not(:hover):not(:focus-visible),
+.delete-row-hover-target:focus-within .delete-row-button:not(:hover):not(:focus-visible) {
+  color: rgba(74, 52, 34, 0.62);
+}
+
+.delete-row-button:hover,
+.delete-row-button:active,
+.delete-row-button:focus-visible {
+  color: #a33a26;
+  background: rgba(163, 58, 38, 0.12);
+}
+
+.delete-row-button:focus-visible {
+  outline: 2px solid rgba(163, 58, 38, 0.5);
+  outline-offset: 2px;
+}
+
+/* Narrow / touch viewports have no hover to reveal the row tint, so keep
+   the icon reachably visible at all times instead of only on rest alpha. */
+@media (max-width: 768px), (hover: none), (pointer: coarse) {
+  .delete-row-button {
+    color: rgba(74, 52, 34, 0.62);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .delete-row-button {
+    transition: none;
+  }
+}
+
+[data-theme="dark"] .delete-row-button {
+  color: rgba(255, 255, 255, 0.38);
+}
+
+[data-theme="dark"] .delete-row-hover-target:hover,
+[data-theme="dark"] .delete-row-hover-target:focus-within {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] .delete-row-hover-target:hover .delete-row-button:not(:hover):not(:focus-visible),
+[data-theme="dark"] .delete-row-hover-target:focus-within .delete-row-button:not(:hover):not(:focus-visible) {
+  color: rgba(255, 255, 255, 0.62);
+}
+
+[data-theme="dark"] .delete-row-button:hover,
+[data-theme="dark"] .delete-row-button:active,
+[data-theme="dark"] .delete-row-button:focus-visible {
+  color: #ff8a72;
+  background: rgba(255, 114, 90, 0.18);
+}
+
+@media (max-width: 768px), (hover: none), (pointer: coarse) {
+  [data-theme="dark"] .delete-row-button {
+    color: rgba(255, 255, 255, 0.62);
+  }
+}

--- a/src/components/DeleteRowButton.js
+++ b/src/components/DeleteRowButton.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import './DeleteRowButton.css';
+import CloseThinIcon from './icons/CloseThinIcon';
+
+// Unified row-delete action used everywhere an item can be removed from a
+// list (guests, event drinks, selected recipes, ingredients, steps, ...).
+// See DeleteRowButton.css for the resting/hover/active/focus states — the
+// row it sits in should carry the `delete-row-hover-target` class so the
+// icon can react to the row (not just the button) being hovered.
+function DeleteRowButton({ itemName, onClick, className = '', ...rest }) {
+  const label = `${itemName} entfernen`;
+
+  return (
+    <button
+      type="button"
+      className={`delete-row-button${className ? ` ${className}` : ''}`}
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      {...rest}
+    >
+      <CloseThinIcon size={13} />
+    </button>
+  );
+}
+
+export default DeleteRowButton;

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -2,6 +2,9 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import './EventsPage.css';
 import { subscribeToAllCustomDrinks, saveCustomDrink, deleteCustomDrink } from '../utils/eventsFirestore';
 import OverviewAddFab from './OverviewAddFab';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 import RecipeTypeahead from './RecipeTypeahead';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel, mergePredefinedDrinks } from '../utils/drinkCategories';
 import { getCustomLists, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
@@ -57,7 +60,6 @@ const isDrinkRecipe = (recipe) =>
 const SWIPE_DELETE_THRESHOLD = 56;
 const SWIPE_DELETE_MAX_OFFSET = 96;
 const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-const DELETE_BANNER_TIMEOUT_MS = 5000;
 
 const UNIT_SIZES = [
   { label: '200 ml', value: 0.2 },
@@ -187,7 +189,18 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <h3>{displayName}</h3>
+        <div className="drink-list-item-header delete-row-hover-target">
+          <h3>{displayName}</h3>
+          {!drink.predefined && canManage && (
+            <DeleteRowButton
+              itemName={displayName}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(drink);
+              }}
+            />
+          )}
+        </div>
         <p className="events-card-meta">
           {[
             drink.kategorie ? getDrinkCategoryLabel(drink.kategorie) : null,
@@ -223,9 +236,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
-  const [deleteBanners, setDeleteBanners] = useState([]);
-  const deleteBannerCounterRef = useRef(0);
-  const deleteBannerTimeoutsRef = useRef(new Map());
+  const { notifyDeleted, undo, pendingName } = useUndoableDelete();
   const formRef = useRef(null);
 
   useEffect(() => {
@@ -257,14 +268,6 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
       setLoading(false);
     });
     return unsubscribe;
-  }, []);
-
-  useEffect(() => {
-    const timeouts = deleteBannerTimeoutsRef.current;
-    return () => {
-      timeouts.forEach((id) => clearTimeout(id));
-      timeouts.clear();
-    };
   }, []);
 
   const drinkRecipes = useMemo(
@@ -420,20 +423,26 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   };
 
   const handleDelete = async (drink) => {
+    const displayName = resolveDrinkDisplay(drink, recipes).displayName;
     try {
       await deleteCustomDrink(drink.ownerId || currentUser.id, drink.id);
-      const id = deleteBannerCounterRef.current;
-      deleteBannerCounterRef.current = (id + 1) % 100000;
-      const deletedDisplayName = resolveDrinkDisplay(drink, recipes).displayName;
-      setDeleteBanners((prev) => [...prev, { id, message: `"${deletedDisplayName}" gelöscht.` }]);
-      const timeoutId = setTimeout(() => {
-        setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
-        deleteBannerTimeoutsRef.current.delete(id);
-      }, DELETE_BANNER_TIMEOUT_MS);
-      deleteBannerTimeoutsRef.current.set(id, timeoutId);
     } catch (err) {
       console.error('Error deleting custom drink:', err);
+      return;
     }
+    notifyDeleted({
+      id: `${drink.ownerId || ''}_${drink.id}`,
+      name: displayName,
+      undo: async () => {
+        // eslint-disable-next-line no-unused-vars
+        const { id, ownerId, predefined, ...payload } = drink;
+        try {
+          await saveCustomDrink(drink.ownerId || currentUser.id, payload, drink.id);
+        } catch (err) {
+          console.error('Error restoring custom drink:', err);
+        }
+      },
+    });
   };
 
   if (showForm) {
@@ -765,12 +774,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
           )}
         </div>
       )}
-      {deleteBanners.map((banner) => (
-        <div key={banner.id} className="drink-delete-banner" role="status">
-          <span>{banner.message}</span>
-        </div>
-      ))}
       <OverviewAddFab onClick={openNew} title="Getränk anlegen" ariaLabel="Getränk anlegen" />
+      <UndoSnackbar itemName={pendingName} onUndo={undo} />
     </div>
   );
 }

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -761,7 +761,7 @@ describe('DrinkManagementPage', () => {
       });
     });
 
-    test('delete banner appears after deleting a drink', async () => {
+    test('undo snackbar appears after deleting a drink', async () => {
       mockDeleteCustomDrink.mockResolvedValue(undefined);
       mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
         cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
@@ -779,7 +779,7 @@ describe('DrinkManagementPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Craft-Bier löschen' }));
 
       await waitFor(() => {
-        expect(screen.getByRole('status')).toHaveTextContent('"Craft-Bier" gelöscht.');
+        expect(screen.getByRole('status')).toHaveTextContent('„Craft-Bier" entfernt');
       });
     });
 

--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -4,6 +4,9 @@ import UnitChip from './UnitChip';
 import { getEffectiveIcon, DEFAULT_BUTTON_ICONS } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const MIN_DISTRIBUTION_FACTOR = 0.1;
 const MAX_DISTRIBUTION_FACTOR = 2.0;
@@ -229,21 +232,13 @@ function DrinkRow({
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <div className="events-drink-row-header">
+        <div className="events-drink-row-header delete-row-hover-target">
           <div className="events-drink-row-name">{displayName}</div>
-          <button
-            type="button"
+          <DeleteRowButton
             className="events-drink-row-delete-btn"
+            itemName={displayName}
             onClick={onRemove}
-            aria-label={`${displayName} löschen`}
-            title="Getränk entfernen"
-          >
-            {isBase64Image(swipeDeleteIcon) ? (
-              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-            ) : (
-              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
-            )}
-          </button>
+          />
         </div>
         <div className="events-drink-row-details">
           <div className="events-drink-row-einheiten">
@@ -317,6 +312,7 @@ function EventDrinkSelectionPage({
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
+  const { notifyDeleted, undo, pendingName } = useUndoableDelete();
 
   const toggleCustomDrink = (id) => {
     setCustomDrinkIds((prev) => {
@@ -350,6 +346,26 @@ function EventDrinkSelectionPage({
         current.add(idx);
       }
       return { ...prev, [drinkId]: current };
+    });
+  };
+
+  const handleRemoveDrink = (drinkId, displayName) => {
+    const priorFactor = drinkDistributionFactors[drinkId];
+    const priorEinheiten = drinkSelectedEinheiten[drinkId];
+    toggleCustomDrink(drinkId);
+    notifyDeleted({
+      id: drinkId,
+      name: displayName,
+      undo: () => {
+        setCustomDrinkIds((prev) => (prev.includes(drinkId) ? prev : [...prev, drinkId]));
+        if (priorFactor !== undefined) {
+          setDrinkDistributionFactors((prev) => ({ ...prev, [drinkId]: priorFactor }));
+        }
+        setDrinkSelectedEinheiten((prev) => ({
+          ...prev,
+          [drinkId]: priorEinheiten ? new Set(priorEinheiten) : new Set([0]),
+        }));
+      },
     });
   };
 
@@ -441,7 +457,7 @@ function EventDrinkSelectionPage({
                         isDeleteVisible={isDeleteVisible}
                         onToggleEinheit={(idx) => toggleEinheit(drink.id, idx)}
                         onUpdateFactor={(val) => updateDistributionFactor(drink.id, val)}
-                        onRemove={() => toggleCustomDrink(drink.id)}
+                        onRemove={() => handleRemoveDrink(drink.id, resolveDrinkDisplay(drink, recipes).displayName)}
                         onSwipeDeleteVisible={() => setSwipeDeleteVisibleId(drink.id)}
                         onSwipeDeleteHidden={() => setSwipeDeleteVisibleId((prev) => prev === drink.id ? null : prev)}
                         minFactor={MIN_DISTRIBUTION_FACTOR}
@@ -523,6 +539,7 @@ function EventDrinkSelectionPage({
           getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)
         )}
       </button>
+      <UndoSnackbar itemName={pendingName} onUndo={undo} />
     </div>
   );
 }

--- a/src/components/EventDrinkSelectionPage.test.js
+++ b/src/components/EventDrinkSelectionPage.test.js
@@ -134,14 +134,14 @@ describe('EventDrinkSelectionPage', () => {
     fireEvent.touchStart(wasserRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
     fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
     fireEvent.touchEnd(wasserRowContent);
-    fireEvent.click(screen.getByLabelText('Wasser (eigen) entfernen'));
+    fireEvent.click(wasserRowContent.parentElement.querySelector('.events-drink-row-swipe-action'));
 
     expect(screen.queryByText('Wasser (eigen)', { selector: '.events-drink-row-name' })).not.toBeInTheDocument();
     expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
   });
 
   test('removes a drink via the always-visible desktop delete button, without swiping', () => {
-    render(
+    const { container } = render(
       <EventDrinkSelectionPage
         customDrinks={customDrinks}
         customDrinkIds={['custom-wasser', 'custom-bier']}
@@ -152,7 +152,7 @@ describe('EventDrinkSelectionPage', () => {
       />,
     );
 
-    fireEvent.click(screen.getByLabelText('Wasser (eigen) löschen'));
+    fireEvent.click(container.querySelector('.events-drink-row-delete-btn'));
 
     expect(screen.queryByText('Wasser (eigen)', { selector: '.events-drink-row-name' })).not.toBeInTheDocument();
     expect(screen.getByText('1 Getränk ausgewählt.')).toBeInTheDocument();
@@ -176,7 +176,7 @@ describe('EventDrinkSelectionPage', () => {
     fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
     fireEvent.touchEnd(wasserRowContent);
 
-    const deleteButton = screen.getByLabelText('Wasser (eigen) entfernen');
+    const deleteButton = wasserRowContent.parentElement.querySelector('.events-drink-row-swipe-action');
 
     // Simulate a real tap on the delete button: touchstart, touchend, then click all target the
     // button itself. Since touch handlers only live on the content element (not the row or the
@@ -208,7 +208,7 @@ describe('EventDrinkSelectionPage', () => {
     fireEvent.touchMove(wasserRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
     fireEvent.touchEnd(wasserRowContent);
 
-    expect(screen.getByLabelText('Wasser (eigen) entfernen')).toHaveTextContent('❌');
+    expect(wasserRowContent.parentElement.querySelector('.events-drink-row-swipe-action')).toHaveTextContent('❌');
   });
 
   test('adds a drink via the dropdown', () => {

--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -4,6 +4,9 @@ import { subscribeToGuestProfiles } from '../utils/eventsFirestore';
 import { getGuestDisplayName } from '../utils/guestPreferences';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 // Matches the swipe-to-delete gesture and delete button behavior used for
 // drinks (see DrinkRow in EventDrinkSelectionPage.js): swiping left reveals
@@ -117,21 +120,13 @@ function GuestRow({
         onTouchEnd={handleTouchEnd}
         onTouchCancel={resetSwipe}
       >
-        <div className="events-guest-row-header">
+        <div className="events-guest-row-header delete-row-hover-target">
           <div className="events-guest-row-name">{fullName}</div>
-          <button
-            type="button"
+          <DeleteRowButton
             className="events-guest-row-delete-btn"
+            itemName={fullName}
             onClick={onRemove}
-            aria-label={`${fullName} löschen`}
-            title="Gast entfernen"
-          >
-            {isBase64Image(swipeDeleteIcon) ? (
-              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-            ) : (
-              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
-            )}
-          </button>
+          />
         </div>
         <label className="events-guest-row-driver">
           <input
@@ -171,6 +166,7 @@ function EventGuestSelectionPage({
   const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
   const effectiveOwnerId = ownerId || currentUser?.id;
   const swipeDeleteIcon = getEffectiveIcon(effectiveButtonIcons, 'swipeDelete', isDarkMode) || '🗑';
+  const { notifyDeleted, undo, pendingName } = useUndoableDelete();
 
   useEffect(() => {
     if (!effectiveOwnerId) return undefined;
@@ -201,6 +197,21 @@ function EventGuestSelectionPage({
     setSelectedGuestIds((prev) =>
       prev.includes(guestId) ? prev.filter((id) => id !== guestId) : [...prev, guestId]
     );
+  };
+
+  const handleRemoveGuest = (guestId, fullName) => {
+    const wasDriver = driverGuestIds.includes(guestId);
+    toggleGuest(guestId);
+    notifyDeleted({
+      id: guestId,
+      name: fullName,
+      undo: () => {
+        setSelectedGuestIds((prev) => (prev.includes(guestId) ? prev : [...prev, guestId]));
+        if (wasDriver) {
+          setDriverGuestIds((prev) => (prev.includes(guestId) ? prev : [...prev, guestId]));
+        }
+      },
+    });
   };
 
   const toggleDriverGuest = (guestId) => {
@@ -301,7 +312,7 @@ function EventGuestSelectionPage({
                     isDriver={driverGuestIds.includes(guest.id)}
                     isDeleteVisible={isDeleteVisible}
                     onToggleDriver={() => toggleDriverGuest(guest.id)}
-                    onRemove={() => toggleGuest(guest.id)}
+                    onRemove={() => handleRemoveGuest(guest.id, fullName)}
                     onSwipeDeleteVisible={() => setSwipeDeleteVisibleId(guest.id)}
                     onSwipeDeleteHidden={() =>
                       setSwipeDeleteVisibleId((prev) => (prev === guest.id ? null : prev))
@@ -380,6 +391,7 @@ function EventGuestSelectionPage({
           getEffectiveIcon(effectiveButtonIcons, 'cancelRecipe', isDarkMode)
         )}
       </button>
+      <UndoSnackbar itemName={pendingName} onUndo={undo} />
     </div>
   );
 }

--- a/src/components/EventGuestSelectionPage.test.js
+++ b/src/components/EventGuestSelectionPage.test.js
@@ -187,14 +187,14 @@ describe('EventGuestSelectionPage', () => {
     fireEvent.touchStart(annaRowContent, { touches: [{ clientX: 200, clientY: 100 }] });
     fireEvent.touchMove(annaRowContent, { touches: [{ clientX: 80, clientY: 100 }] });
     fireEvent.touchEnd(annaRowContent);
-    fireEvent.click(screen.getByLabelText('Anna Beispiel entfernen'));
+    fireEvent.click(annaRowContent.parentElement.querySelector('.events-guest-row-swipe-action'));
 
     expect(screen.getByText('0 Gäste ausgewählt.')).toBeInTheDocument();
     expect(screen.queryByText('Anna Beispiel', { selector: '.events-guest-row-name' })).not.toBeInTheDocument();
   });
 
   test('removes a guest via the always-visible desktop delete button, without swiping', () => {
-    render(
+    const { container } = render(
       <EventGuestSelectionPage
         currentUser={currentUser}
         selectedGuestIds={['g1']}
@@ -204,7 +204,7 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText('Anna Beispiel löschen'));
+    fireEvent.click(container.querySelector('.events-guest-row-delete-btn'));
 
     expect(screen.getByText('0 Gäste ausgewählt.')).toBeInTheDocument();
     expect(screen.queryByText('Anna Beispiel', { selector: '.events-guest-row-name' })).not.toBeInTheDocument();
@@ -274,7 +274,7 @@ describe('EventGuestSelectionPage', () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText('Anna Beispiel löschen'));
+    fireEvent.click(screen.getByLabelText('Anna Beispiel entfernen'));
 
     fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
 

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -128,24 +128,15 @@
 
 .events-guest-delete-btn {
   flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  border: 1px solid #ececec;
-  background: white;
-  color: #b3261e;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  margin-left: auto;
 }
 
 /* Mobile: the delete button is only revealed via the left-swipe gesture,
-   mirroring the "Zutat löschen" swipe-to-delete on the recipe edit page. */
+   mirroring the "Zutat löschen" swipe-to-delete on the recipe edit page.
+   Compounded with .delete-row-button so this wins regardless of CSS import
+   order between this file and DeleteRowButton.css. */
 @media (max-width: 768px) {
-  .events-guest-delete-btn {
+  .delete-row-button.events-guest-delete-btn {
     display: none;
   }
 }
@@ -156,17 +147,6 @@
   .events-guest-card .swipe-delete-background {
     display: none;
   }
-}
-
-.events-guest-delete-btn:hover {
-  background: #fdecea;
-  border-color: #f3b7b1;
-}
-
-.events-guest-delete-btn .swipe-delete-icon-image {
-  width: 1.1rem;
-  height: 1.1rem;
-  object-fit: contain;
 }
 
 .events-card-main h3 {
@@ -1495,36 +1475,14 @@
 }
 
 /* Delete button for desktop, where left-swipe-to-delete isn't available. */
-.events-drink-row-delete-btn {
+.delete-row-button.events-drink-row-delete-btn {
   display: none;
   flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1px solid #ececec;
-  background: white;
-  color: #b3261e;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-
-.events-drink-row-delete-btn:hover {
-  background: #fdecea;
-  border-color: #f3b7b1;
-}
-
-.events-drink-row-delete-btn .swipe-delete-icon-image {
-  width: 1rem;
-  height: 1rem;
-  object-fit: contain;
 }
 
 @media (min-width: 769px) {
-  .events-drink-row-delete-btn {
-    display: flex;
+  .delete-row-button.events-drink-row-delete-btn {
+    display: inline-flex;
   }
 }
 
@@ -1742,36 +1700,14 @@
 }
 
 /* Delete button for desktop, where left-swipe-to-delete isn't available. */
-.events-guest-row-delete-btn {
+.delete-row-button.events-guest-row-delete-btn {
   display: none;
   flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1px solid #ececec;
-  background: white;
-  color: #b3261e;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-
-.events-guest-row-delete-btn:hover {
-  background: #fdecea;
-  border-color: #f3b7b1;
-}
-
-.events-guest-row-delete-btn .swipe-delete-icon-image {
-  width: 1rem;
-  height: 1rem;
-  object-fit: contain;
 }
 
 @media (min-width: 769px) {
-  .events-guest-row-delete-btn {
-    display: flex;
+  .delete-row-button.events-guest-row-delete-btn {
+    display: inline-flex;
   }
 }
 
@@ -1789,6 +1725,13 @@
   position: relative;
   overflow: hidden;
   border-radius: 10px;
+}
+
+.drink-list-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .drink-list-item.swipe-delete-active .drink-swipe-delete-background {
@@ -1831,20 +1774,6 @@
   background: white;
   border-radius: 10px;
   transition: transform 0.15s ease;
-}
-
-.drink-delete-banner {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.75rem;
-  margin: 0.35rem 0 0.5rem;
-  padding: 0.5rem 0.7rem;
-  border: 1px solid #f0c5bf;
-  border-radius: 8px;
-  background: #fff5f4;
-  color: #8b2d21;
-  font-size: 0.9rem;
 }
 
 /* ── Swipe-Delete für Event-Karten (gleiches Pattern wie bei Getränken) ── */

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import './EventsPage.css';
 import OverviewAddFab from './OverviewAddFab';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 import {
   subscribeToGuestProfiles,
   subscribeToAllGuestProfiles,
@@ -132,7 +135,7 @@ function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
         </button>
       </div>
       <div
-        className="events-guest-card-content"
+        className="events-guest-card-content delete-row-hover-target"
         style={{ transform: `translateX(${effectiveSwipeOffset}px)`, transition: 'transform 0.15s ease' }}
         onClick={handleContentClick}
         onTouchStart={handleTouchStart}
@@ -141,22 +144,14 @@ function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
         onTouchCancel={() => resetSwipe()}
       >
         {children}
-        <button
-          type="button"
+        <DeleteRowButton
           className="events-guest-delete-btn"
+          itemName={fullName || 'Gast'}
           onClick={(e) => {
             e.stopPropagation();
             onDelete();
           }}
-          aria-label={deleteLabel}
-          title="Gast löschen"
-        >
-          {isBase64Image(deleteIcon) ? (
-            <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
-          ) : (
-            <span className="swipe-delete-icon-text">{deleteIcon}</span>
-          )}
-        </button>
+        />
       </div>
     </div>
   );
@@ -354,10 +349,11 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     }
   };
 
+  const { notifyDeleted, undo, pendingName } = useUndoableDelete();
+
   const handleDelete = async (profile) => {
     if (!canManageGuests) return;
     const name = getGuestDisplayName(profile) || 'diesen Gast';
-    if (!window.confirm(`Möchtest du "${name}" wirklich löschen?`)) return;
     try {
       // Admin deleting another user's guest: pass their ownerId through.
       if (profile.ownerId && profile.ownerId !== currentUser.id) {
@@ -367,7 +363,25 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
       }
     } catch (err) {
       console.error('Error deleting guest profile:', err);
+      return;
     }
+    notifyDeleted({
+      id: `${profile.ownerId || ''}_${profile.id}`,
+      name,
+      undo: async () => {
+        // eslint-disable-next-line no-unused-vars
+        const { id, ownerId, ...payload } = profile;
+        try {
+          if (profile.ownerId && profile.ownerId !== currentUser.id) {
+            await saveGuestProfile(currentUser.id, payload, profile.id, profile.ownerId);
+          } else {
+            await saveGuestProfile(currentUser.id, payload, profile.id);
+          }
+        } catch (err) {
+          console.error('Error restoring guest profile:', err);
+        }
+      },
+    });
   };
 
   const handleFabClick = (e) => {
@@ -748,6 +762,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
         </div>
       )}
       <OverviewAddFab onClick={openNew} title="Gast anlegen" ariaLabel="Gast anlegen" />
+      <UndoSnackbar itemName={pendingName} onUndo={undo} />
     </div>
   );
 }

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -305,7 +305,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     expect(names).toEqual(['Anna Adler', 'Zora Adler', 'Bernd Zimmer']);
   });
 
-  test('clicking the delete button on a guest card deletes the guest without opening the edit form', () => {
+  test('clicking the delete button on a guest card deletes the guest immediately without a confirm dialog', () => {
     window.confirm = jest.fn(() => true);
     mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
       cb([
@@ -316,14 +316,13 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
 
     render(<GuestManagementPage currentUser={currentUser} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler entfernen' }));
 
-    expect(window.confirm).toHaveBeenCalledWith('Möchtest du "Anna Adler" wirklich löschen?');
+    expect(window.confirm).not.toHaveBeenCalled();
     expect(mockDeleteGuestProfile).toHaveBeenCalledWith('u1', 'g1');
   });
 
   test('delete button click does not trigger the edit form to open', () => {
-    window.confirm = jest.fn(() => true);
     mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
       cb([
         { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
@@ -333,7 +332,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
 
     render(<GuestManagementPage currentUser={currentUser} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler entfernen' }));
 
     expect(screen.queryByRole('heading', { name: 'Gast bearbeiten' })).not.toBeInTheDocument();
   });
@@ -358,7 +357,6 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     });
 
     test('admin immediately sees all users\' guests and can edit/delete another user\'s guest', async () => {
-      window.confirm = jest.fn(() => true);
       mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
         cb([
           {
@@ -379,7 +377,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
 
       expect(await screen.findByText('Ben Beispiel')).toBeInTheDocument();
 
-      const deleteBtn = screen.getByRole('button', { name: 'Ben Beispiel löschen' });
+      const deleteBtn = screen.getByRole('button', { name: 'Ben Beispiel entfernen' });
       expect(deleteBtn).toBeInTheDocument();
 
       // Clicking the card opens the edit form for the other user's guest.
@@ -399,7 +397,6 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     });
 
     test('admin deleting another user\'s guest passes the owner id through', async () => {
-      window.confirm = jest.fn(() => true);
       mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
         cb([
           { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
@@ -409,7 +406,7 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
 
       render(<GuestManagementPage currentUser={adminUser} />);
 
-      fireEvent.click(await screen.findByRole('button', { name: 'Ben Beispiel löschen' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Ben Beispiel entfernen' }));
 
       expect(mockDeleteGuestProfile).toHaveBeenCalledWith(adminUser.id, 'g1', 'other-user');
     });

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -525,21 +525,6 @@
   cursor: grabbing;
 }
 
-.remove-recipe-button {
-  background: none;
-  border: none;
-  color: #999;
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  transition: color 0.2s ease;
-  line-height: 1;
-}
-
-.remove-recipe-button:hover {
-  color: #f44336;
-}
-
 
 /* FAB Save Button */
 .save-fab-button {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -14,6 +14,9 @@ import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { encodeRecipeLink, decodeRecipeLink } from '../utils/recipeLinks';
 import EventForm from './EventForm';
 import DrinkManagementPage from './DrinkManagementPage';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 import {
   DndContext,
   closestCenter,
@@ -215,11 +218,10 @@ function SortableSection({
                         displayName={item.displayName}
                         isFavorite={item.type === 'recipe' && favoriteIds.includes(item.id)}
                         onRemove={() => {
-                          if (item.type === 'recipe') onRemoveRecipeFromSection(sectionIndex, item.id);
-                          else if (item.type === 'event') onRemoveEventDrink(item.id);
-                          else onRemoveDrinkFromSection(sectionIndex, item.id);
+                          if (item.type === 'recipe') onRemoveRecipeFromSection(sectionIndex, item.id, item.displayName);
+                          else if (item.type === 'event') onRemoveEventDrink(item.id, item.displayName);
+                          else onRemoveDrinkFromSection(sectionIndex, item.id, item.displayName);
                         }}
-                        removeTitle={item.type === 'recipe' ? 'Rezept entfernen' : item.type === 'event' ? 'Getränk aus Event entfernen' : 'Getränk entfernen'}
                       />
                     ))}
                   </SortableContext>
@@ -353,7 +355,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) 
     <div
       ref={setNodeRef}
       style={style}
-      className={`selected-recipe-item ${isDragging ? 'dragging' : ''}`}
+      className={`selected-recipe-item delete-row-hover-target ${isDragging ? 'dragging' : ''}`}
     >
       <button
         type="button"
@@ -368,14 +370,10 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) 
         {recipe.title}
         {isFavorite && <span className="favorite-indicator">★</span>}
       </span>
-      <button
-        type="button"
-        className="remove-recipe-button"
-        onClick={() => onRemove(sectionIndex, recipe.id)}
-        title="Rezept entfernen"
-      >
-        ×
-      </button>
+      <DeleteRowButton
+        itemName={recipe.title}
+        onClick={() => onRemove(sectionIndex, recipe.id, recipe.title)}
+      />
     </div>
   );
 }
@@ -383,7 +381,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) 
 // Sortable item for the menu's "Drinks" section, which mixes drink recipes,
 // event-linked drinks, and manually added drinks in a single freely
 // reorderable list (see getDrinksSectionItems).
-function SortableDrinkItem({ id, displayName, isFavorite, onRemove, removeTitle }) {
+function SortableDrinkItem({ id, displayName, isFavorite, onRemove }) {
   const {
     attributes,
     listeners,
@@ -403,7 +401,7 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove, removeTitle 
     <div
       ref={setNodeRef}
       style={style}
-      className={`selected-recipe-item ${isDragging ? 'dragging' : ''}`}
+      className={`selected-recipe-item delete-row-hover-target ${isDragging ? 'dragging' : ''}`}
     >
       <button
         type="button"
@@ -418,14 +416,7 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove, removeTitle 
         {displayName}
         {isFavorite && <span className="favorite-indicator">★</span>}
       </span>
-      <button
-        type="button"
-        className="remove-recipe-button"
-        onClick={onRemove}
-        title={removeTitle}
-      >
-        ×
-      </button>
+      <DeleteRowButton itemName={displayName} onClick={onRemove} />
     </div>
   );
 }
@@ -461,6 +452,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   // Drinks the user removed from the linked event via this menu's "Drinks"
   // section, staged locally until the menu is saved (see handleSubmit).
   const [removedEventDrinkIds, setRemovedEventDrinkIds] = useState([]);
+  const { notifyDeleted, undo, pendingName } = useUndoableDelete();
   // Drag-and-drop reordering of event-linked drinks, staged locally until the
   // menu is saved (see handleSubmit, which writes it back into the linked
   // event's customDrinkIds order).
@@ -653,17 +645,32 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     setRemovedEventDrinkIds((prev) => prev.filter((id) => id !== drinkId));
   };
 
-  const handleRemoveDrinkFromSection = (sectionIndex, drinkId) => {
+  const handleRemoveDrinkFromSection = (sectionIndex, drinkId, displayName) => {
+    const index = (sections[sectionIndex]?.drinkIds || []).indexOf(drinkId);
     setSections((prevSections) => prevSections.map((s, i) => {
       if (i !== sectionIndex) return s;
       return { ...s, drinkIds: (s.drinkIds || []).filter((id) => id !== drinkId) };
     }));
+    notifyDeleted({
+      id: `drink:${sectionIndex}:${drinkId}`,
+      name: displayName || drinkId,
+      undo: () => {
+        setSections((prev) => prev.map((s, i) => {
+          if (i !== sectionIndex) return s;
+          const ids = s.drinkIds || [];
+          if (ids.includes(drinkId)) return s;
+          const next = [...ids];
+          next.splice(Math.min(index, next.length), 0, drinkId);
+          return { ...s, drinkIds: next };
+        }));
+      },
+    });
   };
 
   // Stages the removal of one of the linked event's drinks; it's actually
   // removed from the event (and the event's Getränkeverteilung recalculated)
   // once the menu is saved, see handleSubmit.
-  const handleRemoveEventDrink = (drinkId) => {
+  const handleRemoveEventDrink = (drinkId, displayName) => {
     setRemovedEventDrinkIds((prev) => (prev.includes(drinkId) ? prev : [...prev, drinkId]));
     // The same drink can also sit in a section's own drinkIds (manualDrinkIds
     // is deduped by id against the event drinks, so only the merged
@@ -677,6 +684,11 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
         ? { ...s, drinkIds: s.drinkIds.filter((id) => id !== drinkId) }
         : s
     )));
+    notifyDeleted({
+      id: `event:${drinkId}`,
+      name: displayName || drinkId,
+      undo: () => setRemovedEventDrinkIds((prev) => prev.filter((id) => id !== drinkId)),
+    });
   };
 
   // Merged search results for the Drinks section's single search field:
@@ -1239,22 +1251,40 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
     });
   };
 
-  const handleRemoveRecipeFromSection = (sectionIndex, recipeId) => {
+  const handleRemoveRecipeFromSection = (sectionIndex, recipeId, displayName) => {
     // If this recipe is a drink recipe deduped against a linked event drink
     // (see the `eventDrinks` useMemo above), removing it here would only
     // hide the recipe entry - the event drink would then reappear as its
     // own entry (dedup no longer applies) and need a second click to
     // actually go away. Stage its removal too so both disappear together.
     const section = sections[sectionIndex];
+    const index = section ? section.recipeIds.indexOf(recipeId) : -1;
+    let linkedEventDrinkId = null;
     if (section?.name?.toLowerCase() === 'drinks') {
       const linkedEventDrink = eventDrinks.find((drink) => drink.recipeId === recipeId);
       if (linkedEventDrink) {
+        linkedEventDrinkId = linkedEventDrink.id;
         setRemovedEventDrinkIds((prev) => (prev.includes(linkedEventDrink.id) ? prev : [...prev, linkedEventDrink.id]));
       }
     }
     setSections((prevSections) => prevSections.map((s, i) => (
       i === sectionIndex ? { ...s, recipeIds: s.recipeIds.filter((id) => id !== recipeId) } : s
     )));
+    notifyDeleted({
+      id: `recipe:${sectionIndex}:${recipeId}`,
+      name: displayName || 'Rezept',
+      undo: () => {
+        setSections((prev) => prev.map((s, i) => {
+          if (i !== sectionIndex || s.recipeIds.includes(recipeId)) return s;
+          const next = [...s.recipeIds];
+          next.splice(Math.min(index, next.length), 0, recipeId);
+          return { ...s, recipeIds: next };
+        }));
+        if (linkedEventDrinkId) {
+          setRemovedEventDrinkIds((prev) => prev.filter((id) => id !== linkedEventDrinkId));
+        }
+      },
+    });
   };
 
   const handleDragEndRecipes = (sectionIndex, event) => {
@@ -1736,6 +1766,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
           getEffectiveIcon(buttonIcons, 'saveRecipe', isDarkMode)
         )}
       </button>
+      <UndoSnackbar itemName={pendingName} onUndo={undo} />
     </div>
   );
 }

--- a/src/components/MenuForm.test.js
+++ b/src/components/MenuForm.test.js
@@ -185,7 +185,7 @@ describe('MenuForm - Drinks section manual drink selection', () => {
 
     expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTitle('Getränk entfernen'));
+    fireEvent.click(screen.getByTitle('Cola entfernen'));
 
     await waitFor(() => {
       expect(screen.queryByText('Ausgewählte Rezepte & Getränke:')).not.toBeInTheDocument();
@@ -514,12 +514,12 @@ describe('MenuForm - linked event drinks display', () => {
     );
 
     expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
-    expect(screen.queryByTitle('Getränk aus Event entfernen')).not.toBeInTheDocument();
+    expect(screen.getAllByTitle('Mojito entfernen')).toHaveLength(1);
 
-    fireEvent.click(screen.getByTitle('Rezept entfernen'));
+    fireEvent.click(screen.getByTitle('Mojito entfernen'));
 
     expect(screen.queryByText('Mojito')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Getränk aus Event entfernen')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Mojito entfernen')).not.toBeInTheDocument();
   });
 
   test('removing a drink that is both manually added and in the linked event removes it in one click, not two', async () => {
@@ -553,12 +553,12 @@ describe('MenuForm - linked event drinks display', () => {
 
     expect(await screen.findByText('Ausgewählte Rezepte & Getränke:')).toBeInTheDocument();
     expect(screen.getAllByText('Cola')).toHaveLength(1);
-    expect(screen.queryByTitle('Getränk entfernen')).not.toBeInTheDocument();
+    expect(screen.getAllByTitle('Cola entfernen')).toHaveLength(1);
 
-    fireEvent.click(screen.getByTitle('Getränk aus Event entfernen'));
+    fireEvent.click(screen.getByTitle('Cola entfernen'));
 
     expect(screen.queryByText('Cola')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Getränk entfernen')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Cola entfernen')).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/RecipeForm.css
+++ b/src/components/RecipeForm.css
@@ -690,6 +690,23 @@
   align-items: stretch;
   z-index: 1;
 }
+
+/* Dedicated column for DeleteRowButton, outside the input field so every
+   row's field stays the same width and the buttons all line up. Desktop
+   only - mobile keeps using the swipe-to-delete gesture. */
+.form-list-item-delete-col {
+  display: none;
+}
+
+@media (min-width: 769px) {
+  .form-list-item-delete-col {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    flex: 0 0 28px;
+  }
+}
 .input-wrapper input,
 .input-wrapper textarea {
   flex: 1;
@@ -932,20 +949,6 @@
   justify-content: center;
   position: relative;
   z-index: 1;
-}
-
-.swipe-undo-banner {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.75rem;
-  margin: 0.35rem 0 0.5rem;
-  padding: 0.5rem 0.7rem;
-  border: 1px solid #f0c5bf;
-  border-radius: 8px;
-  background: #fff5f4;
-  color: #8b2d21;
-  font-size: 0.9rem;
 }
 
 .add-item-button .button-icon-image {

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -15,6 +15,9 @@ import RecipeImportModal from './RecipeImportModal';
 import OcrScanModal from './OcrScanModal';
 import WebImportModal from './WebImportModal';
 import RecipeTypeahead from './RecipeTypeahead';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 import {
   DndContext,
   closestCenter,
@@ -36,12 +39,6 @@ import { CSS } from '@dnd-kit/utilities';
 const SWIPE_DELETE_THRESHOLD = 56;
 const SWIPE_DELETE_MAX_OFFSET = 96;
 const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-const DELETE_BANNER_TIMEOUT_MS = 10000;
-
-const clearBannerTimeouts = (bannerTimeoutsRef) => {
-  bannerTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
-  bannerTimeoutsRef.current.clear();
-};
 
 // Sortable Ingredient Item Component
 function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, onToggleType, swipeDeleteIcon }) {
@@ -178,7 +175,7 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
   };
 
   const handleSwipeDeleteClick = () => {
-    onRemove(index, { fromSwipe: true });
+    onRemove(index);
     resetSwipe();
   };
 
@@ -188,7 +185,7 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
     <div
       ref={setNodeRef}
       style={style}
-      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`form-list-item delete-row-hover-target ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
     >
       {canRemove && (
         <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
@@ -233,6 +230,14 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
         >
           ⋮⋮
         </button>
+      </div>
+      <div className="form-list-item-delete-col">
+        {canRemove && (
+          <DeleteRowButton
+            itemName={isHeading ? (text || 'Überschrift') : (text || 'Zutat')}
+            onClick={() => onRemove(index)}
+          />
+        )}
       </div>
       {showContextMenu && (
         <>
@@ -393,7 +398,7 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
   };
 
   const handleSwipeDeleteClick = () => {
-    onRemove(index, { fromSwipe: true });
+    onRemove(index);
     resetSwipe();
   };
 
@@ -403,7 +408,7 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
     <div
       ref={setNodeRef}
       style={style}
-      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`form-list-item delete-row-hover-target ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
     >
       {canRemove && (
         <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
@@ -446,6 +451,14 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
         >
           ⋮⋮
         </button>
+      </div>
+      <div className="form-list-item-delete-col">
+        {canRemove && (
+          <DeleteRowButton
+            itemName={isHeading ? (text || 'Überschrift') : (text || 'Schritt')}
+            onClick={() => onRemove(index)}
+          />
+        )}
       </div>
       {showContextMenu && (
         <>
@@ -521,11 +534,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   const formRef = useRef(null);
   // Cancel button press state
   const [cancelPressed, setCancelPressed] = useState(false);
-  const [ingredientDeleteBanners, setIngredientDeleteBanners] = useState([]);
-  const [stepDeleteBanners, setStepDeleteBanners] = useState([]);
-  const ingredientDeleteBannerTimeoutsRef = useRef(new Map());
-  const stepDeleteBannerTimeoutsRef = useRef(new Map());
-  const swipeDeleteBannerCounterRef = useRef(0);
+  const { notifyDeleted: notifyRowDeleted, undo: undoRowDelete, pendingName: pendingRowDeleteName } = useUndoableDelete();
 
   // Nutrition reference rows for auto-assigning ingredient IDs
   const { rows: nutritionReferenceRows } = useNutritionReference();
@@ -768,28 +777,30 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     setIngredients([...ingredients, { type: 'ingredient', text: '' }]);
   };
 
-  const showTimedDeleteBanner = (setBanners, bannerTimeoutsRef, message) => {
-    const counter = swipeDeleteBannerCounterRef.current;
-    swipeDeleteBannerCounterRef.current = (counter + 1) % 100000;
-    const id = `swipe-delete-${Date.now()}-${counter}`;
-    setBanners((prev) => [...prev, { id, message }]);
-    const timeoutId = setTimeout(() => {
-      setBanners((prev) => prev.filter((banner) => banner.id !== id));
-      bannerTimeoutsRef.current.delete(id);
-    }, DELETE_BANNER_TIMEOUT_MS);
-    bannerTimeoutsRef.current.set(id, timeoutId);
-  };
+  const describeIngredient = (item) =>
+    item.type === 'heading' ? (item.text || 'Überschrift') : (item.text || 'Zutat');
 
-  const handleRemoveIngredient = (index, options = {}) => {
-    if (!ingredients[index]) return;
-    if (ingredients.length > 1) {
+  const handleRemoveIngredient = (index) => {
+    const removedItem = ingredients[index];
+    if (!removedItem) return;
+    const hadOthers = ingredients.length > 1;
+    if (hadOthers) {
       setIngredients(ingredients.filter((_, i) => i !== index));
     } else {
       setIngredients([{ type: 'ingredient', text: '' }]);
     }
-    if (options.fromSwipe) {
-      showTimedDeleteBanner(setIngredientDeleteBanners, ingredientDeleteBannerTimeoutsRef, 'Zutat gelöscht.');
-    }
+    notifyRowDeleted({
+      id: `ingredient-${index}`,
+      name: describeIngredient(removedItem),
+      undo: () => {
+        setIngredients((prev) => {
+          if (!hadOthers) return [removedItem];
+          const next = [...prev];
+          next.splice(Math.min(index, next.length), 0, removedItem);
+          return next;
+        });
+      },
+    });
   };
 
   const handleIngredientChange = (index, value) => {
@@ -833,22 +844,31 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     setSteps([...steps, { type: 'step', text: '' }]);
   };
 
-  const handleRemoveStep = (index, options = {}) => {
-    if (!steps[index]) return;
-    if (steps.length > 1) {
+  const describeStep = (item) =>
+    item.type === 'heading' ? (item.text || 'Überschrift') : (item.text || 'Schritt');
+
+  const handleRemoveStep = (index) => {
+    const removedItem = steps[index];
+    if (!removedItem) return;
+    const hadOthers = steps.length > 1;
+    if (hadOthers) {
       setSteps(steps.filter((_, i) => i !== index));
     } else {
       setSteps([{ type: 'step', text: '' }]);
     }
-    if (options.fromSwipe) {
-      showTimedDeleteBanner(setStepDeleteBanners, stepDeleteBannerTimeoutsRef, 'Schritt gelöscht.');
-    }
+    notifyRowDeleted({
+      id: `step-${index}`,
+      name: describeStep(removedItem),
+      undo: () => {
+        setSteps((prev) => {
+          if (!hadOthers) return [removedItem];
+          const next = [...prev];
+          next.splice(Math.min(index, next.length), 0, removedItem);
+          return next;
+        });
+      },
+    });
   };
-
-  useEffect(() => () => {
-    clearBannerTimeouts(ingredientDeleteBannerTimeoutsRef);
-    clearBannerTimeouts(stepDeleteBannerTimeoutsRef);
-  }, []);
 
   const handleStepChange = (index, value) => {
     const newSteps = [...steps];
@@ -1685,11 +1705,6 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
               ))}
             </SortableContext>
           </DndContext>
-          {ingredientDeleteBanners.map((banner) => (
-            <div key={banner.id} className="swipe-undo-banner" role="status">
-              <span>{banner.message}</span>
-            </div>
-          ))}
           <button
             type="button"
             className="add-item-button add-item-button--ingredient"
@@ -1748,11 +1763,6 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
               })}
             </SortableContext>
           </DndContext>
-          {stepDeleteBanners.map((banner) => (
-            <div key={banner.id} className="swipe-undo-banner" role="status">
-              <span>{banner.message}</span>
-            </div>
-          ))}
           <button
             type="button"
             className="add-item-button add-item-button--step"
@@ -1870,6 +1880,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
           getEffectiveIcon(buttonIcons, 'saveRecipe', isDarkMode)
         )}
       </button>
+      <UndoSnackbar itemName={pendingRowDeleteName} onUndo={undoRowDelete} />
     </div>
   );
 }

--- a/src/components/RecipeForm.test.js
+++ b/src/components/RecipeForm.test.js
@@ -2028,7 +2028,7 @@ describe('RecipeForm - Swipe Delete', () => {
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(screen.getAllByPlaceholderText(/Zutat/)).toHaveLength(1));
-    expect(screen.getByText('Zutat gelöscht.')).toBeInTheDocument();
+    expect(screen.getByText('„Milch" entfernt')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Zutat 1')).toHaveValue('Mehl');
   });
 
@@ -2073,7 +2073,7 @@ describe('RecipeForm - Swipe Delete', () => {
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(screen.getAllByPlaceholderText(/Schritt/)).toHaveLength(1));
-    expect(screen.getByText('Schritt gelöscht.')).toBeInTheDocument();
+    expect(screen.getByText('„Mischen" entfernt')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Schritt 1')).toHaveValue('Backen');
   });
 
@@ -2116,7 +2116,7 @@ describe('RecipeForm - Swipe Delete', () => {
     expect(screen.getByPlaceholderText('Zutat 1')).toHaveValue('');
   });
 
-  test('auto-hides delete banners after 10 seconds and allows multiple banners', async () => {
+  test('undo snackbar shows only one at a time and auto-hides after 6 seconds', async () => {
     jest.useFakeTimers();
     try {
       render(
@@ -2135,17 +2135,21 @@ describe('RecipeForm - Swipe Delete', () => {
       swipeLeft(screen.getByPlaceholderText('Zutat 2'));
       fireEvent.click(await screen.findByRole('button', { name: 'Zutat löschen' }));
 
+      expect(screen.getByText('„Mehl" entfernt')).toBeInTheDocument();
+
       swipeLeft(screen.getByPlaceholderText('Zutat 1'));
       fireEvent.click(await screen.findByRole('button', { name: 'Zutat löschen' }));
 
-      await waitFor(() => expect(screen.getAllByText('Zutat gelöscht.')).toHaveLength(2));
+      // A new deletion replaces the previous snackbar - only one is shown at a time.
+      expect(screen.queryByText('„Mehl" entfernt')).not.toBeInTheDocument();
+      expect(screen.getByText('„Milch" entfernt')).toBeInTheDocument();
 
       act(() => {
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(6000);
       });
 
       await waitFor(() => {
-        expect(screen.queryByText('Zutat gelöscht.')).not.toBeInTheDocument();
+        expect(screen.queryByText('„Milch" entfernt')).not.toBeInTheDocument();
       });
     } finally {
       jest.useRealTimers();
@@ -2578,7 +2582,7 @@ describe('RecipeForm - Drag and Drop', () => {
     expect(inputWrapper.contains(handle)).toBe(true);
   });
 
-  test('does not render inline x remove buttons for ingredients and steps', () => {
+  test('renders the delete button outside the input field, not inline in the text', () => {
     const regularUser = {
       id: 'user-1',
       vorname: 'Regular',
@@ -2597,8 +2601,15 @@ describe('RecipeForm - Drag and Drop', () => {
       />
     );
 
-    expect(screen.queryByLabelText('Zutat entfernen')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Schritt entfernen')).not.toBeInTheDocument();
+    const ingredientDeleteButton = screen.getByLabelText('Zutat entfernen');
+    expect(ingredientDeleteButton).toBeInTheDocument();
+    expect(ingredientDeleteButton.closest('.input-wrapper')).toBeNull();
+    expect(ingredientDeleteButton.closest('.form-list-item-delete-col')).not.toBeNull();
+
+    const stepDeleteButton = screen.getByLabelText('Schritt entfernen');
+    expect(stepDeleteButton).toBeInTheDocument();
+    expect(stepDeleteButton.closest('.input-wrapper')).toBeNull();
+    expect(stepDeleteButton.closest('.form-list-item-delete-col')).not.toBeNull();
   });
 });
 

--- a/src/components/UndoSnackbar.css
+++ b/src/components/UndoSnackbar.css
@@ -1,0 +1,63 @@
+.undo-snackbar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  max-width: calc(100vw - 2rem);
+  padding: 0.75rem 1rem;
+  background: #2b2018;
+  color: #fff;
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+  font-size: 0.9rem;
+  animation: undo-snackbar-in 0.16s ease;
+}
+
+.undo-snackbar-message {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.undo-snackbar-action {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: #ffb4a3;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0.2rem 0.3rem;
+  border-radius: 4px;
+  transition: color 0.16s ease;
+}
+
+.undo-snackbar-action:hover {
+  color: #ffd4c8;
+}
+
+.undo-snackbar-action:focus-visible {
+  outline: 2px solid rgba(163, 58, 38, 0.5);
+  outline-offset: 2px;
+}
+
+@keyframes undo-snackbar-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 8px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .undo-snackbar {
+    animation: none;
+  }
+}

--- a/src/components/UndoSnackbar.js
+++ b/src/components/UndoSnackbar.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import './UndoSnackbar.css';
+
+// Bottom-center "<Item> entfernt" + Rückgängig snackbar, driven by
+// useUndoableDelete's `pendingName`/`undo`. Renders nothing while no
+// deletion is pending; remounts fresh on every new pending item so its
+// entrance animation always restarts (skipped under reduced motion, see
+// UndoSnackbar.css).
+function UndoSnackbar({ itemName, onUndo }) {
+  if (!itemName) return null;
+
+  return (
+    <div className="undo-snackbar" role="status">
+      <span className="undo-snackbar-message">„{itemName}" entfernt</span>
+      <button type="button" className="undo-snackbar-action" onClick={onUndo}>
+        Rückgängig
+      </button>
+    </div>
+  );
+}
+
+export default UndoSnackbar;

--- a/src/components/icons/CloseThinIcon.js
+++ b/src/components/icons/CloseThinIcon.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+// Thin "×" used by DeleteRowButton: 13x13 viewport, 1.5 stroke, round caps.
+const CloseThinIcon = ({ color = 'currentColor', size = 13 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 13 13"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1.5 1.5l10 10M11.5 1.5l-10 10"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default CloseThinIcon;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3017,12 +3017,6 @@
   background: #a7372d;
 }
 
-[data-theme="dark"] .swipe-undo-banner {
-  background: #2b1b19;
-  border-color: #6b332c;
-  color: #f2b8af;
-}
-
 [data-theme="dark"] .swipe-undo-button {
   color: #f2b8af;
 }
@@ -3947,17 +3941,6 @@
   background: #1e1e1e;
 }
 
-[data-theme="dark"] .events-guest-delete-btn {
-  background: #2a2a2a;
-  border-color: #555;
-  color: #e8837a;
-}
-
-[data-theme="dark"] .events-guest-delete-btn:hover {
-  background: #3a2323;
-  border-color: #6b3a35;
-}
-
 [data-theme="dark"] .events-guest-typeahead-list {
   background: #262626;
   border-color: #555;
@@ -4176,17 +4159,6 @@
   color: #7fb8a3;
 }
 
-[data-theme="dark"] .events-drink-row-delete-btn {
-  background: #2a2a2a;
-  border-color: #555;
-  color: #e8837a;
-}
-
-[data-theme="dark"] .events-drink-row-delete-btn:hover {
-  background: #3a2323;
-  border-color: #6b3a35;
-}
-
 [data-theme="dark"] .events-drink-row-empty-label,
 [data-theme="dark"] .events-drink-row-single-unit {
   color: #999;
@@ -4251,17 +4223,6 @@
 
 [data-theme="dark"] .events-guest-row-name {
   color: #7fb8a3;
-}
-
-[data-theme="dark"] .events-guest-row-delete-btn {
-  background: #2a2a2a;
-  border-color: #555;
-  color: #e8837a;
-}
-
-[data-theme="dark"] .events-guest-row-delete-btn:hover {
-  background: #3a2323;
-  border-color: #6b3a35;
 }
 
 [data-theme="dark"] .events-guest-row-driver {

--- a/src/hooks/useUndoableDelete.js
+++ b/src/hooks/useUndoableDelete.js
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const UNDO_TIMEOUT_MS = 6000;
+
+/**
+ * Gemeinsames "sofort löschen + Rückgängig"-Muster für Listen-Zeilen
+ * (DeleteRowButton + UndoSnackbar). Die Löschung selbst passiert sofort und
+ * synchron beim Aufruf von `notifyDeleted` - der Aufrufer entfernt das
+ * Element also schon, bevor er den Hook informiert. Der Hook merkt sich nur,
+ * wie man die Löschung rückgängig macht, zeigt 6s lang die Undo-Snackbar
+ * und ruft bei Klick auf "Rückgängig" die übergebene `undo`-Funktion auf.
+ * Es ist immer nur eine Snackbar/ein Undo gleichzeitig aktiv: eine neue
+ * Löschung ersetzt die alte (deren Undo-Möglichkeit damit verfällt, die
+ * Löschung selbst bleibt bestehen) und startet den 6s-Timer neu. Der Timer
+ * wird beim Unmount abgebrochen (die Löschung ist da längst passiert, es
+ * gibt nur nichts mehr zu tun als das Timeout selbst zu vergessen).
+ */
+export default function useUndoableDelete() {
+  const [pending, setPending] = useState(null); // { id, name, undo }
+  const pendingRef = useRef(null);
+  const timeoutRef = useRef(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const notifyDeleted = useCallback(({ id, name, undo }) => {
+    clearTimer();
+    const entry = { id, name, undo };
+    pendingRef.current = entry;
+    setPending(entry);
+
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      if (pendingRef.current === entry) {
+        pendingRef.current = null;
+        setPending(null);
+      }
+    }, UNDO_TIMEOUT_MS);
+  }, [clearTimer]);
+
+  const undo = useCallback(() => {
+    clearTimer();
+    const entry = pendingRef.current;
+    pendingRef.current = null;
+    setPending(null);
+    if (entry) entry.undo();
+  }, [clearTimer]);
+
+  return {
+    notifyDeleted,
+    undo,
+    pendingName: pending?.name ?? null,
+  };
+}


### PR DESCRIPTION
Consolidates all row-deletion UI across the app into a single, reusable `DeleteRowButton` component paired with `UndoSnackbar`, replacing ad-hoc delete buttons, banners, and confirmation dialogs.

## Summary
Implements the unified delete pattern specified in `design_handoff_pillenkarussell/Löschen Einheitlich.dc.html`:
- **Immediate deletion** with a 6-second undo window (no confirmation dialogs)
- **Consistent UI**: 28×28 transparent button, red only on hover/focus
- **Shared logic**: New `useUndoableDelete` hook manages undo state and timeouts
- **Applies to**: recipe ingredients, steps, menu items, event drinks, guests, custom drinks

## Key Changes

### New Components & Hooks
- `DeleteRowButton.js` – Unified delete button (13×13 CloseThinIcon, aria-label, title)
- `DeleteRowButton.css` – Styling with hover/focus states, dark mode, touch-friendly hit areas
- `UndoSnackbar.js` – Bottom-center snackbar showing `„<Item>" entfernt` + Rückgängig button
- `UndoSnackbar.css` – Fixed positioning, entrance animation, dark mode
- `useUndoableDelete.js` – Manages pending deletion state, 6s timeout, undo callback
- `CloseThinIcon.js` – Thin × SVG icon (1.5 stroke, round caps)

### RecipeForm
- Replaced `showTimedDeleteBanner` + banner state with `useUndoableDelete`
- Added `DeleteRowButton` to both `SortableIngredient` and `SortableStep`
- Added `.form-list-item-delete-col` (desktop-only, hidden on mobile to preserve swipe-to-delete)
- Removed `DELETE_BANNER_TIMEOUT_MS` constant and banner timeout management
- Updated test expectations: `"Zutat gelöscht."` → `"„Milch" entfernt"`

### MenuForm
- Replaced custom remove buttons with `DeleteRowButton` in `SortableRecipeItem` and `SortableDrinkItem`
- Removed `.remove-recipe-button` CSS
- Updated `onRemove` callbacks to pass `displayName` for undo context

### DrinkManagementPage
- Integrated `useUndoableDelete` for custom drink deletion
- Added `DeleteRowButton` to `DrinkRow` header
- Removed `deleteBannerTimeoutsRef` and banner state management
- Updated test: `"delete banner"` → `"undo snackbar"`

### EventDrinkSelectionPage & EventGuestSelectionPage
- Replaced inline delete buttons with `DeleteRowButton`
- Removed custom button markup (icon handling, aria-label duplication)
- Added `delete-row-hover-target` class to row headers for hover styling

### GuestManagementPage
- Replaced custom delete button in `GuestCard` with `DeleteRowButton`
- Removed confirmation dialog (now handled by undo pattern)
- Updated test: removed `window.confirm` assertion

### CSS Cleanup
- `EventsPage.css`: Removed duplicate button styling (`.events-guest-delete-btn`, `.events-drink-row-delete-btn`, `.events-guest-row-delete-btn`); now inherit from `.delete-row-button`
- `RecipeForm.css`: Removed `.swipe-undo-banner` styles; added `.form-list-item-delete-col` for desktop layout
- `MenuForm.css`: Removed `.remove-recipe-button` styles
- `darkMode.css`: Removed dark-mode overrides for deleted button classes

## Implementation Details
- **Undo mechanism**: Caller removes item immediately, then calls `notifyDeleted({ id, name, undo })` with a callback to restore it
- **Single snackbar**: Only one pending deletion at a time; new deletion replaces old (old undo is lost, deletion persists)
- **Mobile**: Swipe-to-delete gesture remains unchanged;

https://claude.ai/code/session_01WdWWT8execj1TbdU9AQmf2