### PR TITLE
Extract swipe-to-delete and undo logic into reusable hooks

### DIFF
--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -11,6 +11,8 @@ import { encodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
 import { parseIngredientPartsSync } from '../utils/ingredientUtils';
 import { updateRecipe } from '../utils/recipeFirestore';
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const DRINK_RECIPE_CATEGORY = 'Drinks';
 
@@ -54,11 +56,6 @@ const isDrinkRecipe = (recipe) =>
     ? recipe.speisekategorie.includes(DRINK_RECIPE_CATEGORY)
     : recipe?.speisekategorie === DRINK_RECIPE_CATEGORY;
 
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-const DELETE_BANNER_TIMEOUT_MS = 5000;
-
 const UNIT_SIZES = [
   { label: '200 ml', value: 0.2 },
   { label: '330 ml', value: 0.33 },
@@ -94,70 +91,11 @@ const emptyForm = () => ({
 });
 
 function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, swipeDeleteIcon }) {
-  const touchStartXRef = React.useRef(null);
-  const touchStartYRef = React.useRef(null);
-  const swipeDirectionLockedRef = React.useRef(null);
-  const isSwipingRef = React.useRef(false);
-  const swipeOffsetRef = React.useRef(0);
-  const [swipeOffset, setSwipeOffset] = React.useState(0);
-  const [isDeleteVisible, setIsDeleteVisible] = React.useState(false);
-
-  const effectiveOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
-
-  const resetSwipe = ({ keepDelete = false } = {}) => {
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    swipeOffsetRef.current = 0;
-    setSwipeOffset(0);
-    if (!keepDelete) setIsDeleteVisible(false);
-  };
-
-  const handleTouchStart = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || drink.predefined || !canManage) return;
-    if (isDeleteVisible) setIsDeleteVisible(false);
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-  };
-
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || drink.predefined || !canManage) return;
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      const clamped = Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET);
-      swipeOffsetRef.current = clamped;
-      setSwipeOffset(clamped);
-      if (e.cancelable) e.preventDefault();
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (isSwipingRef.current && Math.abs(swipeOffsetRef.current) >= SWIPE_DELETE_THRESHOLD) {
-      setIsDeleteVisible(true);
-      resetSwipe({ keepDelete: true });
-      return;
-    }
-    resetSwipe();
-  };
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ disabled: drink.predefined || !canManage });
 
   return (
     <div
-      className={`drink-list-item events-card${effectiveOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`drink-list-item events-card${offset < 0 ? ' swipe-delete-active' : ''}`}
       style={{ padding: 0 }}
     >
       {!drink.predefined && canManage && (
@@ -166,7 +104,7 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
             <button
               type="button"
               className="drink-swipe-delete-action"
-              onClick={() => { onDelete(drink); resetSwipe(); }}
+              onClick={() => { onDelete(drink); reset(); }}
               aria-label={`${displayName} löschen`}
             >
               {isBase64Image(swipeDeleteIcon) ? (
@@ -180,12 +118,9 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
       )}
       <div
         className="drink-swipe-content events-card-main"
-        style={{ transform: `translateX(${effectiveOffset}px)`, padding: '16px 20px', width: '100%' }}
-        onClick={effectiveOffset < 0 || !canManage ? undefined : () => onEdit(drink)}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={resetSwipe}
+        style={{ transform: `translateX(${offset}px)`, padding: '16px 20px', width: '100%' }}
+        onClick={offset < 0 || !canManage ? undefined : () => onEdit(drink)}
+        {...handlers}
       >
         <h3>{displayName}</h3>
         <p className="events-card-meta">
@@ -223,10 +158,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
-  const [deleteBanners, setDeleteBanners] = useState([]);
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
   const [showOwnOnly, setShowOwnOnly] = useState(true);
-  const deleteBannerCounterRef = useRef(0);
-  const deleteBannerTimeoutsRef = useRef(new Map());
   const formRef = useRef(null);
 
   useEffect(() => {
@@ -260,23 +193,16 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     return unsubscribe;
   }, []);
 
-  useEffect(() => {
-    const timeouts = deleteBannerTimeoutsRef.current;
-    return () => {
-      timeouts.forEach((id) => clearTimeout(id));
-      timeouts.clear();
-    };
-  }, []);
-
   const drinkRecipes = useMemo(
     () => (Array.isArray(recipes) ? recipes.filter(isDrinkRecipe) : []),
     [recipes]
   );
   const allDrinks = useMemo(() => {
-    const merged = mergePredefinedDrinks(drinks, currentUser?.id);
+    const merged = mergePredefinedDrinks(drinks, currentUser?.id)
+      .filter((drink) => !pendingDeleteKeys.has(`${drink.ownerId || ''}_${drink.id}`));
     if (!showOwnOnly) return merged;
     return merged.filter((drink) => !drink.ownerId || drink.ownerId === currentUser?.id);
-  }, [drinks, currentUser?.id, showOwnOnly]);
+  }, [drinks, currentUser?.id, showOwnOnly, pendingDeleteKeys]);
   const groupedDrinks = useMemo(() => groupDrinksByCategory(allDrinks, recipes), [allDrinks, recipes]);
   const getOwnerFirstName = (ownerId) => {
     if (!ownerId) return null;
@@ -421,21 +347,21 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     }
   };
 
-  const handleDelete = async (drink) => {
-    try {
-      await deleteCustomDrink(drink.ownerId || currentUser.id, drink.id);
-      const id = deleteBannerCounterRef.current;
-      deleteBannerCounterRef.current = (id + 1) % 100000;
-      const deletedDisplayName = resolveDrinkDisplay(drink, recipes).displayName;
-      setDeleteBanners((prev) => [...prev, { id, message: `"${deletedDisplayName}" gelöscht.` }]);
-      const timeoutId = setTimeout(() => {
-        setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
-        deleteBannerTimeoutsRef.current.delete(id);
-      }, DELETE_BANNER_TIMEOUT_MS);
-      deleteBannerTimeoutsRef.current.set(id, timeoutId);
-    } catch (err) {
-      console.error('Error deleting custom drink:', err);
-    }
+  const handleDelete = (drink) => {
+    const ownerId = drink.ownerId || currentUser.id;
+    const deletedDisplayName = resolveDrinkDisplay(drink, recipes).displayName;
+    scheduleDelete({
+      key: `${drink.ownerId || ''}_${drink.id}`,
+      message: `"${deletedDisplayName}" gelöscht.`,
+      onConfirm: async () => {
+        try {
+          await deleteCustomDrink(ownerId, drink.id);
+        } catch (err) {
+          console.error('Error deleting custom drink:', err);
+        }
+      },
+      onUndo: () => {},
+    });
   };
 
   if (showForm) {
@@ -793,8 +719,11 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
         </div>
       )}
       {deleteBanners.map((banner) => (
-        <div key={banner.id} className="drink-delete-banner" role="status">
+        <div key={banner.id} className="undo-snackbar" role="status">
           <span>{banner.message}</span>
+          <button type="button" className="undo-snackbar-btn" onClick={() => undoDelete(banner.id)}>
+            Rückgängig
+          </button>
         </div>
       ))}
       <OverviewAddFab onClick={openNew} title="Getränk anlegen" ariaLabel="Getränk anlegen" />

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import DrinkManagementPage from './DrinkManagementPage';
 
 const mockSubscribeToAllCustomDrinks = jest.fn();
@@ -736,29 +736,38 @@ describe('DrinkManagementPage', () => {
       });
     });
 
-    test('clicking swipe-delete button calls deleteCustomDrink', async () => {
-      mockDeleteCustomDrink.mockResolvedValue(undefined);
-      mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
-        cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
-        return jest.fn();
-      });
+    test('clicking swipe-delete button calls deleteCustomDrink only after the undo window passes', async () => {
+      jest.useFakeTimers();
+      try {
+        mockDeleteCustomDrink.mockResolvedValue(undefined);
+        mockSubscribeToAllCustomDrinks.mockImplementation((cb) => {
+          cb([{ id: 'd1', name: 'Craft-Bier', kategorie: 'bier', einheiten: [] }]);
+          return jest.fn();
+        });
 
-      render(<DrinkManagementPage currentUser={currentUser} />);
+        render(<DrinkManagementPage currentUser={currentUser} />);
 
-      const drinkContent = screen.getByText('Craft-Bier').closest('.drink-swipe-content');
-      fireEvent.touchStart(drinkContent, createTouchEvent('touchstart', 200, 100));
-      fireEvent.touchMove(drinkContent, createTouchEvent('touchmove', 130, 100));
-      fireEvent.touchEnd(drinkContent, {});
+        const drinkContent = screen.getByText('Craft-Bier').closest('.drink-swipe-content');
+        fireEvent.touchStart(drinkContent, createTouchEvent('touchstart', 200, 100));
+        fireEvent.touchMove(drinkContent, createTouchEvent('touchmove', 130, 100));
+        fireEvent.touchEnd(drinkContent, {});
 
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Craft-Bier löschen' })).toBeInTheDocument();
-      });
+        await waitFor(() => {
+          expect(screen.getByRole('button', { name: 'Craft-Bier löschen' })).toBeInTheDocument();
+        });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Craft-Bier löschen' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Craft-Bier löschen' }));
 
-      await waitFor(() => {
+        expect(mockDeleteCustomDrink).not.toHaveBeenCalled();
+
+        await act(async () => {
+          jest.advanceTimersByTime(6000);
+        });
+
         expect(mockDeleteCustomDrink).toHaveBeenCalledWith(currentUser.id, 'd1');
-      });
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     test('delete banner appears after deleting a drink', async () => {

--- a/src/components/EventDrinkSelectionPage.js
+++ b/src/components/EventDrinkSelectionPage.js
@@ -4,6 +4,8 @@ import UnitChip from './UnitChip';
 import { getEffectiveIcon, DEFAULT_BUTTON_ICONS } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const MIN_DISTRIBUTION_FACTOR = 0.1;
 const MAX_DISTRIBUTION_FACTOR = 2.0;
@@ -113,10 +115,6 @@ function EinheitenTypeahead({ einheiten, selectedIndices, onToggle, drinkName })
   );
 }
 
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-
 function DrinkRow({
   drink,
   displayName,
@@ -133,78 +131,25 @@ function DrinkRow({
   maxFactor,
   swipeDeleteIcon,
 }) {
-  const touchStartXRef = useRef(null);
-  const touchStartYRef = useRef(null);
-  const swipeDirectionLockedRef = useRef(null);
-  const isSwipingRef = useRef(false);
-  const [swipeOffset, setSwipeOffset] = useState(0);
+  const { offset, reset, handlers } = useSwipeToDelete({
+    isDeleteVisible,
+    onDeleteVisibleChange: (visible) => (visible ? onSwipeDeleteVisible() : onSwipeDeleteHidden()),
+  });
   const [factorInput, setFactorInput] = useState(factor.toFixed(2));
-
-  const effectiveSwipeOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
-
-  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    setSwipeOffset(0);
-    if (!keepDeleteAction) {
-      onSwipeDeleteHidden();
-    }
-  };
-
-  const handleTouchStart = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch) return;
-    if (isDeleteVisible) onSwipeDeleteHidden();
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-  };
-
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null) return;
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
-      if (e.cancelable) e.preventDefault();
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (isSwipingRef.current && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
-      onSwipeDeleteVisible();
-      resetSwipe({ keepDeleteAction: true });
-      return;
-    }
-    resetSwipe();
-  };
 
   const handleSwipeDeleteClick = () => {
     onRemove();
-    resetSwipe();
+    reset();
   };
 
   const swipeContentStyle = {
-    transform: `translateX(${effectiveSwipeOffset}px)`,
+    transform: `translateX(${offset}px)`,
     transition: 'transform 0.15s ease',
   };
 
   return (
     <div
-      className={`events-drink-row${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`events-drink-row${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
       <div className="events-drink-row-swipe-background" aria-hidden={!isDeleteVisible}>
         {isDeleteVisible && (
@@ -225,10 +170,7 @@ function DrinkRow({
       <div
         className="events-drink-row-content"
         style={swipeContentStyle}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={resetSwipe}
+        {...handlers}
       >
         <div className="events-drink-row-header">
           <div className="events-drink-row-name">{displayName}</div>
@@ -325,6 +267,7 @@ function EventDrinkSelectionPage({
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
 
   const toggleCustomDrink = (id) => {
     setCustomDrinkIds((prev) => {
@@ -362,12 +305,16 @@ function EventDrinkSelectionPage({
   };
 
   const handleSave = () => {
-    const optimizedFactors = customDrinkIds.reduce((acc, drinkId) => {
+    // Drinks still pending an undoable swipe-delete haven't actually been removed from
+    // customDrinkIds yet (see handleRemoveDrink), but should be saved as removed since
+    // they're already hidden from view.
+    const drinkIdsToSave = customDrinkIds.filter((id) => !pendingDeleteKeys.has(id));
+    const optimizedFactors = drinkIdsToSave.reduce((acc, drinkId) => {
       const factor = normalizeDistributionFactor(drinkDistributionFactors[drinkId]);
       if (factor !== 1) acc[drinkId] = factor;
       return acc;
     }, {});
-    const optimizedEinheiten = customDrinkIds.reduce((acc, drinkId) => {
+    const optimizedEinheiten = drinkIdsToSave.reduce((acc, drinkId) => {
       const selected = drinkSelectedEinheiten[drinkId];
       const indices = selected ? [...selected].sort((a, b) => a - b) : [0];
       if (indices.length > 1 || (indices.length === 1 && indices[0] !== 0)) {
@@ -375,10 +322,20 @@ function EventDrinkSelectionPage({
       }
       return acc;
     }, {});
-    onSave(customDrinkIds, optimizedFactors, optimizedEinheiten, Number(pufferProzent));
+    onSave(drinkIdsToSave, optimizedFactors, optimizedEinheiten, Number(pufferProzent));
   };
 
-  const selectedDrinks = customDrinks.filter((d) => customDrinkIds.includes(d.id));
+  const handleRemoveDrink = (drink) => {
+    const displayName = resolveDrinkDisplay(drink, recipes).displayName;
+    scheduleDelete({
+      key: drink.id,
+      message: `"${displayName}" entfernt.`,
+      onConfirm: () => toggleCustomDrink(drink.id),
+      onUndo: () => {},
+    });
+  };
+
+  const selectedDrinks = customDrinks.filter((d) => customDrinkIds.includes(d.id) && !pendingDeleteKeys.has(d.id));
   const updateDistributionFactor = (drinkId, value) => {
     setDrinkDistributionFactors((prev) => {
       const factor = normalizeDistributionFactor(value);
@@ -465,7 +422,7 @@ function EventDrinkSelectionPage({
                         isDeleteVisible={isDeleteVisible}
                         onToggleEinheit={(idx) => toggleEinheit(drink.id, idx)}
                         onUpdateFactor={(val) => updateDistributionFactor(drink.id, val)}
-                        onRemove={() => toggleCustomDrink(drink.id)}
+                        onRemove={() => handleRemoveDrink(drink)}
                         onSwipeDeleteVisible={() => setSwipeDeleteVisibleId(drink.id)}
                         onSwipeDeleteHidden={() => setSwipeDeleteVisibleId((prev) => prev === drink.id ? null : prev)}
                         minFactor={MIN_DISTRIBUTION_FACTOR}
@@ -480,9 +437,17 @@ function EventDrinkSelectionPage({
           ) : (
             <p className="events-info-text">Noch keine eigenen Getränke angelegt.</p>
           )}
+          {deleteBanners.map((banner) => (
+            <div key={banner.id} className="undo-snackbar" role="status">
+              <span>{banner.message}</span>
+              <button type="button" className="undo-snackbar-btn" onClick={() => undoDelete(banner.id)}>
+                Rückgängig
+              </button>
+            </div>
+          ))}
 
           <span className="events-selected-count-badge">
-            {customDrinkIds.length} {customDrinkIds.length === 1 ? 'Getränk' : 'Getränke'} ausgewählt.
+            {selectedDrinks.length} {selectedDrinks.length === 1 ? 'Getränk' : 'Getränke'} ausgewählt.
           </span>
         </div>
 

--- a/src/components/EventGuestSelectionPage.js
+++ b/src/components/EventGuestSelectionPage.js
@@ -4,14 +4,8 @@ import { subscribeToGuestProfiles } from '../utils/eventsFirestore';
 import { getGuestDisplayName } from '../utils/guestPreferences';
 import { DEFAULT_BUTTON_ICONS, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
-
-// Matches the swipe-to-delete gesture and delete button behavior used for
-// drinks (see DrinkRow in EventDrinkSelectionPage.js): swiping left reveals
-// the delete button on the right; on desktop the static button next to the
-// row stays visible instead (no touch events to trigger the swipe).
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 function GuestRow({
   fullName,
@@ -23,76 +17,23 @@ function GuestRow({
   onSwipeDeleteHidden,
   swipeDeleteIcon,
 }) {
-  const touchStartXRef = useRef(null);
-  const touchStartYRef = useRef(null);
-  const swipeDirectionLockedRef = useRef(null);
-  const isSwipingRef = useRef(false);
-  const [swipeOffset, setSwipeOffset] = useState(0);
-
-  const effectiveSwipeOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
-
-  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    setSwipeOffset(0);
-    if (!keepDeleteAction) {
-      onSwipeDeleteHidden();
-    }
-  };
-
-  const handleTouchStart = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch) return;
-    if (isDeleteVisible) onSwipeDeleteHidden();
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-  };
-
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null) return;
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
-      if (e.cancelable) e.preventDefault();
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (isSwipingRef.current && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
-      onSwipeDeleteVisible();
-      resetSwipe({ keepDeleteAction: true });
-      return;
-    }
-    resetSwipe();
-  };
+  const { offset, reset, handlers } = useSwipeToDelete({
+    isDeleteVisible,
+    onDeleteVisibleChange: (visible) => (visible ? onSwipeDeleteVisible() : onSwipeDeleteHidden()),
+  });
 
   const handleSwipeDeleteClick = () => {
     onRemove();
-    resetSwipe();
+    reset();
   };
 
   const swipeContentStyle = {
-    transform: `translateX(${effectiveSwipeOffset}px)`,
+    transform: `translateX(${offset}px)`,
     transition: 'transform 0.15s ease',
   };
 
   return (
-    <div className={`events-guest-row${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}>
+    <div className={`events-guest-row${offset < 0 ? ' swipe-delete-active' : ''}`}>
       <div className="events-guest-row-swipe-background" aria-hidden={!isDeleteVisible}>
         {isDeleteVisible && (
           <button
@@ -112,10 +53,7 @@ function GuestRow({
       <div
         className="events-guest-row-content"
         style={swipeContentStyle}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={resetSwipe}
+        {...handlers}
       >
         <div className="events-guest-row-header">
           <div className="events-guest-row-name">{fullName}</div>
@@ -167,6 +105,7 @@ function EventGuestSelectionPage({
   const [fabPressed, setFabPressed] = useState(false);
   const [cancelPressed, setCancelPressed] = useState(false);
   const [swipeDeleteVisibleId, setSwipeDeleteVisibleId] = useState(null);
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
   const searchRef = useRef(null);
   const dropdownRef = useRef(null);
   const effectiveButtonIcons = buttonIcons || DEFAULT_BUTTON_ICONS;
@@ -204,6 +143,16 @@ function EventGuestSelectionPage({
     );
   };
 
+  const handleRemoveGuest = (guest) => {
+    const fullName = getGuestDisplayName(guest) || 'Unbenannter Gast';
+    scheduleDelete({
+      key: guest.id,
+      message: `"${fullName}" entfernt.`,
+      onConfirm: () => toggleGuest(guest.id),
+      onUndo: () => {},
+    });
+  };
+
   const toggleDriverGuest = (guestId) => {
     if (!selectedGuestIds.includes(guestId)) return;
     setDriverGuestIds((prev) =>
@@ -212,7 +161,11 @@ function EventGuestSelectionPage({
   };
 
   const handleSave = () => {
-    onSave(selectedGuestIds, driverGuestIds);
+    // Guests still pending an undoable swipe-delete haven't actually been removed from
+    // selectedGuestIds yet (see handleRemoveGuest), but should be saved as removed since
+    // they're already hidden from view.
+    const guestIdsToSave = selectedGuestIds.filter((id) => !pendingDeleteKeys.has(id));
+    onSave(guestIdsToSave, driverGuestIds.filter((id) => guestIdsToSave.includes(id)));
   };
 
   const handleSearchChange = (e) => {
@@ -234,7 +187,9 @@ function EventGuestSelectionPage({
       })
     : [];
 
-  const selectedGuests = guests.filter((g) => selectedGuestIds.includes(g.id));
+  const effectiveSelectedGuestIds = selectedGuestIds.filter((id) => !pendingDeleteKeys.has(id));
+  const effectiveDriverGuestIds = driverGuestIds.filter((id) => !pendingDeleteKeys.has(id));
+  const selectedGuests = guests.filter((g) => selectedGuestIds.includes(g.id) && !pendingDeleteKeys.has(g.id));
 
   return (
     <div className="events-page-container">
@@ -302,7 +257,7 @@ function EventGuestSelectionPage({
                     isDriver={driverGuestIds.includes(guest.id)}
                     isDeleteVisible={isDeleteVisible}
                     onToggleDriver={() => toggleDriverGuest(guest.id)}
-                    onRemove={() => toggleGuest(guest.id)}
+                    onRemove={() => handleRemoveGuest(guest)}
                     onSwipeDeleteVisible={() => setSwipeDeleteVisibleId(guest.id)}
                     onSwipeDeleteHidden={() =>
                       setSwipeDeleteVisibleId((prev) => (prev === guest.id ? null : prev))
@@ -313,13 +268,21 @@ function EventGuestSelectionPage({
               })}
             </div>
           )}
+          {deleteBanners.map((banner) => (
+            <div key={banner.id} className="undo-snackbar" role="status">
+              <span>{banner.message}</span>
+              <button type="button" className="undo-snackbar-btn" onClick={() => undoDelete(banner.id)}>
+                Rückgängig
+              </button>
+            </div>
+          ))}
 
           <div className="events-guest-summary-badges">
             <span className="events-summary-badge">
-              {selectedGuestIds.length} {selectedGuestIds.length === 1 ? 'Gast' : 'Gäste'} ausgewählt.
+              {effectiveSelectedGuestIds.length} {effectiveSelectedGuestIds.length === 1 ? 'Gast' : 'Gäste'} ausgewählt.
             </span>
             <span className="events-summary-badge">
-              {driverGuestIds.length} Fahrer markiert.
+              {effectiveDriverGuestIds.length} Fahrer markiert.
             </span>
           </div>
         </div>

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1932,10 +1932,10 @@
   transition: transform 0.15s ease;
 }
 
-.drink-delete-banner {
+.undo-snackbar {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 0.75rem;
   margin: 0.35rem 0 0.5rem;
   padding: 0.5rem 0.7rem;
@@ -1944,6 +1944,22 @@
   background: #fff5f4;
   color: #8b2d21;
   font-size: 0.9rem;
+}
+
+.undo-snackbar-btn {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: #a33a26;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.15rem 0.3rem;
+  cursor: pointer;
+}
+
+.undo-snackbar-btn:hover,
+.undo-snackbar-btn:focus-visible {
+  text-decoration: underline;
 }
 
 /* ── Swipe-Delete für Event-Karten (gleiches Pattern wie bei Getränken) ── */
@@ -1996,16 +2012,3 @@
   transition: transform 0.15s ease;
 }
 
-.events-delete-banner {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.75rem;
-  margin: 0.35rem 0 0.5rem;
-  padding: 0.5rem 0.7rem;
-  border: 1px solid #f0c5bf;
-  border-radius: 8px;
-  background: #fff5f4;
-  color: #8b2d21;
-  font-size: 0.9rem;
-}

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import './EventsPage.css';
 import { subscribeToEvents, subscribeToAllEvents, deleteEvent, getEvent } from '../utils/eventsFirestore';
 import { CATEGORY_LABELS, EVENT_TYPE_LABELS } from './EventForm';
@@ -11,6 +11,8 @@ import { canEditRecipes, getUsers } from '../utils/userManagement';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const STATUS_LABELS = {
   geplant: 'Geplant',
@@ -18,11 +20,6 @@ const STATUS_LABELS = {
   eingekauft: 'Eingekauft',
   verbrauchErfasst: 'Verbrauch erfasst',
 };
-
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-const DELETE_BANNER_TIMEOUT_MS = 5000;
 
 const formatDate = (dateStr) => {
   if (!dateStr) return '';
@@ -90,70 +87,11 @@ const formatDrinkSummary = (berechnung) => {
 };
 
 function EventCard({ event, ownerName, canManage, onSelect, onDelete, swipeDeleteIcon }) {
-  const touchStartXRef = React.useRef(null);
-  const touchStartYRef = React.useRef(null);
-  const swipeDirectionLockedRef = React.useRef(null);
-  const isSwipingRef = React.useRef(false);
-  const swipeOffsetRef = React.useRef(0);
-  const [swipeOffset, setSwipeOffset] = React.useState(0);
-  const [isDeleteVisible, setIsDeleteVisible] = React.useState(false);
-
-  const effectiveOffset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
-
-  const resetSwipe = ({ keepDelete = false } = {}) => {
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    swipeOffsetRef.current = 0;
-    setSwipeOffset(0);
-    if (!keepDelete) setIsDeleteVisible(false);
-  };
-
-  const handleTouchStart = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || !canManage) return;
-    if (isDeleteVisible) setIsDeleteVisible(false);
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-  };
-
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || !canManage) return;
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      const clamped = Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET);
-      swipeOffsetRef.current = clamped;
-      setSwipeOffset(clamped);
-      if (e.cancelable) e.preventDefault();
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (isSwipingRef.current && Math.abs(swipeOffsetRef.current) >= SWIPE_DELETE_THRESHOLD) {
-      setIsDeleteVisible(true);
-      resetSwipe({ keepDelete: true });
-      return;
-    }
-    resetSwipe();
-  };
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ disabled: !canManage });
 
   return (
     <div
-      className={`events-card-swipe-wrapper events-card${effectiveOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`events-card-swipe-wrapper events-card${offset < 0 ? ' swipe-delete-active' : ''}`}
       style={{ padding: 0 }}
     >
       {canManage && (
@@ -162,7 +100,7 @@ function EventCard({ event, ownerName, canManage, onSelect, onDelete, swipeDelet
             <button
               type="button"
               className="events-card-swipe-delete-action"
-              onClick={() => { onDelete(event); resetSwipe(); }}
+              onClick={() => { onDelete(event); reset(); }}
               aria-label={`${event.eventName} löschen`}
             >
               {isBase64Image(swipeDeleteIcon) ? (
@@ -176,12 +114,9 @@ function EventCard({ event, ownerName, canManage, onSelect, onDelete, swipeDelet
       )}
       <div
         className="events-card-swipe-content events-card-main"
-        style={{ transform: `translateX(${effectiveOffset}px)`, padding: '16px 20px', width: '100%' }}
-        onClick={effectiveOffset < 0 || !canManage ? undefined : () => onSelect(event)}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={resetSwipe}
+        style={{ transform: `translateX(${offset}px)`, padding: '16px 20px', width: '100%' }}
+        onClick={offset < 0 || !canManage ? undefined : () => onSelect(event)}
+        {...handlers}
       >
         <h3>{event.eventName}</h3>
         <div className="events-card-meta-row">
@@ -224,9 +159,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
   const [allEvents, setAllEvents] = useState([]);
   const [allEventsLoading, setAllEventsLoading] = useState(true);
   const [allUsers, setAllUsers] = useState([]);
-  const [deleteBanners, setDeleteBanners] = useState([]);
-  const deleteBannerCounterRef = useRef(0);
-  const deleteBannerTimeoutsRef = useRef(new Map());
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
 
   useEffect(() => {
     const handleResize = () => setIsMobileView(window.innerWidth <= 768);
@@ -274,14 +207,6 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     });
     return unsubscribe;
   }, [isAdmin]);
-
-  useEffect(() => {
-    const timeouts = deleteBannerTimeoutsRef.current;
-    return () => {
-      timeouts.forEach((id) => clearTimeout(id));
-      timeouts.clear();
-    };
-  }, []);
 
   // Deep link from a push notification: jump straight to the consumption form.
   useEffect(() => {
@@ -387,20 +312,20 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
     }
   };
 
-  const handleSwipeDelete = async (event) => {
-    try {
-      await deleteEvent(event.ownerId || currentUser.id, event.id);
-      const id = deleteBannerCounterRef.current;
-      deleteBannerCounterRef.current = (id + 1) % 100000;
-      setDeleteBanners((prev) => [...prev, { id, message: `"${event.eventName}" gelöscht.` }]);
-      const timeoutId = setTimeout(() => {
-        setDeleteBanners((prev) => prev.filter((b) => b.id !== id));
-        deleteBannerTimeoutsRef.current.delete(id);
-      }, DELETE_BANNER_TIMEOUT_MS);
-      deleteBannerTimeoutsRef.current.set(id, timeoutId);
-    } catch (err) {
-      console.error('Error deleting event:', err);
-    }
+  const handleSwipeDelete = (event) => {
+    const ownerId = event.ownerId || currentUser.id;
+    scheduleDelete({
+      key: `${ownerId}_${event.id}`,
+      message: `"${event.eventName}" gelöscht.`,
+      onConfirm: async () => {
+        try {
+          await deleteEvent(ownerId, event.id);
+        } catch (err) {
+          console.error('Error deleting event:', err);
+        }
+      },
+      onUndo: () => {},
+    });
   };
 
   if (subView === 'drinks') {
@@ -671,7 +596,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
           </div>
         ) : (
           <div className="events-list">
-            {allEvents.map((event) => (
+            {allEvents.filter((event) => !pendingDeleteKeys.has(`${event.ownerId}_${event.id}`)).map((event) => (
               <EventCard
                 key={`${event.ownerId}_${event.id}`}
                 event={event}
@@ -695,7 +620,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         </div>
       ) : (
         <div className="events-list">
-          {events.map((event) => (
+          {events.filter((event) => !pendingDeleteKeys.has(`${event.ownerId || currentUser.id}_${event.id}`)).map((event) => (
             <EventCard
               key={event.id}
               event={event}
@@ -708,8 +633,11 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         </div>
       )}
       {deleteBanners.map((banner) => (
-        <div key={banner.id} className="events-delete-banner" role="status">
+        <div key={banner.id} className="undo-snackbar" role="status">
           <span>{banner.message}</span>
+          <button type="button" className="undo-snackbar-btn" onClick={() => undoDelete(banner.id)}>
+            Rückgängig
+          </button>
         </div>
       ))}
       <OverviewAddFab onClick={() => setSubView('new')} title="Event erstellen" ariaLabel="Event erstellen" />

--- a/src/components/EventsPage.test.js
+++ b/src/components/EventsPage.test.js
@@ -671,7 +671,7 @@ describe('EventsPage', () => {
       });
     });
 
-    test('clicking swipe-delete button calls deleteEvent and shows a banner, without opening the event', async () => {
+    test('clicking swipe-delete button hides the event immediately and shows an undo banner, without calling deleteEvent yet', async () => {
       mockDeleteEvent.mockResolvedValue(undefined);
       mockSubscribeToEvents.mockImplementation((_uid, cb) => {
         cb([event]);
@@ -691,12 +691,70 @@ describe('EventsPage', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Sommerfest löschen' }));
 
-      await waitFor(() => {
+      expect(screen.queryByText('Sommerfest')).not.toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveTextContent('"Sommerfest" gelöscht.');
+      expect(mockDeleteEvent).not.toHaveBeenCalled();
+    });
+
+    test('deletes the event only after the undo window passes without a click on "Rückgängig"', async () => {
+      jest.useFakeTimers();
+      try {
+        mockDeleteEvent.mockResolvedValue(undefined);
+        mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+          cb([event]);
+          return jest.fn();
+        });
+
+        render(<EventsPage currentUser={currentUser} />);
+
+        const eventCardContent = screen.getByText('Sommerfest').closest('.events-card-swipe-content');
+        fireEvent.touchStart(eventCardContent, createTouchEvent(200, 100));
+        fireEvent.touchMove(eventCardContent, createTouchEvent(130, 100));
+        fireEvent.touchEnd(eventCardContent, {});
+        fireEvent.click(screen.getByRole('button', { name: 'Sommerfest löschen' }));
+
+        expect(mockDeleteEvent).not.toHaveBeenCalled();
+
+        await act(async () => {
+          jest.advanceTimersByTime(6000);
+        });
+
         expect(mockDeleteEvent).toHaveBeenCalledWith(currentUser.id, 'e1');
-      });
-      await waitFor(() => {
-        expect(screen.getByRole('status')).toHaveTextContent('"Sommerfest" gelöscht.');
-      });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('clicking "Rückgängig" restores the event and never calls deleteEvent', async () => {
+      jest.useFakeTimers();
+      try {
+        mockDeleteEvent.mockResolvedValue(undefined);
+        mockSubscribeToEvents.mockImplementation((_uid, cb) => {
+          cb([event]);
+          return jest.fn();
+        });
+
+        render(<EventsPage currentUser={currentUser} />);
+
+        const eventCardContent = screen.getByText('Sommerfest').closest('.events-card-swipe-content');
+        fireEvent.touchStart(eventCardContent, createTouchEvent(200, 100));
+        fireEvent.touchMove(eventCardContent, createTouchEvent(130, 100));
+        fireEvent.touchEnd(eventCardContent, {});
+        fireEvent.click(screen.getByRole('button', { name: 'Sommerfest löschen' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Rückgängig' }));
+
+        expect(screen.getByText('Sommerfest')).toBeInTheDocument();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+        await act(async () => {
+          jest.advanceTimersByTime(6000);
+        });
+
+        expect(mockDeleteEvent).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -14,6 +14,8 @@ import { DRINK_CATEGORIES, getDrinkCategoryLabel } from '../utils/drinkCategorie
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const emptyForm = () => ({
   vorname: '',
@@ -34,75 +36,13 @@ const getPreferenceLabel = (factor) => {
   return 'wird nicht berücksichtigt';
 };
 
-// Matches the "Zutat löschen" swipe-to-delete gesture from the recipe edit page
-// (see SortableIngredient in RecipeForm.js): swiping left reveals the delete
-// button on the right. On desktop the static button next to the card stays
-// visible instead (no touch events to trigger the swipe).
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-
 function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
-  const touchStartXRef = React.useRef(null);
-  const touchStartYRef = React.useRef(null);
-  const swipeDirectionLockedRef = React.useRef(null);
-  const isSwipingRef = React.useRef(false);
-  const [swipeOffset, setSwipeOffset] = useState(0);
-  const [isDeleteActionVisible, setIsDeleteActionVisible] = useState(false);
-
-  const effectiveSwipeOffset = isDeleteActionVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
   const deleteLabel = `${fullName || 'Gast'} löschen`;
 
-  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    setSwipeOffset(0);
-    if (!keepDeleteAction) setIsDeleteActionVisible(false);
-  };
-
-  const handleTouchStart = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch) return;
-    if (isDeleteActionVisible) setIsDeleteActionVisible(false);
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-  };
-
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null) return;
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
-      if (e.cancelable) e.preventDefault();
-    }
-  };
-
-  const handleTouchEnd = () => {
-    if (isSwipingRef.current && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
-      setIsDeleteActionVisible(true);
-      resetSwipe({ keepDeleteAction: true });
-      return;
-    }
-    resetSwipe();
-  };
-
   const handleContentClick = () => {
-    if (isDeleteActionVisible) {
-      resetSwipe();
+    if (isDeleteVisible) {
+      reset();
       return;
     }
     onOpenEdit();
@@ -111,18 +51,18 @@ function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
   const handleSwipeDeleteClick = (e) => {
     e.stopPropagation();
     onDelete();
-    resetSwipe();
+    reset();
   };
 
   return (
-    <div className={`events-card events-guest-card${isDeleteActionVisible ? ' swipe-delete-active' : ''}`}>
-      <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible && effectiveSwipeOffset === 0}>
+    <div className={`events-card events-guest-card${isDeleteVisible ? ' swipe-delete-active' : ''}`}>
+      <div className="swipe-delete-background" aria-hidden={!isDeleteVisible && offset === 0}>
         <button
           type="button"
           className="swipe-delete-action"
           onClick={handleSwipeDeleteClick}
           aria-label={deleteLabel}
-          tabIndex={isDeleteActionVisible ? 0 : -1}
+          tabIndex={isDeleteVisible ? 0 : -1}
         >
           {isBase64Image(deleteIcon) ? (
             <img src={deleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
@@ -133,12 +73,9 @@ function GuestCard({ fullName, deleteIcon, onOpenEdit, onDelete, children }) {
       </div>
       <div
         className="events-guest-card-content"
-        style={{ transform: `translateX(${effectiveSwipeOffset}px)`, transition: 'transform 0.15s ease' }}
+        style={{ transform: `translateX(${offset}px)`, transition: 'transform 0.15s ease' }}
         onClick={handleContentClick}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={() => resetSwipe()}
+        {...handlers}
       >
         {children}
         <button
@@ -179,6 +116,7 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
   const formRef = React.useRef(null);
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
 
   const canManageGuests = canEditRecipes(currentUser);
   const closeIcon = getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode);
@@ -254,8 +192,15 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     });
   };
 
-  const sortedProfiles = useMemo(() => sortByName(profiles), [profiles]);
-  const sortedAllProfiles = useMemo(() => sortByName(allProfiles), [allProfiles]);
+  const getProfileKey = (profile) => `${profile.ownerId || currentUser?.id}_${profile.id}`;
+  const sortedProfiles = useMemo(
+    () => sortByName(profiles).filter((p) => !pendingDeleteKeys.has(`${p.ownerId || currentUser?.id}_${p.id}`)),
+    [profiles, pendingDeleteKeys, currentUser?.id]
+  );
+  const sortedAllProfiles = useMemo(
+    () => sortByName(allProfiles).filter((p) => !pendingDeleteKeys.has(`${p.ownerId || currentUser?.id}_${p.id}`)),
+    [allProfiles, pendingDeleteKeys, currentUser?.id]
+  );
 
   const openNew = () => {
     setEditId(null);
@@ -354,20 +299,26 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
     }
   };
 
-  const handleDelete = async (profile) => {
+  const handleDelete = (profile) => {
     if (!canManageGuests) return;
     const name = getGuestDisplayName(profile) || 'diesen Gast';
-    if (!window.confirm(`Möchtest du "${name}" wirklich löschen?`)) return;
-    try {
-      // Admin deleting another user's guest: pass their ownerId through.
-      if (profile.ownerId && profile.ownerId !== currentUser.id) {
-        await deleteGuestProfile(currentUser.id, profile.id, profile.ownerId);
-      } else {
-        await deleteGuestProfile(currentUser.id, profile.id);
-      }
-    } catch (err) {
-      console.error('Error deleting guest profile:', err);
-    }
+    scheduleDelete({
+      key: getProfileKey(profile),
+      message: `"${name}" gelöscht.`,
+      onConfirm: async () => {
+        try {
+          // Admin deleting another user's guest: pass their ownerId through.
+          if (profile.ownerId && profile.ownerId !== currentUser.id) {
+            await deleteGuestProfile(currentUser.id, profile.id, profile.ownerId);
+          } else {
+            await deleteGuestProfile(currentUser.id, profile.id);
+          }
+        } catch (err) {
+          console.error('Error deleting guest profile:', err);
+        }
+      },
+      onUndo: () => {},
+    });
   };
 
   const handleFabClick = (e) => {
@@ -759,6 +710,14 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
           })}
         </div>
       )}
+      {deleteBanners.map((banner) => (
+        <div key={banner.id} className="undo-snackbar" role="status">
+          <span>{banner.message}</span>
+          <button type="button" className="undo-snackbar-btn" onClick={() => undoDelete(banner.id)}>
+            Rückgängig
+          </button>
+        </div>
+      ))}
       <OverviewAddFab onClick={openNew} title="Gast anlegen" ariaLabel="Gast anlegen" />
     </div>
   );

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import GuestManagementPage from './GuestManagementPage';
 
 const mockSubscribeToGuestProfiles = jest.fn();
@@ -305,25 +305,34 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     expect(names).toEqual(['Anna Adler', 'Zora Adler', 'Bernd Zimmer']);
   });
 
-  test('clicking the delete button on a guest card deletes the guest without opening the edit form', () => {
-    window.confirm = jest.fn(() => true);
-    mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
-      cb([
-        { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
-      ]);
-      return jest.fn();
-    });
+  test('clicking the delete button on a guest card hides the guest immediately and deletes it once the undo window passes', async () => {
+    jest.useFakeTimers();
+    try {
+      mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
+        cb([
+          { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
+        ]);
+        return jest.fn();
+      });
 
-    render(<GuestManagementPage currentUser={currentUser} />);
+      render(<GuestManagementPage currentUser={currentUser} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Anna Adler löschen' }));
 
-    expect(window.confirm).toHaveBeenCalledWith('Möchtest du "Anna Adler" wirklich löschen?');
-    expect(mockDeleteGuestProfile).toHaveBeenCalledWith('u1', 'g1');
+      expect(screen.queryByText('Anna Adler')).not.toBeInTheDocument();
+      expect(mockDeleteGuestProfile).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(6000);
+      });
+
+      expect(mockDeleteGuestProfile).toHaveBeenCalledWith('u1', 'g1');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('delete button click does not trigger the edit form to open', () => {
-    window.confirm = jest.fn(() => true);
     mockSubscribeToGuestProfiles.mockImplementation((_uid, cb) => {
       cb([
         { id: 'g1', vorname: 'Anna', nachname: 'Adler', alkoholischeGetränke: true, bevorzugteGetränke: [], bevorzugteKategorien: [], präferenzFaktor: 0.5 },
@@ -399,19 +408,27 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     });
 
     test('admin deleting another user\'s guest passes the owner id through', async () => {
-      window.confirm = jest.fn(() => true);
-      mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
-        cb([
-          { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
-        ]);
-        return jest.fn();
-      });
+      jest.useFakeTimers();
+      try {
+        mockSubscribeToAllGuestProfiles.mockImplementation((cb) => {
+          cb([
+            { id: 'g1', vorname: 'Ben', nachname: 'Beispiel', ownerId: 'other-user' },
+          ]);
+          return jest.fn();
+        });
 
-      render(<GuestManagementPage currentUser={adminUser} />);
+        render(<GuestManagementPage currentUser={adminUser} />);
 
-      fireEvent.click(await screen.findByRole('button', { name: 'Ben Beispiel löschen' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Ben Beispiel löschen' }));
 
-      expect(mockDeleteGuestProfile).toHaveBeenCalledWith(adminUser.id, 'g1', 'other-user');
+        await act(async () => {
+          jest.advanceTimersByTime(6000);
+        });
+
+        expect(mockDeleteGuestProfile).toHaveBeenCalledWith(adminUser.id, 'g1', 'other-user');
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/src/components/RecipeForm.css
+++ b/src/components/RecipeForm.css
@@ -934,10 +934,10 @@
   z-index: 1;
 }
 
-.swipe-undo-banner {
+.undo-snackbar {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 0.75rem;
   margin: 0.35rem 0 0.5rem;
   padding: 0.5rem 0.7rem;
@@ -946,6 +946,22 @@
   background: #fff5f4;
   color: #8b2d21;
   font-size: 0.9rem;
+}
+
+.undo-snackbar-btn {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: #a33a26;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.15rem 0.3rem;
+  cursor: pointer;
+}
+
+.undo-snackbar-btn:hover,
+.undo-snackbar-btn:focus-visible {
+  text-decoration: underline;
 }
 
 .add-item-button .button-icon-image {

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -32,16 +32,8 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-
-const SWIPE_DELETE_THRESHOLD = 56;
-const SWIPE_DELETE_MAX_OFFSET = 96;
-const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
-const DELETE_BANNER_TIMEOUT_MS = 10000;
-
-const clearBannerTimeouts = (bannerTimeoutsRef) => {
-  bannerTimeoutsRef.current.forEach((timeoutId) => clearTimeout(timeoutId));
-  bannerTimeoutsRef.current.clear();
-};
+import useSwipeToDelete, { SWIPE_DIRECTION_LOCK_THRESHOLD } from '../hooks/useSwipeToDelete';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 // Sortable Ingredient Item Component
 function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, onToggleType, swipeDeleteIcon }) {
@@ -58,15 +50,34 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
   const [contextMenuPos, setContextMenuPos] = useState({ top: 0, right: 0 });
   const longPressTimerRef = useRef(null);
   const inputRef = useRef(null);
-  const touchStartXRef = useRef(null);
-  const touchStartYRef = useRef(null);
-  const swipeDirectionLockedRef = useRef(null);
-  const isSwipingRef = useRef(false);
-  const [swipeOffset, setSwipeOffset] = useState(0);
-  const [isDeleteActionVisible, setIsDeleteActionVisible] = useState(false);
+
+  const startLongPress = () => {
+    longPressTimerRef.current = setTimeout(() => {
+      if (inputRef.current) {
+        const rect = inputRef.current.getBoundingClientRect();
+        setContextMenuPos({ top: rect.top, right: window.innerWidth - rect.right });
+      }
+      setShowContextMenu(true);
+    }, 500);
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({
+    disabled: !canRemove,
+    onMove: (info) => {
+      if (!info || (info.direction === 'horizontal' && info.deltaX < 0) || info.absY > SWIPE_DIRECTION_LOCK_THRESHOLD) {
+        cancelLongPress();
+      }
+    },
+  });
 
   const baseTransform = CSS.Transform.toString(transform);
-  const effectiveSwipeOffset = isDeleteActionVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
 
   const style = {
     transform: baseTransform,
@@ -74,7 +85,7 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
     opacity: isDragging ? 0.5 : 1,
   };
   const swipeContentStyle = {
-    transform: `translateX(${effectiveSwipeOffset}px)`,
+    transform: `translateX(${offset}px)`,
     transition: isDragging ? transition : 'transform 0.15s ease',
   };
 
@@ -99,87 +110,24 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
     setShowContextMenu(true);
   };
 
-  const startLongPress = () => {
-    longPressTimerRef.current = setTimeout(() => {
-      if (inputRef.current) {
-        const rect = inputRef.current.getBoundingClientRect();
-        setContextMenuPos({ top: rect.top, right: window.innerWidth - rect.right });
-      }
-      setShowContextMenu(true);
-    }, 500);
-  };
-
-  const cancelLongPress = () => {
-    if (longPressTimerRef.current) {
-      clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  };
-
-  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
-    cancelLongPress();
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    setSwipeOffset(0);
-    if (!keepDeleteAction) {
-      setIsDeleteActionVisible(false);
-    }
-  };
-
   const handleTouchStart = (e) => {
     startLongPress();
-    const touch = e.touches?.[0];
-    if (!touch || !canRemove) return;
-    if (isDeleteActionVisible) {
-      setIsDeleteActionVisible(false);
-    }
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
+    handlers.onTouchStart(e);
   };
 
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || !canRemove) {
-      cancelLongPress();
-      return;
-    }
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      cancelLongPress();
-      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
-      if (e.cancelable) e.preventDefault();
-    } else if (absY > SWIPE_DIRECTION_LOCK_THRESHOLD) {
-      cancelLongPress();
-    }
-  };
-
-  const handleTouchEnd = () => {
+  const handleTouchEnd = (e) => {
     cancelLongPress();
-    if (isSwipingRef.current && canRemove && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
-      setIsDeleteActionVisible(true);
-      resetSwipe({ keepDeleteAction: true });
-      return;
-    }
-    resetSwipe();
+    handlers.onTouchEnd(e);
+  };
+
+  const handleTouchCancel = (e) => {
+    cancelLongPress();
+    handlers.onTouchCancel(e);
   };
 
   const handleSwipeDeleteClick = () => {
     onRemove(index, { fromSwipe: true });
-    resetSwipe();
+    reset();
   };
 
   useEffect(() => () => cancelLongPress(), []);
@@ -188,11 +136,11 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
     <div
       ref={setNodeRef}
       style={style}
-      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
       {canRemove && (
-        <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
-          {isDeleteActionVisible && (
+        <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
+          {isDeleteVisible && (
             <button
               type="button"
               className="swipe-delete-action"
@@ -221,8 +169,8 @@ function SortableIngredient({ id, item, index, onChange, onRemove, canRemove, on
           onContextMenu={handleContextMenu}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
-          onTouchCancel={resetSwipe}
-          onTouchMove={handleTouchMove}
+          onTouchCancel={handleTouchCancel}
+          onTouchMove={handlers.onTouchMove}
         />
         <button
           type="button"
@@ -271,15 +219,34 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [contextMenuPos, setContextMenuPos] = useState({ top: 0, right: 0 });
   const longPressTimerRef = useRef(null);
-  const touchStartXRef = useRef(null);
-  const touchStartYRef = useRef(null);
-  const swipeDirectionLockedRef = useRef(null);
-  const isSwipingRef = useRef(false);
-  const [swipeOffset, setSwipeOffset] = useState(0);
-  const [isDeleteActionVisible, setIsDeleteActionVisible] = useState(false);
+
+  const startLongPress = () => {
+    longPressTimerRef.current = setTimeout(() => {
+      if (textareaRef.current) {
+        const rect = textareaRef.current.getBoundingClientRect();
+        setContextMenuPos({ top: rect.top, right: window.innerWidth - rect.right });
+      }
+      setShowContextMenu(true);
+    }, 500);
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({
+    disabled: !canRemove,
+    onMove: (info) => {
+      if (!info || (info.direction === 'horizontal' && info.deltaX < 0) || info.absY > SWIPE_DIRECTION_LOCK_THRESHOLD) {
+        cancelLongPress();
+      }
+    },
+  });
 
   const baseTransform = CSS.Transform.toString(transform);
-  const effectiveSwipeOffset = isDeleteActionVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
 
   const style = {
     transform: baseTransform,
@@ -287,7 +254,7 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
     opacity: isDragging ? 0.5 : 1,
   };
   const swipeContentStyle = {
-    transform: `translateX(${effectiveSwipeOffset}px)`,
+    transform: `translateX(${offset}px)`,
     transition: isDragging ? transition : 'transform 0.15s ease',
   };
 
@@ -314,87 +281,24 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
     setShowContextMenu(true);
   };
 
-  const startLongPress = () => {
-    longPressTimerRef.current = setTimeout(() => {
-      if (textareaRef.current) {
-        const rect = textareaRef.current.getBoundingClientRect();
-        setContextMenuPos({ top: rect.top, right: window.innerWidth - rect.right });
-      }
-      setShowContextMenu(true);
-    }, 500);
-  };
-
-  const cancelLongPress = () => {
-    if (longPressTimerRef.current) {
-      clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  };
-
-  const resetSwipe = ({ keepDeleteAction = false } = {}) => {
-    cancelLongPress();
-    touchStartXRef.current = null;
-    touchStartYRef.current = null;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
-    setSwipeOffset(0);
-    if (!keepDeleteAction) {
-      setIsDeleteActionVisible(false);
-    }
-  };
-
   const handleTouchStart = (e) => {
     startLongPress();
-    const touch = e.touches?.[0];
-    if (!touch || !canRemove) return;
-    if (isDeleteActionVisible) {
-      setIsDeleteActionVisible(false);
-    }
-    touchStartXRef.current = touch.clientX;
-    touchStartYRef.current = touch.clientY;
-    swipeDirectionLockedRef.current = null;
-    isSwipingRef.current = false;
+    handlers.onTouchStart(e);
   };
 
-  const handleTouchMove = (e) => {
-    const touch = e.touches?.[0];
-    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || !canRemove) {
-      cancelLongPress();
-      return;
-    }
-
-    const deltaX = touch.clientX - touchStartXRef.current;
-    const deltaY = touch.clientY - touchStartYRef.current;
-    const absX = Math.abs(deltaX);
-    const absY = Math.abs(deltaY);
-
-    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
-      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
-    }
-
-    if (swipeDirectionLockedRef.current === 'horizontal' && deltaX < 0) {
-      isSwipingRef.current = true;
-      cancelLongPress();
-      setSwipeOffset(Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET));
-      if (e.cancelable) e.preventDefault();
-    } else if (absY > SWIPE_DIRECTION_LOCK_THRESHOLD) {
-      cancelLongPress();
-    }
-  };
-
-  const handleTouchEnd = () => {
+  const handleTouchEnd = (e) => {
     cancelLongPress();
-    if (isSwipingRef.current && canRemove && Math.abs(swipeOffset) >= SWIPE_DELETE_THRESHOLD) {
-      setIsDeleteActionVisible(true);
-      resetSwipe({ keepDeleteAction: true });
-      return;
-    }
-    resetSwipe();
+    handlers.onTouchEnd(e);
+  };
+
+  const handleTouchCancel = (e) => {
+    cancelLongPress();
+    handlers.onTouchCancel(e);
   };
 
   const handleSwipeDeleteClick = () => {
     onRemove(index, { fromSwipe: true });
-    resetSwipe();
+    reset();
   };
 
   useEffect(() => () => cancelLongPress(), []);
@@ -403,11 +307,11 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
     <div
       ref={setNodeRef}
       style={style}
-      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${effectiveSwipeOffset < 0 ? ' swipe-delete-active' : ''}`}
+      className={`form-list-item ${isDragging ? 'dragging' : ''} ${isHeading ? 'heading-item' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
       {canRemove && (
-        <div className="swipe-delete-background" aria-hidden={!isDeleteActionVisible}>
-          {isDeleteActionVisible && (
+        <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
+          {isDeleteVisible && (
             <button
               type="button"
               className="swipe-delete-action"
@@ -434,8 +338,8 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
           onContextMenu={handleContextMenu}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
-          onTouchCancel={resetSwipe}
-          onTouchMove={handleTouchMove}
+          onTouchCancel={handleTouchCancel}
+          onTouchMove={handlers.onTouchMove}
         />
         <button
           type="button"
@@ -521,11 +425,8 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   const formRef = useRef(null);
   // Cancel button press state
   const [cancelPressed, setCancelPressed] = useState(false);
-  const [ingredientDeleteBanners, setIngredientDeleteBanners] = useState([]);
-  const [stepDeleteBanners, setStepDeleteBanners] = useState([]);
-  const ingredientDeleteBannerTimeoutsRef = useRef(new Map());
-  const stepDeleteBannerTimeoutsRef = useRef(new Map());
-  const swipeDeleteBannerCounterRef = useRef(0);
+  const ingredientUndo = useUndoableDelete();
+  const stepUndo = useUndoableDelete();
 
   // Nutrition reference rows for auto-assigning ingredient IDs
   const { rows: nutritionReferenceRows } = useNutritionReference();
@@ -768,27 +669,29 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     setIngredients([...ingredients, { type: 'ingredient', text: '' }]);
   };
 
-  const showTimedDeleteBanner = (setBanners, bannerTimeoutsRef, message) => {
-    const counter = swipeDeleteBannerCounterRef.current;
-    swipeDeleteBannerCounterRef.current = (counter + 1) % 100000;
-    const id = `swipe-delete-${Date.now()}-${counter}`;
-    setBanners((prev) => [...prev, { id, message }]);
-    const timeoutId = setTimeout(() => {
-      setBanners((prev) => prev.filter((banner) => banner.id !== id));
-      bannerTimeoutsRef.current.delete(id);
-    }, DELETE_BANNER_TIMEOUT_MS);
-    bannerTimeoutsRef.current.set(id, timeoutId);
-  };
-
   const handleRemoveIngredient = (index, options = {}) => {
-    if (!ingredients[index]) return;
-    if (ingredients.length > 1) {
+    const removedItem = ingredients[index];
+    if (!removedItem) return;
+    const wasOnlyItem = ingredients.length === 1;
+    if (!wasOnlyItem) {
       setIngredients(ingredients.filter((_, i) => i !== index));
     } else {
       setIngredients([{ type: 'ingredient', text: '' }]);
     }
     if (options.fromSwipe) {
-      showTimedDeleteBanner(setIngredientDeleteBanners, ingredientDeleteBannerTimeoutsRef, 'Zutat gelöscht.');
+      ingredientUndo.scheduleDelete({
+        key: `ingredient-${index}`,
+        message: 'Zutat gelöscht.',
+        onConfirm: () => {},
+        onUndo: () => {
+          setIngredients((current) => {
+            if (wasOnlyItem) return [removedItem];
+            const next = [...current];
+            next.splice(index, 0, removedItem);
+            return next;
+          });
+        },
+      });
     }
   };
 
@@ -834,21 +737,30 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   };
 
   const handleRemoveStep = (index, options = {}) => {
-    if (!steps[index]) return;
-    if (steps.length > 1) {
+    const removedItem = steps[index];
+    if (!removedItem) return;
+    const wasOnlyItem = steps.length === 1;
+    if (!wasOnlyItem) {
       setSteps(steps.filter((_, i) => i !== index));
     } else {
       setSteps([{ type: 'step', text: '' }]);
     }
     if (options.fromSwipe) {
-      showTimedDeleteBanner(setStepDeleteBanners, stepDeleteBannerTimeoutsRef, 'Schritt gelöscht.');
+      stepUndo.scheduleDelete({
+        key: `step-${index}`,
+        message: 'Schritt gelöscht.',
+        onConfirm: () => {},
+        onUndo: () => {
+          setSteps((current) => {
+            if (wasOnlyItem) return [removedItem];
+            const next = [...current];
+            next.splice(index, 0, removedItem);
+            return next;
+          });
+        },
+      });
     }
   };
-
-  useEffect(() => () => {
-    clearBannerTimeouts(ingredientDeleteBannerTimeoutsRef);
-    clearBannerTimeouts(stepDeleteBannerTimeoutsRef);
-  }, []);
 
   const handleStepChange = (index, value) => {
     const newSteps = [...steps];
@@ -1685,9 +1597,12 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
               ))}
             </SortableContext>
           </DndContext>
-          {ingredientDeleteBanners.map((banner) => (
-            <div key={banner.id} className="swipe-undo-banner" role="status">
+          {ingredientUndo.banners.map((banner) => (
+            <div key={banner.id} className="undo-snackbar" role="status">
               <span>{banner.message}</span>
+              <button type="button" className="undo-snackbar-btn" onClick={() => ingredientUndo.undoDelete(banner.id)}>
+                Rückgängig
+              </button>
             </div>
           ))}
           <button
@@ -1748,9 +1663,12 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
               })}
             </SortableContext>
           </DndContext>
-          {stepDeleteBanners.map((banner) => (
-            <div key={banner.id} className="swipe-undo-banner" role="status">
+          {stepUndo.banners.map((banner) => (
+            <div key={banner.id} className="undo-snackbar" role="status">
               <span>{banner.message}</span>
+              <button type="button" className="undo-snackbar-btn" onClick={() => stepUndo.undoDelete(banner.id)}>
+                Rückgängig
+              </button>
             </div>
           ))}
           <button

--- a/src/components/RecipeForm.test.js
+++ b/src/components/RecipeForm.test.js
@@ -2116,7 +2116,7 @@ describe('RecipeForm - Swipe Delete', () => {
     expect(screen.getByPlaceholderText('Zutat 1')).toHaveValue('');
   });
 
-  test('auto-hides delete banners after 10 seconds and allows multiple banners', async () => {
+  test('auto-hides delete banners after 6 seconds (CLAUDE.md undo-snackbar spec) and allows multiple banners', async () => {
     jest.useFakeTimers();
     try {
       render(
@@ -2139,9 +2139,15 @@ describe('RecipeForm - Swipe Delete', () => {
       fireEvent.click(await screen.findByRole('button', { name: 'Zutat löschen' }));
 
       await waitFor(() => expect(screen.getAllByText('Zutat gelöscht.')).toHaveLength(2));
+      expect(screen.getAllByRole('button', { name: 'Rückgängig' })).toHaveLength(2);
 
       act(() => {
-        jest.advanceTimersByTime(10000);
+        jest.advanceTimersByTime(5999);
+      });
+      expect(screen.getAllByText('Zutat gelöscht.')).toHaveLength(2);
+
+      act(() => {
+        jest.advanceTimersByTime(1);
       });
 
       await waitFor(() => {
@@ -2150,6 +2156,31 @@ describe('RecipeForm - Swipe Delete', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  test('clicking "Rückgängig" restores a swipe-deleted ingredient at its original position', async () => {
+    render(
+      <RecipeForm
+        recipe={null}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+        currentUser={regularUser}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Zutat 1'), { target: { value: 'Milch' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Zutat hinzufügen' }));
+    fireEvent.change(screen.getByPlaceholderText('Zutat 2'), { target: { value: 'Mehl' } });
+
+    swipeLeft(screen.getByPlaceholderText('Zutat 1'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Zutat löschen' }));
+
+    expect(screen.queryByDisplayValue('Milch')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rückgängig' }));
+
+    expect(screen.getByPlaceholderText('Zutat 1')).toHaveValue('Milch');
+    expect(screen.getByPlaceholderText('Zutat 2')).toHaveValue('Mehl');
   });
 
   test('uses configurable swipe delete icon from settings', async () => {

--- a/src/hooks/useSwipeToDelete.js
+++ b/src/hooks/useSwipeToDelete.js
@@ -1,0 +1,107 @@
+import { useCallback, useRef, useState } from 'react';
+
+// Shared left-swipe-to-reveal-delete gesture for mobile list rows (events,
+// drinks, guests, recipe ingredients/steps). See CLAUDE.md: mobile uses this
+// gesture in place of the desktop DeleteRowButton.
+export const SWIPE_DELETE_THRESHOLD = 56;
+export const SWIPE_DELETE_MAX_OFFSET = 96;
+export const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
+
+/**
+ * @param {Object} [options]
+ * @param {boolean} [options.disabled] - Disables the gesture entirely (e.g. no permission, predefined item).
+ * @param {boolean} [options.isDeleteVisible] - Pass to control the revealed-delete-button state externally
+ *   (e.g. so only one row in a list has its delete button open at a time). Omit for internal state.
+ * @param {(visible: boolean) => void} [options.onDeleteVisibleChange] - Required when isDeleteVisible is controlled.
+ * @param {(info: {deltaX: number, deltaY: number, absX: number, absY: number, direction: string|null}|null) => void} [options.onMove] -
+ *   Called on every touchmove with the raw gesture delta (or null when the move is ignored), for callers that need
+ *   to react to movement beyond the swipe itself (e.g. cancelling a long-press timer).
+ */
+export default function useSwipeToDelete({
+  disabled = false,
+  isDeleteVisible: controlledVisible,
+  onDeleteVisibleChange,
+  onMove,
+} = {}) {
+  const touchStartXRef = useRef(null);
+  const touchStartYRef = useRef(null);
+  const swipeDirectionLockedRef = useRef(null);
+  const isSwipingRef = useRef(false);
+  const swipeOffsetRef = useRef(0);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [internalVisible, setInternalVisible] = useState(false);
+
+  const isControlled = controlledVisible !== undefined;
+  const isDeleteVisible = isControlled ? controlledVisible : internalVisible;
+  const setIsDeleteVisible = useCallback((value) => {
+    if (isControlled) onDeleteVisibleChange?.(value);
+    else setInternalVisible(value);
+  }, [isControlled, onDeleteVisibleChange]);
+
+  const offset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+
+  const reset = useCallback(({ keepDelete = false } = {}) => {
+    touchStartXRef.current = null;
+    touchStartYRef.current = null;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+    swipeOffsetRef.current = 0;
+    setSwipeOffset(0);
+    if (!keepDelete) setIsDeleteVisible(false);
+  }, [setIsDeleteVisible]);
+
+  const onTouchStart = useCallback((e) => {
+    const touch = e.touches?.[0];
+    if (!touch || disabled) return;
+    setIsDeleteVisible(false);
+    touchStartXRef.current = touch.clientX;
+    touchStartYRef.current = touch.clientY;
+    swipeDirectionLockedRef.current = null;
+    isSwipingRef.current = false;
+  }, [disabled, setIsDeleteVisible]);
+
+  const onTouchMove = useCallback((e) => {
+    const touch = e.touches?.[0];
+    if (!touch || touchStartXRef.current === null || touchStartYRef.current === null || disabled) {
+      onMove?.(null);
+      return;
+    }
+
+    const deltaX = touch.clientX - touchStartXRef.current;
+    const deltaY = touch.clientY - touchStartYRef.current;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    if (!swipeDirectionLockedRef.current && (absX > SWIPE_DIRECTION_LOCK_THRESHOLD || absY > SWIPE_DIRECTION_LOCK_THRESHOLD)) {
+      swipeDirectionLockedRef.current = absX > absY ? 'horizontal' : 'vertical';
+    }
+    const direction = swipeDirectionLockedRef.current;
+
+    if (direction === 'horizontal' && deltaX < 0) {
+      isSwipingRef.current = true;
+      const clamped = Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET);
+      swipeOffsetRef.current = clamped;
+      setSwipeOffset(clamped);
+      if (e.cancelable) e.preventDefault();
+    }
+    onMove?.({ deltaX, deltaY, absX, absY, direction });
+  }, [disabled, onMove]);
+
+  const onTouchEnd = useCallback(() => {
+    if (isSwipingRef.current && Math.abs(swipeOffsetRef.current) >= SWIPE_DELETE_THRESHOLD) {
+      setIsDeleteVisible(true);
+      reset({ keepDelete: true });
+      return;
+    }
+    reset();
+  }, [reset, setIsDeleteVisible]);
+
+  const onTouchCancel = useCallback(() => reset(), [reset]);
+
+  return {
+    offset,
+    isDeleteVisible,
+    reset,
+    handlers: { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel },
+  };
+}

--- a/src/hooks/useUndoableDelete.js
+++ b/src/hooks/useUndoableDelete.js
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+// Shared "Löschen wirkt sofort + Snackbar 'Rückgängig'" behavior (see CLAUDE.md),
+// used by every swipe-to-delete row in the app. The item disappears from view the
+// moment the gesture completes; the actual mutation (a Firestore delete, or nothing
+// at all for a purely local list) only runs once the undo window has passed without
+// being cancelled.
+const UNDO_TIMEOUT_MS = 6000;
+
+/**
+ * @param {number} [timeoutMs] - How long the "Rückgängig" snackbar stays up.
+ * @returns {{
+ *   banners: Array<{id: number, key: string, message: string}>,
+ *   pendingKeys: Set<string>,
+ *   scheduleDelete: (opts: { key: string, message: string, onConfirm: () => void, onUndo: () => void }) => void,
+ *   undoDelete: (id: number) => void,
+ * }}
+ */
+export default function useUndoableDelete(timeoutMs = UNDO_TIMEOUT_MS) {
+  const [banners, setBanners] = useState([]);
+  const entriesRef = useRef(new Map()); // id -> { key, timeoutId, onUndo }
+  const counterRef = useRef(0);
+
+  useEffect(() => {
+    const entries = entriesRef.current;
+    return () => {
+      entries.forEach(({ timeoutId }) => clearTimeout(timeoutId));
+      entries.clear();
+    };
+  }, []);
+
+  const scheduleDelete = useCallback(({ key, message, onConfirm, onUndo }) => {
+    const id = counterRef.current;
+    counterRef.current = (id + 1) % 100000;
+    const timeoutId = setTimeout(() => {
+      entriesRef.current.delete(id);
+      setBanners((prev) => prev.filter((banner) => banner.id !== id));
+      onConfirm();
+    }, timeoutMs);
+    entriesRef.current.set(id, { key, timeoutId, onUndo });
+    setBanners((prev) => [...prev, { id, key, message }]);
+  }, [timeoutMs]);
+
+  const undoDelete = useCallback((id) => {
+    const entry = entriesRef.current.get(id);
+    if (!entry) return;
+    clearTimeout(entry.timeoutId);
+    entriesRef.current.delete(id);
+    setBanners((prev) => prev.filter((banner) => banner.id !== id));
+    entry.onUndo();
+  }, []);
+
+  const pendingKeys = useMemo(() => new Set(banners.map((banner) => banner.key)), [banners]);
+
+  return { banners, pendingKeys, scheduleDelete, undoDelete };
+}


### PR DESCRIPTION
## Summary
Refactors the swipe-to-delete gesture and undo-snackbar behavior into two reusable custom hooks (`useSwipeToDelete` and `useUndoableDelete`) to eliminate code duplication across multiple components. This change consolidates the mobile delete interaction pattern used in RecipeForm, GuestManagementPage, DrinkManagementPage, EventsPage, EventGuestSelectionPage, and EventDrinkSelectionPage.

## Key Changes

- **New hook: `useSwipeToDelete`**
  - Encapsulates all touch event handling for the left-swipe-to-reveal-delete gesture
  - Exports shared constants (`SWIPE_DELETE_THRESHOLD`, `SWIPE_DELETE_MAX_OFFSET`, `SWIPE_DIRECTION_LOCK_THRESHOLD`)
  - Supports both internal and externally-controlled delete visibility state (for single-open-at-a-time list behavior)
  - Provides `offset`, `isDeleteVisible`, `reset()`, and `handlers` (touch event callbacks)
  - Includes optional `onMove` callback for coordinating with other interactions (e.g., cancelling long-press timers)

- **New hook: `useUndoableDelete`**
  - Manages the undo-snackbar lifecycle per CLAUDE.md spec (6-second timeout, "Rückgängig" button)
  - Tracks pending deletions and schedules actual mutations only after the undo window expires
  - Returns `banners` array, `pendingKeys` set, and `scheduleDelete`/`undoDelete` methods
  - Automatically cleans up timeouts on unmount

- **Updated components**
  - RecipeForm: Removed ~150 lines of swipe/undo logic from `SortableIngredient` and `SortableStep`; now uses hooks
  - GuestManagementPage: Simplified `GuestCard` swipe handling; integrated undo-snackbar
  - DrinkManagementPage: Removed duplicate swipe logic from `DrinkRow`; added undo-snackbar
  - EventsPage: Removed duplicate swipe logic from `EventCard`; added undo-snackbar
  - EventGuestSelectionPage: Simplified `GuestRow` swipe handling
  - EventDrinkSelectionPage: Simplified `DrinkRow` swipe handling

- **CSS updates**
  - Unified `.swipe-undo-banner` and `.drink-delete-banner` into single `.undo-snackbar` class
  - Added `.undo-snackbar-btn` for the "Rückgängig" button styling
  - Updated layout to `justify-content: space-between` for proper button alignment

- **Test updates**
  - Updated GuestManagementPage, EventsPage, DrinkManagementPage, and RecipeForm tests to verify undo behavior
  - Tests now confirm items hide immediately and deletion only occurs after timeout (or is cancelled via "Rückgängig")
  - Adjusted timeout expectations from 10s to 6s per spec

## Implementation Details

- The hooks follow React best practices: memoized callbacks, proper cleanup, and support for both controlled and uncontrolled state patterns
- Touch event handlers are bundled in a `handlers` object for easy spread onto DOM elements
- The `onMove` callback in `useSwipeToDelete` allows components like RecipeForm to cancel long-press timers when a swipe is detected
- Undo snackbars are rendered at the page level (e.g., in EventsPage, DrinkManagementPage) to avoid duplication and ensure consistent UX

https://claude.ai/code/session_01HUR1fU71ViEHLvHC8c5eHp