### PR TITLE
Add swipe-to-delete gesture for menu items on mobile

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -480,20 +480,52 @@
 }
 
 .selected-recipe-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.selected-recipe-item-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 0.75rem;
   background: #f9f6f3;
   border-radius: 6px;
-  margin-bottom: 0.5rem;
   gap: 0.5rem;
+  position: relative;
+  z-index: 1;
 }
 
-.selected-recipe-item.dragging {
+.selected-recipe-item.dragging .selected-recipe-item-content {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   background: #fff;
   border: 1px solid #402C1C;
+}
+
+/* Mobile: the delete button is only revealed via the left-swipe gesture
+   (useSwipeToDelete), mirroring the swipe-to-delete used elsewhere (e.g.
+   EventsPage's guest/drink rows). Compounded with .delete-row-button so this
+   wins regardless of CSS import order between this file and
+   DeleteRowButton.css. See CLAUDE.md: DeleteRowButton spec is desktop-only. */
+.selected-recipe-item.swipe-delete-active .swipe-delete-background {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 768px) {
+  .delete-row-button.selected-recipe-item-delete-btn {
+    display: none;
+  }
+}
+
+/* Desktop: no touch swipe, so the static delete button stays visible and
+   the swipe reveal background never engages. */
+@media (min-width: 769px) {
+  .selected-recipe-item .swipe-delete-background {
+    display: none;
+  }
 }
 
 .menu-form-container .drag-handle {

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -17,6 +17,7 @@ import DrinkManagementPage from './DrinkManagementPage';
 import DeleteRowButton from './DeleteRowButton';
 import UndoSnackbar from './UndoSnackbar';
 import useUndoableDelete from '../hooks/useUndoableDelete';
+import useSwipeToDelete from '../hooks/useSwipeToDelete';
 import {
   DndContext,
   closestCenter,
@@ -89,7 +90,7 @@ function SortableSection({
   isDrinksSection, drinkSearchQueries, onDrinkSearchChange, onAddDrinkToSection,
   onAddRecipeToDrinksSection, onRemoveDrinkFromSection, getFilteredDrinkSectionOptions,
   getDrinkDisplayName, eventDrinks = [], onRemoveEventDrink, onDragEndDrinks,
-  showOwnDrinksOnly, onToggleShowOwnDrinksOnly,
+  showOwnDrinksOnly, onToggleShowOwnDrinksOnly, swipeDeleteIcon,
 }) {
   const {
     attributes,
@@ -162,6 +163,7 @@ function SortableSection({
               isFavorite={isFavorite}
               sectionIndex={sectionIndex}
               onRemove={onRemoveRecipeFromSection}
+              swipeDeleteIcon={swipeDeleteIcon}
             />
           );
         })}
@@ -223,6 +225,7 @@ function SortableSection({
                           else if (item.type === 'event') onRemoveEventDrink(item.id, item.displayName);
                           else onRemoveDrinkFromSection(sectionIndex, item.id, item.displayName);
                         }}
+                        swipeDeleteIcon={swipeDeleteIcon}
                       />
                     ))}
                   </SortableContext>
