### PR TITLE
Allow users to add custom units to drinks owned by others

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -186,6 +186,12 @@ service cloud.firestore {
     // Readable by any recognised user – drinks are a shared library visible to
     // everyone. Owners may create/update/delete their own entries; admins may
     // additionally edit/delete any user's entries.
+    //
+    // A doc carrying `extendsOwnerId` is not a standalone drink but another
+    // user's own "additional units" contribution to the drink owned by
+    // `extendsOwnerId` with the same `drinkId` (see mergeDrinkUnitAdditions
+    // in src/utils/drinkCategories.js). It still lives under its
+    // contributor's own path, so this rule already covers it without change.
     match /users/{userId}/customDrinks/{drinkId} {
       allow read: if isAnyUser();
       allow write: if isAuthenticated() && (request.auth.uid == userId || isAdmin());

--- a/src/components/DrinkManagementPage.js
+++ b/src/components/DrinkManagementPage.js
@@ -7,7 +7,6 @@ import useUndoableDelete from '../hooks/useUndoableDelete';
 import RecipeTypeahead from './RecipeTypeahead';
 import { DRINK_CATEGORIES, getDrinkCategoryLabel, mergePredefinedDrinks } from '../utils/drinkCategories';
 import { getCustomLists, DEFAULT_BUTTON_ICONS, getEffectiveIcon, getDarkModePreference } from '../utils/customLists';
-import { getUsers } from '../utils/userManagement';
 import { isBase64Image } from '../utils/imageUtils';
 import { encodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
 import { resolveDrinkDisplay } from '../utils/drinkDisplay';
@@ -91,8 +90,13 @@ const emptyForm = () => ({
   einheiten: [emptyEinheit()],
 });
 
-function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, swipeDeleteIcon }) {
+function DrinkRow({ drink, displayName, isForeign, canManage, canAddUnits, onEdit, onAddUnits, onDelete, swipeDeleteIcon }) {
   const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ disabled: drink.predefined || !canManage });
+  const isClickable = canManage || canAddUnits;
+  const handleRowClick = () => {
+    if (canManage) onEdit(drink);
+    else if (canAddUnits) onAddUnits(drink);
+  };
 
   return (
     <div
@@ -120,11 +124,11 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
       <div
         className="drink-swipe-content events-card-main"
         style={{ transform: `translateX(${offset}px)`, padding: '16px 20px', width: '100%' }}
-        onClick={offset < 0 || !canManage ? undefined : () => onEdit(drink)}
+        onClick={offset < 0 || !isClickable ? undefined : handleRowClick}
         {...handlers}
       >
         <div className="drink-list-item-header delete-row-hover-target">
-          <h3>{displayName}</h3>
+          <h3 className={isForeign ? 'drink-list-item-title--foreign' : undefined}>{displayName}</h3>
           {!drink.predefined && canManage && (
             <DeleteRowButton
               itemName={displayName}
@@ -144,7 +148,6 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
                   .map((e) => getUnitSizeLabel(e.einheitsgroesse) || String(e.einheitsgroesse))
                   .join(', ')
               : null,
-            ownerName ? `von ${ownerName}` : null,
           ].filter(Boolean).join(' · ')}
         </p>
       </div>
@@ -154,12 +157,13 @@ function DrinkRow({ drink, displayName, ownerName, canManage, onEdit, onDelete, 
 
 function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const [drinks, setDrinks] = useState([]);
-  const [allUsers, setAllUsers] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editId, setEditId] = useState(null);
   const [editOwnerId, setEditOwnerId] = useState(null);
   const [isPredefined, setIsPredefined] = useState(false);
+  const [isAddUnitsMode, setIsAddUnitsMode] = useState(false);
+  const [addUnitsDrink, setAddUnitsDrink] = useState(null);
   const isAdmin = currentUser?.isAdmin === true;
   const [form, setForm] = useState(emptyForm());
   const [saving, setSaving] = useState(false);
@@ -195,10 +199,6 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   }, []);
 
   useEffect(() => {
-    getUsers().then(setAllUsers).catch(() => setAllUsers([]));
-  }, []);
-
-  useEffect(() => {
     const unsubscribe = subscribeToAllCustomDrinks((loaded) => {
       setDrinks(loaded);
       setLoading(false);
@@ -217,10 +217,6 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     return merged.filter((drink) => !drink.ownerId || drink.ownerId === currentUser?.id);
   }, [drinks, currentUser?.id, showOwnOnly, pendingDeleteKeys]);
   const groupedDrinks = useMemo(() => groupDrinksByCategory(allDrinks, recipes), [allDrinks, recipes]);
-  const getOwnerFirstName = (ownerId) => {
-    if (!ownerId) return null;
-    return allUsers.find((u) => u.id === ownerId)?.vorname || null;
-  };
 
   const nameDrinkDisplay = resolveDrinkDisplay(form.name, recipes);
 
@@ -228,6 +224,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     setEditId(null);
     setEditOwnerId(null);
     setIsPredefined(false);
+    setIsAddUnitsMode(false);
+    setAddUnitsDrink(null);
     setForm(emptyForm());
     setError('');
     setShowNameTypeahead(false);
@@ -238,6 +236,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     setEditId(drink.id);
     setEditOwnerId(drink.ownerId || null);
     setIsPredefined(Boolean(drink.predefined));
+    setIsAddUnitsMode(false);
+    setAddUnitsDrink(null);
     setForm({
       name: drink.name || '',
       kategorie: drink.kategorie || '',
@@ -250,6 +250,34 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
               einheitenProGebinde: e.einheitenProGebinde ?? '',
             }))
           : [emptyEinheit()],
+    });
+    setError('');
+    setShowNameTypeahead(false);
+    setShowForm(true);
+  };
+
+  // Drinks owned by another user can't be edited directly (Firestore only
+  // lets the owner/an admin write their document); instead, the current
+  // user maintains their own additional Einheiten alongside the owner's,
+  // stored under their own account and merged in wherever the drink is used.
+  const openAddUnits = (drink) => {
+    setEditId(drink.id);
+    setEditOwnerId(drink.ownerId || null);
+    setIsPredefined(false);
+    setIsAddUnitsMode(true);
+    setAddUnitsDrink(drink);
+    const ownEinheiten = (Array.isArray(drink.einheiten) ? drink.einheiten : [])
+      .filter((e) => e.addedByUserId === currentUser?.id)
+      .map((e) => ({
+        einheitsgroesse: e.einheitsgroesse ?? 0.5,
+        einheit: e.einheit || '',
+        gebindeinheit: e.gebindeinheit || '',
+        einheitenProGebinde: e.einheitenProGebinde ?? '',
+      }));
+    setForm({
+      name: drink.name || '',
+      kategorie: drink.kategorie || '',
+      einheiten: ownEinheiten.length > 0 ? ownEinheiten : [emptyEinheit()],
     });
     setError('');
     setShowNameTypeahead(false);
@@ -273,6 +301,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
   const closeForm = () => {
     setShowNameTypeahead(false);
     setShowForm(false);
+    setIsAddUnitsMode(false);
+    setAddUnitsDrink(null);
   };
 
   const addEinheit = () => {
@@ -307,8 +337,45 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     }
   };
 
