### PR TITLE
Sort custom drinks client-side to include nameless contributions

### DIFF
--- a/src/utils/eventsFirestore.js
+++ b/src/utils/eventsFirestore.js
@@ -22,6 +22,14 @@ import {
 import { httpsCallable } from 'firebase/functions';
 import { mergeDrinkUnitAdditions } from './drinkCategories';
 
+// Additional-units contribution docs (see mergeDrinkUnitAdditions) never carry
+// a `name` field. Firestore excludes any document missing an orderBy field
+// from the query results entirely, so collection-group queries over
+// customDrinks must not sort by `name` in Firestore or those contributions
+// would never come back. Sort client-side instead.
+const sortDrinksByName = (drinks) =>
+  [...drinks].sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), 'de', { sensitivity: 'base' }));
+
 export const EVENT_CATEGORIES = [
   'wasser', 'softdrinks', 'saft', 'bier', 'wein', 'sekt', 'spirituosen', 'kaffee', 'tee',
 ];
@@ -292,13 +300,12 @@ export const subscribeToCustomDrinks = (uid, callback) => {
  */
 export const subscribeToAllCustomDrinks = (callback) => {
   const ref = collectionGroup(db, 'customDrinks');
-  const q = query(ref, orderBy('name', 'asc'));
-  return onSnapshot(q, (snapshot) => {
+  return onSnapshot(ref, (snapshot) => {
     const drinks = [];
     snapshot.forEach((docSnap) => {
       drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
     });
-    callback(mergeDrinkUnitAdditions(drinks));
+    callback(sortDrinksByName(mergeDrinkUnitAdditions(drinks)));
   }, (error) => {
     console.error('Error subscribing to all customDrinks:', error);
     callback([]);
@@ -314,13 +321,12 @@ export const subscribeToAllCustomDrinks = (callback) => {
 export const getAllCustomDrinks = async () => {
   try {
     const ref = collectionGroup(db, 'customDrinks');
-    const q = query(ref, orderBy('name', 'asc'));
-    const snapshot = await getDocs(q);
+    const snapshot = await getDocs(ref);
     const drinks = [];
     snapshot.forEach((docSnap) => {
       drinks.push({ id: docSnap.id, ...docSnap.data(), ownerId: docSnap.ref.parent.parent.id });
     });
-    return mergeDrinkUnitAdditions(drinks);
+    return sortDrinksByName(mergeDrinkUnitAdditions(drinks));
   } catch (error) {
     console.error('Error getting all customDrinks:', error);
     return [];

--- a/src/utils/eventsFirestore.test.js
+++ b/src/utils/eventsFirestore.test.js
@@ -143,6 +143,37 @@ describe('subscribeToAllCustomDrinks', () => {
 
     expect(cb).toHaveBeenCalledWith([]);
   });
+
+  it('does not order the collection-group query by name, since Firestore drops any document missing that field from the results – which would silently exclude every nameless additional-units doc', () => {
+    const groupRef = { __marker: 'customDrinks-group' };
+    mockCollectionGroup.mockReturnValue(groupRef);
+    mockOnSnapshot.mockImplementation((_ref, cb) => {
+      cb(createSnapshot([]));
+      return jest.fn();
+    });
+
+    subscribeToAllCustomDrinks(jest.fn());
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockOrderBy).not.toHaveBeenCalled();
+    expect(mockOnSnapshot).toHaveBeenCalledWith(groupRef, expect.any(Function), expect.any(Function));
+  });
+
+  it('sorts the merged result by name client-side', () => {
+    const drinks = [
+      { id: 'd2', __ownerId: 'u1', name: 'Wasser', einheiten: [] },
+      { id: 'd1', __ownerId: 'u1', name: 'Apfelsaft', einheiten: [] },
+    ];
+    mockOnSnapshot.mockImplementation((_ref, cb) => {
+      cb(createSnapshot(drinks));
+      return jest.fn();
+    });
+
+    const cb = jest.fn();
+    subscribeToAllCustomDrinks(cb);
+
+    expect(cb.mock.calls[0][0].map((d) => d.name)).toEqual(['Apfelsaft', 'Wasser']);
+  });
 });
 
 describe('getAllCustomDrinks / getCustomDrinks', () => {
@@ -165,6 +196,18 @@ describe('getAllCustomDrinks / getCustomDrinks', () => {
         einheiten: [{ einheitsgroesse: 0.33, addedByUserId: 'u2' }],
       },
     ]);
+  });
+
+  it('getAllCustomDrinks does not order the collection-group query by name, since Firestore drops any document missing that field from the results – which would silently exclude every nameless additional-units doc', async () => {
+    const groupRef = { __marker: 'customDrinks-group' };
+    mockCollectionGroup.mockReturnValue(groupRef);
+    mockGetDocs.mockResolvedValue(createSnapshot([]));
+
+    await getAllCustomDrinks();
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockOrderBy).not.toHaveBeenCalled();
+    expect(mockGetDocs).toHaveBeenCalledWith(groupRef);
   });
 
   it('getCustomDrinks excludes this user\'s own additional-units contributions to someone else\'s drink', async () => {


### PR DESCRIPTION
## Summary
Fixes a bug where additional-units contributions (which lack a `name` field) were silently excluded from custom drinks queries due to Firestore's behavior of dropping documents missing an orderBy field.

## Changes
- Removed `orderBy('name', 'asc')` from Firestore collection-group queries in `subscribeToAllCustomDrinks()` and `getAllCustomDrinks()`
- Added `sortDrinksByName()` utility function that sorts drinks client-side using locale-aware comparison (German locale, base sensitivity)
- Applied client-side sorting after merging drink unit additions to ensure all documents are included in results
- Added comprehensive test coverage for both the subscription and async query functions to verify:
  - Firestore queries are not ordered by name
  - Results are sorted by name client-side
  - Nameless documents are not excluded

## Implementation Details
The root cause was that Firestore automatically excludes any document missing a field used in an `orderBy` clause. Since additional-units contribution documents (created via `mergeDrinkUnitAdditions`) never have a `name` field, they were being silently filtered out. By moving the sort operation to the client after all documents are retrieved and merged, we ensure complete data integrity while maintaining the desired sort order.

https://claude.ai/code/session_016yvLFhCZsBPpBrs8stJsvE