### PR TITLE
Adjust FAB opacity and hide manage links on mobile

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1394,6 +1394,10 @@
     display: none;
   }
 
+  .events-manage-links {
+    display: none;
+  }
+
   .event-save-fab-button {
     display: flex;
     position: fixed;

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -1374,7 +1374,7 @@
     height: 56px;
     min-width: 56px;
     max-width: 56px;
-    opacity: 0.85;
+    opacity: 0.6;
   }
 
   .events-cancel-fab-button {


### PR DESCRIPTION
## Summary
This PR adjusts the visual styling of the floating action button (FAB) and hides the manage links section on mobile viewports to improve the mobile user experience.

## Key Changes
- Reduced the opacity of the FAB button from 0.85 to 0.6 for a more subtle appearance
- Hidden the `.events-manage-links` element on mobile devices by setting `display: none`

## Implementation Details
These changes appear to be part of a responsive design refinement for the Events page, ensuring that the interface is appropriately optimized for mobile viewports while maintaining the desktop experience.

https://claude.ai/code/session_01XDNGkenCQzpXeyuZLsQBq3