+  const buildEinheitenPayload = () => form.einheiten.map((e) => {
+    const einheit = { einheitsgroesse: Number(e.einheitsgroesse) };
+    const einheitTrimmed = String(e.einheit || '').trim();
+    if (einheitTrimmed) einheit.einheit = einheitTrimmed;
+    const gebindeinheitTrimmed = String(e.gebindeinheit || '').trim();
+    if (gebindeinheitTrimmed) einheit.gebindeinheit = gebindeinheitTrimmed;
+    if (e.einheitenProGebinde !== '' && e.einheitenProGebinde !== null && e.einheitenProGebinde !== undefined) {
+      einheit.einheitenProGebinde = Number(e.einheitenProGebinde);
+    }
+    return einheit;
+  });
+
+  const handleSaveUnitAddition = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const einheiten = buildEinheitenPayload().filter((e) => e.einheitsgroesse);
+      if (einheiten.length === 0) {
+        await deleteCustomDrink(currentUser.id, editId);
+      } else {
+        await saveCustomDrink(currentUser.id, { einheiten, extendsOwnerId: editOwnerId }, editId);
+      }
+      setShowForm(false);
+      setIsAddUnitsMode(false);
+      setAddUnitsDrink(null);
+    } catch (err) {
+      console.error('Error saving drink unit addition:', err);
+      setError('Die zusätzlichen Einheiten konnten nicht gespeichert werden. Bitte versuche es erneut.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const handleSave = async (e) => {
     e.preventDefault();
+    if (isAddUnitsMode) {
+      await handleSaveUnitAddition();
+      return;
+    }
     if (!isPredefined && !form.name.trim()) {
       setError('Bitte einen Namen angeben.');
       return;
@@ -328,17 +395,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     try {
       const payload = {
         ...(isPredefined ? {} : { name: form.name.trim(), kategorie: form.kategorie || null }),
-        einheiten: form.einheiten.map((e) => {
-          const einheit = { einheitsgroesse: Number(e.einheitsgroesse) };
-          const einheitTrimmed = String(e.einheit || '').trim();
-          if (einheitTrimmed) einheit.einheit = einheitTrimmed;
-          const gebindeinheitTrimmed = String(e.gebindeinheit || '').trim();
-          if (gebindeinheitTrimmed) einheit.gebindeinheit = gebindeinheitTrimmed;
-          if (e.einheitenProGebinde !== '' && e.einheitenProGebinde !== null && e.einheitenProGebinde !== undefined) {
-            einheit.einheitenProGebinde = Number(e.einheitenProGebinde);
-          }
-          return einheit;
-        }),
+        einheiten: buildEinheitenPayload(),
       };
       const targetOwnerId = editId ? (editOwnerId || currentUser.id) : currentUser.id;
       if (isPredefined) {
@@ -381,62 +438,91 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
     return (
       <div className="events-page-container">
         <div className="events-page-header">
-          <h2>{editId ? 'Getränk bearbeiten' : 'Neues Getränk'}</h2>
+          <h2>{isAddUnitsMode ? 'Zusätzliche Einheiten' : editId ? 'Getränk bearbeiten' : 'Neues Getränk'}</h2>
         </div>
         <form className="events-form" onSubmit={handleSave} ref={formRef}>
-          <label className="events-form-field">
-            <span>Name</span>
-            <div className="events-name-input-wrapper">
-              <input
-                type="text"
-                value={nameDrinkDisplay.isRecipe ? nameDrinkDisplay.displayName : form.name}
-                onChange={(e) => handleNameChange(e.target.value)}
-                placeholder="z. B. Craft-Bier, Apfelsaft, ... (# verlinkt ein Rezept)"
-                required={!isPredefined}
-                disabled={isPredefined}
-                readOnly={nameDrinkDisplay.isRecipe}
-                className={nameDrinkDisplay.isRecipe ? 'recipe-link-input' : ''}
-                title={nameDrinkDisplay.isRecipe ? `Verlinktes Rezept: ${nameDrinkDisplay.displayName}` : undefined}
-              />
-              {nameDrinkDisplay.isRecipe && !isPredefined && (
-                <button
-                  type="button"
-                  className="events-name-link-clear-btn"
-                  onClick={handleClearNameLink}
-                  aria-label="Verknüpfung entfernen"
-                  title="Verknüpfung entfernen"
+          {isAddUnitsMode ? (
+            <div className="events-form-field">
+              <span>Getränk</span>
+              <p className="drink-add-units-name">{resolveDrinkDisplay(addUnitsDrink, recipes).displayName}</p>
+            </div>
+          ) : (
+            <>
+              <label className="events-form-field">
+                <span>Name</span>
+                <div className="events-name-input-wrapper">
+                  <input
+                    type="text"
+                    value={nameDrinkDisplay.isRecipe ? nameDrinkDisplay.displayName : form.name}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    placeholder="z. B. Craft-Bier, Apfelsaft, ... (# verlinkt ein Rezept)"
+                    required={!isPredefined}
+                    disabled={isPredefined}
+                    readOnly={nameDrinkDisplay.isRecipe}
+                    className={nameDrinkDisplay.isRecipe ? 'recipe-link-input' : ''}
+                    title={nameDrinkDisplay.isRecipe ? `Verlinktes Rezept: ${nameDrinkDisplay.displayName}` : undefined}
+                  />
+                  {nameDrinkDisplay.isRecipe && !isPredefined && (
+                    <button
+                      type="button"
+                      className="events-name-link-clear-btn"
+                      onClick={handleClearNameLink}
+                      aria-label="Verknüpfung entfernen"
+                      title="Verknüpfung entfernen"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              </label>
+
+              <label className="events-form-field">
+                <span>Getränkekategorie</span>
+                <select
+                  value={form.kategorie}
+                  onChange={(e) => setForm((f) => ({ ...f, kategorie: e.target.value }))}
+                  disabled={isPredefined}
                 >
-                  ×
-                </button>
+                  <option value="">Keine Kategorie</option>
+                  {DRINK_CATEGORIES.map((cat) =>
+                    cat.subcategories ? (
+                      <optgroup key={cat.id} label={cat.label}>
+                        <option value={cat.id}>{cat.label}</option>
+                        {cat.subcategories.map((sub) => (
+                          <option key={sub.id} value={sub.id}>{sub.label}</option>
+                        ))}
+                      </optgroup>
+                    ) : (
+                      <option key={cat.id} value={cat.id}>{cat.label}</option>
+                    )
+                  )}
+                </select>
+              </label>
+            </>
+          )}
+
+          {isAddUnitsMode && (
+            <div className="events-form-field">
+              <span>Vorhandene Einheiten</span>
+              {(Array.isArray(addUnitsDrink?.einheiten) ? addUnitsDrink.einheiten : [])
+                .filter((e) => e.addedByUserId !== currentUser?.id).length > 0 ? (
+                <ul className="drink-existing-einheiten-list">
+                  {addUnitsDrink.einheiten
+                    .filter((e) => e.addedByUserId !== currentUser?.id)
+                    .map((e, idx) => (
+                      <li key={idx}>
+                        {[getUnitSizeLabel(e.einheitsgroesse) || String(e.einheitsgroesse), e.einheit].filter(Boolean).join(' ')}
+                      </li>
+                    ))}
+                </ul>
+              ) : (
+                <p className="events-info-text">Noch keine Einheiten vorhanden.</p>
               )}
             </div>
-          </label>
-
-          <label className="events-form-field">
-            <span>Getränkekategorie</span>
-            <select
-              value={form.kategorie}
-              onChange={(e) => setForm((f) => ({ ...f, kategorie: e.target.value }))}
-              disabled={isPredefined}
-            >
-              <option value="">Keine Kategorie</option>
-              {DRINK_CATEGORIES.map((cat) =>
-                cat.subcategories ? (
-                  <optgroup key={cat.id} label={cat.label}>
-                    <option value={cat.id}>{cat.label}</option>
-                    {cat.subcategories.map((sub) => (
-                      <option key={sub.id} value={sub.id}>{sub.label}</option>
-                    ))}
-                  </optgroup>
-                ) : (
-                  <option key={cat.id} value={cat.id}>{cat.label}</option>
-                )
-              )}
-            </select>
-          </label>
+          )}
 
           <div className="events-form-field">
-            <span>Einheiten</span>
+            <span>{isAddUnitsMode ? 'Meine zusätzlichen Einheiten' : 'Einheiten'}</span>
             {form.einheiten.map((einheit, idx) => (
               <div key={idx} className="events-einheit-group">
                 <div className="events-form-row events-einheit-row">
@@ -523,7 +609,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
                       />
                     )}
                   </label>
-                  {form.einheiten.length > 1 && (
+                  {(form.einheiten.length > 1 || isAddUnitsMode) && (
                     <button
                       type="button"
                       className="events-secondary-btn"
@@ -545,7 +631,7 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
             </button>
           </div>
 
-          {nameDrinkDisplay.isRecipe && nameDrinkDisplay.recipe && (
+          {!isAddUnitsMode && nameDrinkDisplay.isRecipe && nameDrinkDisplay.recipe && (
             <div className="events-form-field">
               <span>Zutaten von „{nameDrinkDisplay.displayName}"</span>
               <ul className="drink-recipe-ingredient-list">
@@ -614,8 +700,8 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
           onTouchStart={() => setFabPressed(true)}
           onTouchEnd={() => setFabPressed(false)}
           disabled={saving}
-          aria-label={editId ? 'Getränk aktualisieren' : 'Getränk speichern'}
-          title={editId ? 'Getränk aktualisieren' : 'Getränk speichern'}
+          aria-label={isAddUnitsMode ? 'Einheiten speichern' : editId ? 'Getränk aktualisieren' : 'Getränk speichern'}
+          title={isAddUnitsMode ? 'Einheiten speichern' : editId ? 'Getränk aktualisieren' : 'Getränk speichern'}
         >
           {isBase64Image(getEffectiveIcon(buttonIcons, 'saveRecipe', isDarkMode)) ? (
             <img src={getEffectiveIcon(buttonIcons, 'saveRecipe', isDarkMode)} alt="Speichern" className="button-icon-image" draggable="false" />
@@ -712,18 +798,25 @@ function DrinkManagementPage({ onBack, currentUser, recipes }) {
           {groupedDrinks.map((group) => (
             <div key={group.id} className="drink-category-group">
               <h3 className="drink-category-group-header">{group.label}</h3>
-              {group.drinks.map((drink) => (
-                <DrinkRow
-                  key={`${drink.ownerId || ''}_${drink.id}`}
-                  drink={drink}
-                  displayName={resolveDrinkDisplay(drink, recipes).displayName}
-                  ownerName={drink.ownerId && drink.ownerId !== currentUser?.id ? getOwnerFirstName(drink.ownerId) : null}
-                  canManage={drink.predefined || !drink.ownerId || drink.ownerId === currentUser?.id || isAdmin}
-                  onEdit={openEdit}
-                  onDelete={handleDelete}
-                  swipeDeleteIcon={swipeDeleteIcon}
-                />
-              ))}
+              {group.drinks.map((drink) => {
+                const isForeign = Boolean(drink.ownerId) && drink.ownerId !== currentUser?.id;
+                const canManage = drink.predefined || !isForeign || isAdmin;
+                const canAddUnits = isForeign && !isAdmin;
+                return (
+                  <DrinkRow
+                    key={`${drink.ownerId || ''}_${drink.id}`}
+                    drink={drink}
+                    displayName={resolveDrinkDisplay(drink, recipes).displayName}
+                    isForeign={isForeign}
+                    canManage={canManage}
+                    canAddUnits={canAddUnits}
+                    onEdit={openEdit}
+                    onAddUnits={openAddUnits}
+                    onDelete={handleDelete}
+                    swipeDeleteIcon={swipeDeleteIcon}
+                  />
+                );
+              })}
             </div>
           ))}
           {drinks.length === 0 && (

--- a/src/components/DrinkManagementPage.test.js
+++ b/src/components/DrinkManagementPage.test.js
@@ -835,9 +835,12 @@ describe('DrinkManagementPage', () => {
       expect(screen.getByRole('heading', { level: 2, name: 'Getränk bearbeiten' })).toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
 
-      // Someone else's drink is not clickable into the edit form.
+      // Someone else's drink is not clickable into the full edit form – it
+      // opens the "add my own units" form instead.
       fireEvent.click(screen.getByText('Papas Wein'));
       expect(screen.queryByRole('heading', { level: 2, name: 'Getränk bearbeiten' })).not.toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 2, name: 'Zusätzliche Einheiten' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Abbrechen' }));
 
       // Someone else's drink can't be swiped open for deletion either.
       const othersDrinkContent = screen.getByText('Papas Wein').closest('.drink-swipe-content');
@@ -853,6 +856,64 @@ describe('DrinkManagementPage', () => {
       render(<DrinkManagementPage currentUser={currentUser} />);
 
       expect(screen.getByText('Mineralwasser')).toBeInTheDocument();
+    });
+
+    test('does not show the drink creator\'s name', () => {
+      mockOtherUsersDrinks();
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' }));
+
+      expect(screen.queryByText(/von /)).not.toBeInTheDocument();
+    });
+
+    test('a drink belonging to another user gets an anthracite heading instead of the default green', () => {
+      mockOtherUsersDrinks();
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' }));
+
+      expect(screen.getByText('Eigenes Bier')).not.toHaveClass('drink-list-item-title--foreign');
+      expect(screen.getByText('Papas Wein')).toHaveClass('drink-list-item-title--foreign');
+    });
+
+    test('saving additional units for another user\'s drink stores them under the current user, not the owner', async () => {
+      mockOtherUsersDrinks();
+      mockSaveCustomDrink.mockResolvedValue(undefined);
+
+      render(<DrinkManagementPage currentUser={currentUser} />);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' }));
+
+      fireEvent.click(screen.getByText('Papas Wein'));
+      expect(screen.getByRole('heading', { level: 2, name: 'Zusätzliche Einheiten' })).toBeInTheDocument();
+      // No name/category fields to edit for a foreign drink.
+      expect(screen.queryByRole('textbox', { name: /Name/i })).not.toBeInTheDocument();
+
+      const einheitInput = screen.getByPlaceholderText('z. B. Glas, Flasche, Dose');
+      fireEvent.change(einheitInput, { target: { value: 'Piccolo' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Speichern' }));
+
+      await waitFor(() => {
+        expect(mockSaveCustomDrink).toHaveBeenCalledWith(
+          currentUser.id,
+          expect.objectContaining({
+            extendsOwnerId: 'u2',
+            einheiten: [expect.objectContaining({ einheit: 'Piccolo' })],
+          }),
+          'd2',
+        );
+      });
+    });
+
+    test('an admin keeps full edit access to another user\'s drink instead of the add-units form', () => {
+      mockOtherUsersDrinks();
+
+      render(<DrinkManagementPage currentUser={{ id: 'u1', isAdmin: true }} />);
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Nur eigene Getränke anzeigen' }));
+
+      fireEvent.click(screen.getByText('Papas Wein'));
+      expect(screen.getByRole('heading', { level: 2, name: 'Getränk bearbeiten' })).toBeInTheDocument();
     });
   });
 });

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1842,6 +1842,26 @@
   gap: 12px;
 }
 
+/* Drinks belonging to another user are visually distinguished from the
+   current user's own drinks (which keep the default green heading). */
+.drink-list-item-header h3.drink-list-item-title--foreign {
+  color: #383838;
+}
+
+.drink-add-units-name {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #2F5D50;
+}
+
+.drink-existing-einheiten-list {
+  margin: 4px 0 0;
+  padding: 0 0 0 20px;
+  color: #555;
+  font-size: 14px;
+}
+
 /* These row headers opt out of the shared row tint from DeleteRowButton.css —
    only the delete button itself should react when the row is hovered/focused. */
 .events-drink-row-header.delete-row-hover-target:hover,

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -3901,6 +3901,18 @@
   color: #7fb8a3;
 }
 
+[data-theme="dark"] .drink-list-item-header h3.drink-list-item-title--foreign {
+  color: #ccc;
+}
+
+[data-theme="dark"] .drink-add-units-name {
+  color: #7fb8a3;
+}
+
+[data-theme="dark"] .drink-existing-einheiten-list {
+  color: #bbb;
+}
+
 [data-theme="dark"] .drink-category-group-header {
   color: #7fb8a3;
 }

--- a/src/utils/drinkCategories.js
+++ b/src/utils/drinkCategories.js
@@ -81,6 +81,45 @@ export const mergePredefinedDrinks = (customDrinks = [], currentUserId = null) =
   return [...mergedPredefined, ...customById.values()];
 };
 
+/**
+ * Merge per-user "additional units" into the drinks they extend.
+ *
+ * Any user may maintain their own extra Einheiten for a drink owned by
+ * someone else without being able to write to that owner's document (the
+ * Firestore rules only let a drink's own owner/admin write it). Instead,
+ * an addition is stored as an ordinary customDrinks doc under the
+ * contributing user's own path, reusing the target drink's id and carrying
+ * `extendsOwnerId` (the target drink's owner) to mark it as an addition
+ * rather than a standalone drink. Addition docs never appear on their own
+ * in the merged list – each is folded into its target drink's `einheiten`,
+ * tagged with `addedByUserId` so callers can tell who contributed it.
+ *
+ * @param {Array} rawDrinks - Raw customDrinks docs, each annotated with
+ *   `ownerId` (as produced by subscribeToAllCustomDrinks/getAllCustomDrinks).
+ */
+export const mergeDrinkUnitAdditions = (rawDrinks = []) => {
+  const list = Array.isArray(rawDrinks) ? rawDrinks : [];
+  const additions = list.filter((drink) => drink.extendsOwnerId);
+  const drinks = list.filter((drink) => !drink.extendsOwnerId);
+
+  return drinks.map((drink) => {
+    const ownAdditions = additions.filter(
+      (addition) => addition.extendsOwnerId === drink.ownerId && addition.id === drink.id
+    );
+    if (ownAdditions.length === 0) return drink;
+    const addedEinheiten = ownAdditions.flatMap((addition) =>
+      (Array.isArray(addition.einheiten) ? addition.einheiten : []).map((einheit) => ({
+        ...einheit,
+        addedByUserId: addition.ownerId,
+      }))
+    );
+    return {
+      ...drink,
+      einheiten: [...(Array.isArray(drink.einheiten) ? drink.einheiten : []), ...addedEinheiten],
+    };
+  });
+};
+
 export const getDrinkCategoryLabel = (kategorieId) => {
   for (const cat of DRINK_CATEGORIES) {
     if (cat.id === kategorieId) return cat.label;

--- a/src/utils/drinkCategories.test.js
+++ b/src/utils/drinkCategories.test.js
@@ -1,0 +1,70 @@
+import { mergeDrinkUnitAdditions } from './drinkCategories';
+
+describe('mergeDrinkUnitAdditions', () => {
+  it('returns drinks unchanged when there are no additions', () => {
+    const drinks = [{ id: 'd1', ownerId: 'u1', name: 'Bier', einheiten: [{ einheitsgroesse: 0.5 }] }];
+    expect(mergeDrinkUnitAdditions(drinks)).toEqual(drinks);
+  });
+
+  it('folds an addition doc into its target drink and tags the added einheiten', () => {
+    const drinks = [
+      { id: 'd1', ownerId: 'u1', name: 'Papas Wein', einheiten: [{ einheitsgroesse: 0.75 }] },
+      {
+        id: 'd1',
+        ownerId: 'u2',
+        extendsOwnerId: 'u1',
+        einheiten: [{ einheitsgroesse: 0.2, einheit: 'Glas' }],
+      },
+    ];
+
+    const result = mergeDrinkUnitAdditions(drinks);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('d1');
+    expect(result[0].ownerId).toBe('u1');
+    expect(result[0].einheiten).toEqual([
+      { einheitsgroesse: 0.75 },
+      { einheitsgroesse: 0.2, einheit: 'Glas', addedByUserId: 'u2' },
+    ]);
+  });
+
+  it('never surfaces an addition doc as a standalone drink', () => {
+    const drinks = [
+      { id: 'd1', ownerId: 'u2', extendsOwnerId: 'u1', einheiten: [{ einheitsgroesse: 0.2 }] },
+    ];
+
+    expect(mergeDrinkUnitAdditions(drinks)).toEqual([]);
+  });
+
+  it('merges additions from multiple different users into the same drink', () => {
+    const drinks = [
+      { id: 'd1', ownerId: 'u1', einheiten: [] },
+      { id: 'd1', ownerId: 'u2', extendsOwnerId: 'u1', einheiten: [{ einheitsgroesse: 0.2 }] },
+      { id: 'd1', ownerId: 'u3', extendsOwnerId: 'u1', einheiten: [{ einheitsgroesse: 1.0 }] },
+    ];
+
+    const result = mergeDrinkUnitAdditions(drinks);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].einheiten).toEqual([
+      { einheitsgroesse: 0.2, addedByUserId: 'u2' },
+      { einheitsgroesse: 1.0, addedByUserId: 'u3' },
+    ]);
+  });
+
+  it('ignores an addition whose target drink id/owner does not match any drink', () => {
+    const drinks = [
+      { id: 'd1', ownerId: 'u1', einheiten: [{ einheitsgroesse: 0.5 }] },
+      { id: 'd2', ownerId: 'u2', extendsOwnerId: 'someone-else', einheiten: [{ einheitsgroesse: 0.2 }] },
+    ];
+
+    const result = mergeDrinkUnitAdditions(drinks);
+
+    expect(result).toEqual([{ id: 'd1', ownerId: 'u1', einheiten: [{ einheitsgroesse: 0.5 }] }]);
+  });
+
+  it('handles a non-array input gracefully', () => {
+    expect(mergeDrinkUnitAdditions(undefined)).toEqual([]);
+    expect(mergeDrinkUnitAdditions(null)).toEqual([]);
+  });
+});

--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -20,6 +20,7 @@ import {
   serverTimestamp,
 } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
+import { mergeDrinkUnitAdditions } from './drinkCategories';
 
 export const EVENT_CATEGORIES = [
   'wasser', 'softdrinks', 'saft', 'bier', 'wein', 'sekt', 'spirituosen', 'kaffee', 'tee',
@@ -268,7 +269,11 @@ export const subscribeToCustomDrinks = (uid, callback) => {
   return onSnapshot(q, (snapshot) => {
     const drinks = [];
     snapshot.forEach((docSnap) => {
-      drinks.push({ id: docSnap.id, ...docSnap.data() });
+      const data = docSnap.data();
+      // Docs carrying extendsOwnerId are this user's additional-units
+      // contributions to someone else's drink, not drinks of their own.
+      if (data.extendsOwnerId) return;
+      drinks.push({ id: docSnap.id, ...data });
     });
     callback(drinks);
   }, (error) => {
@@ -293,7 +298,7 @@ export const subscribeToAllCustomDrinks = (callback) => {
     snapshot.forEach((docSnap) => {
       drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
     });
-    callback(drinks);
+    callback(mergeDrinkUnitAdditions(drinks));
   }, (error) => {
     console.error('Error subscribing to all customDrinks:', error);
     callback([]);
@@ -315,7 +320,7 @@ export const getAllCustomDrinks = async () => {
     snapshot.forEach((docSnap) => {
       drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
     });
-    return drinks;
+    return mergeDrinkUnitAdditions(drinks);
   } catch (error) {
     console.error('Error getting all customDrinks:', error);
     return [];
@@ -334,7 +339,11 @@ export const getCustomDrinks = async (uid) => {
     const snapshot = await getDocs(q);
     const drinks = [];
     snapshot.forEach((docSnap) => {
-      drinks.push({ id: docSnap.id, ...docSnap.data() });
+      const data = docSnap.data();
+      // Docs carrying extendsOwnerId are this user's additional-units
+      // contributions to someone else's drink, not drinks of their own.
+      if (data.extendsOwnerId) return;
+      drinks.push({ id: docSnap.id, ...data });
     });
     return drinks;
   } catch (error) {
@@ -344,7 +353,12 @@ export const getCustomDrinks = async (uid) => {
 };
 
 /**
- * Save a custom drink (create or update).
+ * Save a custom drink (create or update). Also used to save another user's
+ * "additional units" contribution to someone else's drink: pass `uid` as the
+ * contributor, `drinkId` as the target drink's id, and `drink` as
+ * `{ einheiten, extendsOwnerId }` (no name/kategorie) – see
+ * mergeDrinkUnitAdditions in drinkCategories.js for how these are folded
+ * back into the target drink.
  * @param {string} uid - Current user ID
  * @param {Object} drink - { name, kategorie, einheiten: [{ einheitsgroesse, gebindeinheit, einheitenProGebinde }] }
  * @param {string} [drinkId] - If provided, update existing drink

--- a/src/utils/eventsFirestore.test.js
+++ b/src/utils/eventsFirestore.test.js
@@ -8,18 +8,22 @@ const mockAddDoc = jest.fn();
 const mockSetDoc = jest.fn();
 const mockDeleteDoc = jest.fn();
 const mockOnSnapshot = jest.fn();
+const mockGetDocs = jest.fn();
 const mockServerTimestamp = jest.fn(() => 'mock-ts');
 const mockOrderBy = jest.fn((...args) => args);
 const mockQuery = jest.fn((...args) => args);
 const mockCollection = jest.fn();
+const mockCollectionGroup = jest.fn();
 const mockDoc = jest.fn();
 const mockHttpsCallable = jest.fn();
 const mockGuestCallable = jest.fn();
 
 jest.mock('firebase/firestore', () => ({
   collection: (...args) => mockCollection(...args),
+  collectionGroup: (...args) => mockCollectionGroup(...args),
   doc: (...args) => mockDoc(...args),
   getDoc: jest.fn(),
+  getDocs: (...args) => mockGetDocs(...args),
   addDoc: (...args) => mockAddDoc(...args),
   setDoc: (...args) => mockSetDoc(...args),
   deleteDoc: (...args) => mockDeleteDoc(...args),
@@ -35,6 +39,9 @@ jest.mock('firebase/functions', () => ({
 
 import {
   subscribeToCustomDrinks,
+  subscribeToAllCustomDrinks,
+  getAllCustomDrinks,
+  getCustomDrinks,
   saveCustomDrink,
   deleteCustomDrink,
   subscribeToGuestProfiles,
@@ -44,7 +51,11 @@ import {
 
 const createSnapshot = (items) => ({
   forEach: (cb) =>
-    items.forEach((item) => cb({ id: item.id, data: () => { const { id, ...rest } = item; return rest; } })),
+    items.forEach((item) => cb({
+      id: item.id,
+      data: () => { const { id, __ownerId, ...rest } = item; return rest; },
+      ref: { parent: { parent: { id: item.__ownerId || 'owner' } } },
+    })),
 });
 
 describe('subscribeToCustomDrinks', () => {
@@ -73,6 +84,99 @@ describe('subscribeToCustomDrinks', () => {
     subscribeToCustomDrinks('user1', cb);
 
     expect(cb).toHaveBeenCalledWith([]);
+  });
+
+  it('filters out this user\'s own additional-units contributions to someone else\'s drink', () => {
+    const drinks = [
+      { id: 'd1', name: 'Craft-Bier', einheiten: [] },
+      { id: 'd2', extendsOwnerId: 'other-user', einheiten: [{ einheitsgroesse: 0.2 }] },
+    ];
+    mockOnSnapshot.mockImplementation((_ref, cb) => {
+      cb(createSnapshot(drinks));
+      return jest.fn();
+    });
+
+    const cb = jest.fn();
+    subscribeToCustomDrinks('user1', cb);
+
+    expect(cb).toHaveBeenCalledWith([{ id: 'd1', name: 'Craft-Bier', einheiten: [] }]);
+  });
+});
+
+describe('subscribeToAllCustomDrinks', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('merges another user\'s additional-units addition into the drink it extends', () => {
+    const drinks = [
+      { id: 'd1', __ownerId: 'u1', name: 'Papas Wein', einheiten: [{ einheitsgroesse: 0.75 }] },
+      { id: 'd1', __ownerId: 'u2', extendsOwnerId: 'u1', einheiten: [{ einheitsgroesse: 0.2, einheit: 'Glas' }] },
+    ];
+    mockOnSnapshot.mockImplementation((_ref, cb) => {
+      cb(createSnapshot(drinks));
+      return jest.fn();
+    });
+
+    const cb = jest.fn();
+    subscribeToAllCustomDrinks(cb);
+
+    expect(cb).toHaveBeenCalledWith([
+      {
+        id: 'd1',
+        name: 'Papas Wein',
+        ownerId: 'u1',
+        einheiten: [
+          { einheitsgroesse: 0.75 },
+          { einheitsgroesse: 0.2, einheit: 'Glas', addedByUserId: 'u2' },
+        ],
+      },
+    ]);
+  });
+
+  it('calls callback with empty array on error', () => {
+    mockOnSnapshot.mockImplementation((_ref, _success, errorCb) => {
+      errorCb(new Error('firestore error'));
+      return jest.fn();
+    });
+
+    const cb = jest.fn();
+    subscribeToAllCustomDrinks(cb);
+
+    expect(cb).toHaveBeenCalledWith([]);
+  });
+});
+
+describe('getAllCustomDrinks / getCustomDrinks', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('getAllCustomDrinks merges additional-units additions across owners', async () => {
+    const drinks = [
+      { id: 'd1', __ownerId: 'u1', name: 'Papas Wein', einheiten: [] },
+      { id: 'd1', __ownerId: 'u2', extendsOwnerId: 'u1', einheiten: [{ einheitsgroesse: 0.33 }] },
+    ];
+    mockGetDocs.mockResolvedValue(createSnapshot(drinks));
+
+    const result = await getAllCustomDrinks();
+
+    expect(result).toEqual([
+      {
+        id: 'd1',
+        name: 'Papas Wein',
+        ownerId: 'u1',
+        einheiten: [{ einheitsgroesse: 0.33, addedByUserId: 'u2' }],
+      },
+    ]);
+  });
+
+  it('getCustomDrinks excludes this user\'s own additional-units contributions to someone else\'s drink', async () => {
+    const drinks = [
+      { id: 'd1', name: 'Eigenes Bier', einheiten: [] },
+      { id: 'd2', extendsOwnerId: 'other-user', einheiten: [{ einheitsgroesse: 0.2 }] },
+    ];
+    mockGetDocs.mockResolvedValue(createSnapshot(drinks));
+
+    const result = await getCustomDrinks('user1');
+
+    expect(result).toEqual([{ id: 'd1', name: 'Eigenes Bier', einheiten: [] }]);
   });
 });
 


### PR DESCRIPTION
## Summary
This change enables non-admin users to contribute additional unit sizes to drinks owned by other users, without requiring write access to the owner's drink document. A new "add units" mode allows users to maintain their own supplementary Einheiten alongside the original owner's, which are merged and displayed together across the app.

## Key Changes

- **New "add units" workflow**: Non-admin users can now click on drinks owned by others to open an "add units" form instead of the full edit form. This form shows existing units from the owner and allows adding personal supplementary units.

- **Unit addition storage model**: Additional units are stored as separate Firestore documents under the contributing user's own path, marked with `extendsOwnerId` to indicate they extend another user's drink rather than being standalone drinks.

- **Merging logic**: Implemented `mergeDrinkUnitAdditions()` to fold per-user additions into their target drink's `einheiten` array, tagging each added unit with `addedByUserId` for attribution.

- **Firestore integration**: Updated `subscribeToAllCustomDrinks()` and `getAllCustomDrinks()` to apply the merge logic; `subscribeToCustomDrinks()` filters out the current user's own additions (which are managed separately).

- **UI refinements**:
  - Removed user name display from drink rows (no longer shows "von [Owner]")
  - Added visual distinction for foreign drinks with anthracite heading color (`drink-list-item-title--foreign`)
  - Form conditionally shows name/category fields only when editing own drinks
  - Shows existing owner units in read-only list when adding units
  - Updated button labels and form titles to reflect the mode

- **Admin behavior**: Admins retain full edit access to any drink, bypassing the add-units form.

- **Removed dependencies**: Eliminated unused `getUsers()` import and related user lookup logic.

## Implementation Details

- The `DrinkRow` component now accepts `isForeign`, `canAddUnits`, and `onAddUnits` props to handle the dual-mode interaction.
- Form state tracks `isAddUnitsMode` and `addUnitsDrink` separately from edit mode.
- `handleSaveUnitAddition()` saves only the `einheiten` and `extendsOwnerId` fields, storing under the current user's ID.
- Comprehensive test coverage added for the merge logic and the new add-units workflow.

https://claude.ai/code/session_01AQqdNYiZZRjwSV8QmZCZzk