### PR TITLE
Events-Menüpunkt im 3-Strichmenü mit Event-Signalfarbe hervorheben

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -437,6 +437,10 @@
   color: #DF7A00;
 }
 
+.menu-item-events.active {
+  color: #2F5D50;
+}
+
 .menu-user-info {
   padding: 0.75rem 1rem;
   display: flex;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -277,7 +277,7 @@ const Header = forwardRef(function Header({
                         Festtafel
                       </button>
                       <button
-                        className={`menu-item ${currentView === 'events' ? 'active' : ''}`}
+                        className={`menu-item menu-item-events ${currentView === 'events' ? 'active' : ''}`}
                         onClick={() => handleViewChangeInternal('events')}
                       >
                         Events

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -2076,6 +2076,10 @@
   color: #DF7A00;
 }
 
+[data-theme="dark"] .menu-item-events.active {
+  color: #2F5D50;
+}
+
 [data-theme="dark"] .menu-user-name {
   color: #e8e8e8;
 }


### PR DESCRIPTION
Der aktive "Events"-Eintrag im Hamburger-Menü nutzt jetzt das Grün
(#2F5D50) des Eventmoduls statt der Standard-Akzentfarbe Orange.