### PR TITLE
Add filter toggle for own drinks in menu editor

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -942,6 +942,15 @@
   box-shadow: 0 0 0 3px rgba(47, 93, 80, 0.3);
 }
 
+/* Brown ("App-Braun") variant, used for the Drinks-section toggle in the menu editor. */
+.drink-own-filter-toggle--brown input:checked + .drink-own-filter-toggle-slider {
+  background-color: #402C1C;
+}
+
+.drink-own-filter-toggle--brown input:focus-visible + .drink-own-filter-toggle-slider {
+  box-shadow: 0 0 0 3px rgba(150, 98, 47, 0.3);
+}
+
 .events-drink-selector {
   display: flex;
   gap: 8px;

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -86,6 +86,7 @@ function SortableSection({
   isDrinksSection, drinkSearchQueries, onDrinkSearchChange, onAddDrinkToSection,
   onAddRecipeToDrinksSection, onRemoveDrinkFromSection, getFilteredDrinkSectionOptions,
   getDrinkDisplayName, eventDrinks = [], onRemoveEventDrink, onDragEndDrinks,
+  showOwnDrinksOnly, onToggleShowOwnDrinksOnly,
 }) {
   const {
     attributes,
@@ -320,6 +321,20 @@ function SortableSection({
               </div>
             )}
           </div>
+          <div className="drink-own-filter-row">
+            <label className="drink-own-filter-label">
+              <span>Eigene Getränke</span>
+              <span className="drink-own-filter-toggle drink-own-filter-toggle--brown">
+                <input
+                  type="checkbox"
+                  checked={showOwnDrinksOnly}
+                  onChange={(e) => onToggleShowOwnDrinksOnly(e.target.checked)}
+                  aria-label="Nur eigene Getränke in der Suche anzeigen"
+                />
+                <span className="drink-own-filter-toggle-slider" aria-hidden="true" />
+              </span>
+            </label>
+          </div>
         </div>
       )}
       <div className="section-summary">
@@ -468,6 +483,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
   const [availableEvents, setAvailableEvents] = useState([]);
   const [userCustomDrinks, setUserCustomDrinks] = useState([]);
   const [drinkSearchQueries, setDrinkSearchQueries] = useState({});
+  const [showOwnDrinksOnly, setShowOwnDrinksOnly] = useState(true);
   const [newEventDrinkIds, setNewEventDrinkIds] = useState([]);
   const [preparingNewEvent, setPreparingNewEvent] = useState(false);
 
@@ -699,6 +715,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
       // offered as their underlying recipe in recipeOptions above - listing
       // both would show the same name twice.
       .filter((drink) => !decodeRecipeLink(drink.name))
+      .filter((drink) => !showOwnDrinksOnly || !drink.ownerId || drink.ownerId === currentUser?.id)
       .map((drink) => ({ type: 'drink', id: drink.id, drink, searchLabel: resolveDrinkDisplay(drink, recipes).displayName }));
 
     const combinedOptions = [...recipeOptions, ...drinkOptions];
@@ -1662,6 +1679,8 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   eventDrinks={section.name?.toLowerCase() === 'drinks' ? orderedEventDrinks : []}
                   onRemoveEventDrink={handleRemoveEventDrink}
                   onDragEndDrinks={handleDragEndDrinks}
+                  showOwnDrinksOnly={showOwnDrinksOnly}
+                  onToggleShowOwnDrinksOnly={setShowOwnDrinksOnly}
                 />
                 {isMobile && (
                   <div className="add-section-gap">


### PR DESCRIPTION
## Summary
Added a toggle filter in the drinks section of the menu editor that allows users to show only their own drinks when searching. This improves the user experience by reducing clutter when managing custom drinks.

## Key Changes
- Added `showOwnDrinksOnly` state to `MenuForm` component, defaulting to `true`
- Implemented toggle UI in the `SortableSection` component with a brown-themed checkbox toggle matching the drinks section styling
- Added filter logic to exclude drinks with different owners when the toggle is active
- Extended the `SortableSection` component props to accept `showOwnDrinksOnly` and `onToggleShowOwnDrinksOnly`
- Added CSS styling for the brown variant of the toggle switch with appropriate focus states and colors

## Implementation Details
- The filter checks if `showOwnDrinksOnly` is enabled and excludes drinks where `ownerId` exists but doesn't match the current user's ID
- The toggle is placed in a new `.drink-own-filter-row` container within the drinks section UI
- The brown toggle variant (`drink-own-filter-toggle--brown`) uses the app's brown color (#402C1C) with a matching focus shadow for visual consistency
- Includes proper accessibility attributes: `aria-label` for the checkbox and `aria-hidden` for the decorative slider element

https://claude.ai/code/session_01HRiTtBXqa14foXAaugpsSA