### PR TITLE
Beim Linksswipe des ausgewählten Rezepts nur den Löschbutton rot einfärben

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -484,6 +484,7 @@
   overflow: hidden;
   border-radius: 6px;
   margin-bottom: 0.5rem;
+  background: #f9f6f3;
 }
 
 .selected-recipe-item-content {
@@ -512,6 +513,24 @@
 .selected-recipe-item.swipe-delete-active .swipe-delete-background {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Unlike the solid red reveal used elsewhere, only the button itself should
+   read as red here (CLAUDE.md DeleteRowButton spec: red is reserved for the
+   button, never a filled row/area). The row keeps its normal background as
+   it slides away; a DeleteRowButton-styled circle sits in the revealed
+   strip instead of a red rectangle. */
+.selected-recipe-item .swipe-delete-background {
+  background: transparent;
+  padding-right: 0.6rem;
+}
+
+.selected-recipe-item .swipe-delete-action {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(163, 58, 38, 0.12);
+  color: #a33a26;
 }
 
 @media (max-width: 768px) {

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -2490,6 +2490,11 @@
   background: #2a2a2a;
 }
 
+[data-theme="dark"] .selected-recipe-item .swipe-delete-action {
+  background: rgba(255, 114, 90, 0.18);
+  color: #ff8a72;
+}
+
 [data-theme="dark"] .selected-recipes h5 {
   color: #aaa;
 }


### PR DESCRIPTION
Die Zeile blieb bisher in ihrer normalen Hintergrundfarbe, während beim
Swipe eine volle rote Fläche hinter dem Inhalt sichtbar wurde. Jetzt
bleibt die Zeile neutral und nur der runde Löschbutton bekommt die
rote DeleteRowButton-Färbung (auch im Dark Mode).