### PR TITLE
Centralize touch gesture logic for delete actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,15 @@ Spezifikation: design_handoff_pillenkarussell/Löschen Einheitlich.dc.html
 Diese Spezifikation gilt nur für Desktop. Auf Mobile gilt stattdessen die
 Linksswipe-Geste als Löschalternative — analog zur aktuell z. B. beim
 Event-Löschen verwendeten Interaktion.
+
+Die Touch-Gesten-Logik ist zentralisiert, nicht mehr pro Liste dupliziert:
+- `src/hooks/useSwipeToDelete.js` — Linksswipe-Erkennung für mobile Listenzeilen
+  (Events, Getränke, Gäste, Rezept-Zutaten/-Schritte). Direction-Lock (6 px),
+  Swipe-Schwelle 56 px, Klemmung bei max. 96 px Offset.
+- `src/hooks/useUndoableDelete.js` — verwaltet Snackbar-Banner + 6-s-Timer:
+  die Zeile verschwindet sofort aus der Ansicht, die eigentliche Mutation
+  (Firestore-Delete bzw. Entfernen aus dem lokalen Array) läuft erst nach
+  Ablauf des Undo-Fensters — oder wird bei Klick auf „Rückgängig" verworfen.
+
+Neue Lösch-UIs (Desktop wie Mobile) sollen diese beiden Hooks wiederverwenden
+statt eigene Swipe-/Undo-Logik zu implementieren.


### PR DESCRIPTION
## Summary
Extracted and centralized the touch gesture and undo logic for delete actions into reusable hooks, eliminating duplication across list components (Events, Drinks, Guests, Recipe Ingredients/Steps).

## Key Changes
- **`src/hooks/useSwipeToDelete.js`** — New hook for left-swipe detection on mobile list rows
  - Direction lock threshold: 6 px
  - Swipe threshold: 56 px
  - Maximum offset clamping: 96 px
  
- **`src/hooks/useUndoableDelete.js`** — New hook managing undo behavior
  - Displays snackbar banner with 6-second timer
  - Row disappears immediately from view
  - Actual mutation (Firestore delete or local array removal) deferred until timer expires
  - Undo action cancels the pending deletion

## Implementation Details
These hooks implement the mobile alternative to the desktop delete button specified in the design handoff, providing consistent swipe-to-delete behavior across all list types. Future delete UIs should reuse these hooks rather than implementing custom swipe/undo logic.

https://claude.ai/code/session_016GnwZei7UUXdxVBnfiHDPu