@@ -350,7 +353,7 @@ function SortableSection({
 }
 
 // Sortable Recipe Item Component for menu sections
-function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) {
+function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex, swipeDeleteIcon }) {
   const {
     attributes,
     listeners,
@@ -360,35 +363,65 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) 
     isDragging,
   } = useSortable({ id });
 
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
+  };
+  const swipeContentStyle = {
+    transform: `translateX(${offset}px)`,
+    transition: isDragging ? transition : 'transform 0.15s ease',
+  };
+
+  const handleSwipeDeleteClick = () => {
+    onRemove(sectionIndex, recipe.id, recipe.title);
+    reset();
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={`selected-recipe-item delete-row-hover-target ${isDragging ? 'dragging' : ''}`}
+      className={`selected-recipe-item ${isDragging ? 'dragging' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
-      <button
-        type="button"
-        className="drag-handle"
-        {...attributes}
-        {...listeners}
-        aria-label="Rezept verschieben"
-      >
-        ⋮⋮
-      </button>
-      <span className="recipe-name">
-        {recipe.title}
-        {isFavorite && <span className="favorite-indicator">★</span>}
-      </span>
-      <DeleteRowButton
-        itemName={recipe.title}
-        onClick={() => onRemove(sectionIndex, recipe.id, recipe.title)}
-      />
+      <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
+        {isDeleteVisible && (
+          <button
+            type="button"
+            className="swipe-delete-action"
+            onClick={handleSwipeDeleteClick}
+            aria-label={`${recipe.title} entfernen`}
+          >
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
+          </button>
+        )}
+      </div>
+      <div className="selected-recipe-item-content delete-row-hover-target" style={swipeContentStyle}>
+        <button
+          type="button"
+          className="drag-handle"
+          {...attributes}
+          {...listeners}
+          aria-label="Rezept verschieben"
+        >
+          ⋮⋮
+        </button>
+        <span className="recipe-name" {...handlers}>
+          {recipe.title}
+          {isFavorite && <span className="favorite-indicator">★</span>}
+        </span>
+        <DeleteRowButton
+          itemName={recipe.title}
+          className="selected-recipe-item-delete-btn"
+          onClick={() => onRemove(sectionIndex, recipe.id, recipe.title)}
+        />
+      </div>
     </div>
   );
 }
@@ -396,7 +429,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex }) 
 // Sortable item for the menu's "Drinks" section, which mixes drink recipes,
 // event-linked drinks, and manually added drinks in a single freely
 // reorderable list (see getDrinksSectionItems).
-function SortableDrinkItem({ id, displayName, isFavorite, onRemove }) {
+function SortableDrinkItem({ id, displayName, isFavorite, onRemove, swipeDeleteIcon }) {
   const {
     attributes,
     listeners,
@@ -406,32 +439,65 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove }) {
     isDragging,
   } = useSortable({ id });
 
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
+  };
+  const swipeContentStyle = {
+    transform: `translateX(${offset}px)`,
+    transition: isDragging ? transition : 'transform 0.15s ease',
+  };
+
+  const handleSwipeDeleteClick = () => {
+    onRemove();
+    reset();
   };
 
   return (
     <div
       ref={setNodeRef}
       style={style}
-      className={`selected-recipe-item delete-row-hover-target ${isDragging ? 'dragging' : ''}`}
+      className={`selected-recipe-item ${isDragging ? 'dragging' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
-      <button
-        type="button"
-        className="drag-handle"
-        {...attributes}
-        {...listeners}
-        aria-label="Eintrag verschieben"
-      >
-        ⋮⋮
-      </button>
-      <span className="recipe-name">
-        {displayName}
-        {isFavorite && <span className="favorite-indicator">★</span>}
-      </span>
-      <DeleteRowButton itemName={displayName} onClick={onRemove} />
+      <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
+        {isDeleteVisible && (
+          <button
+            type="button"
+            className="swipe-delete-action"
+            onClick={handleSwipeDeleteClick}
+            aria-label={`${displayName} entfernen`}
+          >
+            {isBase64Image(swipeDeleteIcon) ? (
+              <img src={swipeDeleteIcon} alt="" className="swipe-delete-icon-image" draggable="false" />
+            ) : (
+              <span className="swipe-delete-icon-text">{swipeDeleteIcon || '🗑'}</span>
+            )}
+          </button>
+        )}
+      </div>
+      <div className="selected-recipe-item-content delete-row-hover-target" style={swipeContentStyle}>
+        <button
+          type="button"
+          className="drag-handle"
+          {...attributes}
+          {...listeners}
+          aria-label="Eintrag verschieben"
+        >
+          ⋮⋮
+        </button>
+        <span className="recipe-name" {...handlers}>
+          {displayName}
+          {isFavorite && <span className="favorite-indicator">★</span>}
+        </span>
+        <DeleteRowButton
+          itemName={displayName}
+          className="selected-recipe-item-delete-btn"
+          onClick={onRemove}
+        />
+      </div>
     </div>
   );
 }
@@ -1692,6 +1758,7 @@ function MenuForm({ menu, recipes, onSave, onCancel, currentUser }) {
                   favoriteIds={favoriteIds}
                   searchQueries={searchQueries}
                   closeIcon={getEffectiveIcon(buttonIcons, 'closeButtonDefaultImg', isDarkMode) || getEffectiveIcon(buttonIcons, 'closeButton', isDarkMode)}
+                  swipeDeleteIcon={getEffectiveIcon(buttonIcons, 'swipeDelete', isDarkMode) || '🗑'}
                   onRemoveSection={handleRemoveSection}
                   onDragEndRecipes={handleDragEndRecipes}
                   onRemoveRecipeFromSection={handleRemoveRecipeFromSection}


### PR DESCRIPTION
## Summary
Implements swipe-to-delete functionality for recipe and drink items in menu sections on mobile devices, while maintaining the existing hover-based delete button on desktop. This aligns with the project's mobile interaction patterns used elsewhere (e.g., EventsPage).

## Key Changes
- **New hook integration**: Added `useSwipeToDelete` hook to `SortableRecipeItem` and `SortableDrinkItem` components to handle left-swipe gesture detection and state management
- **Component updates**: 
  - Modified `SortableRecipeItem` and `SortableDrinkItem` to accept `swipeDeleteIcon` prop
  - Restructured item markup to include a hidden delete background layer that reveals on swipe
  - Applied swipe offset transform to content wrapper for smooth drag animation
- **Icon support**: Added `swipeDeleteIcon` prop threading through `SortableSection` and `MenuForm` to support custom delete icons (image or emoji)
- **Responsive styling**:
  - Mobile (≤768px): Delete button hidden, swipe-to-delete background visible
  - Desktop (>769px): Traditional delete button visible, swipe background hidden
  - Added `.swipe-delete-active` state class for visual feedback during swipe
- **Accessibility**: Maintained aria-labels and proper button semantics for both interaction modes

## Implementation Details
- Swipe gesture is handled by `useSwipeToDelete()` which provides `offset`, `isDeleteVisible`, `reset()`, and `handlers` for the swipeable element
- Delete action triggers the same `onRemove` callback as the desktop button, ensuring consistent behavior
- Smooth transitions between swipe states with conditional transition timing (disabled during drag to prevent conflicts)
- Icon rendering supports both base64 image data and text/emoji fallback

https://claude.ai/code/session_01VY6zBiBXUtMvCAhqKXXYmA