### PR TITLE
Add mobile swipe-to-delete for drink list items

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -194,6 +194,7 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
           {!drink.predefined && canManage && (
             <DeleteRowButton
               itemName={displayName}
+              className="drink-list-item-delete-btn"
               onClick={(e) => {
                 e.stopPropagation();
                 onDelete(drink);

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1884,6 +1884,24 @@
   transition: transform 0.15s ease;
 }
 
+/* Mobile: the delete button is only revealed via the left-swipe gesture,
+   mirroring the guest card's swipe-to-delete. Compounded with
+   .delete-row-button so this wins regardless of CSS import order between
+   this file and DeleteRowButton.css. */
+@media (max-width: 768px) {
+  .delete-row-button.drink-list-item-delete-btn {
+    display: none;
+  }
+}
+
+/* Desktop: no touch swipe, so the static delete button stays visible and
+   the swipe reveal background never engages. */
+@media (min-width: 769px) {
+  .drink-swipe-delete-background {
+    display: none;
+  }
+}
+
 /* ── Swipe-Delete für Event-Karten (gleiches Pattern wie bei Getränken) ── */
 
 .events-card-swipe-wrapper {


### PR DESCRIPTION
## Summary
Implements mobile swipe-to-delete gesture for drink list items, consistent with the existing event card deletion pattern. On desktop, the static delete button remains visible; on mobile, it's hidden and revealed via left-swipe gesture.

## Changes
- **DrinkManagementPage.js**: Added `className="drink-list-item-delete-btn"` to the `DeleteRowButton` component to enable targeted styling for mobile/desktop differentiation
- **EventsPage.css**: Added responsive media queries to:
  - Hide the delete button on mobile (≤768px) to reveal it only via swipe gesture
  - Hide the swipe background on desktop (≥769px) since the button is always visible

## Implementation Details
The solution follows the established pattern used for event card deletion:
- Mobile users swipe left to reveal the delete action
- Desktop users see the delete button statically positioned at the right edge
- CSS specificity is managed by compounding selectors (`.delete-row-button.drink-list-item-delete-btn`) to ensure consistent behavior regardless of stylesheet import order
- Aligns with the project's unified deletion interaction guidelines per CLAUDE.md

https://claude.ai/code/session_01R3956pyu87ujrBLEUju6bV