### PR TITLE
Remove brown row tint on hover for drink/guest row headers

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1842,6 +1842,17 @@
   gap: 12px;
 }
 
+/* These row headers opt out of the shared row tint from DeleteRowButton.css —
+   only the delete button itself should react when the row is hovered/focused. */
+.events-drink-row-header.delete-row-hover-target:hover,
+.events-drink-row-header.delete-row-hover-target:focus-within,
+.events-guest-row-header.delete-row-hover-target:hover,
+.events-guest-row-header.delete-row-hover-target:focus-within,
+.drink-list-item-header.delete-row-hover-target:hover,
+.drink-list-item-header.delete-row-hover-target:focus-within {
+  background: transparent;
+}
+
 .drink-list-item.swipe-delete-active .drink-swipe-delete-background {
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
The shared .delete-row-hover-target:hover rule in DeleteRowButton.css
tints the whole row on hover/focus. Opt out of that tint for the
event drink rows, event guest rows, and drink list rows so only the
delete button itself reacts, per the request to drop the light-brown
background on these rows.