### PR TITLE
Rezept-Swipe: Löschicon sofort während des Swipes anzeigen

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -387,7 +387,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex, sw
       className={`selected-recipe-item ${isDragging ? 'dragging' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
       <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
-        {isDeleteVisible && (
+        {(isDeleteVisible || offset < 0) && (
           <button
             type="button"
             className="swipe-delete-action"
@@ -463,7 +463,7 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove, swipeDeleteI
       className={`selected-recipe-item ${isDragging ? 'dragging' : ''}${offset < 0 ? ' swipe-delete-active' : ''}`}
     >
       <div className="swipe-delete-background" aria-hidden={!isDeleteVisible}>
-        {isDeleteVisible && (
+        {(isDeleteVisible || offset < 0) && (
           <button
             type="button"
             className="swipe-delete-action"


### PR DESCRIPTION
Der Papierkorb-Button wurde bisher erst nach Loslassen über der
Swipe-Schwelle gerendert, sodass eine Zeile beim Wegswipen zunächst
vollflächig rot ohne Icon war und erst danach die endgültige
Vier-Zeilen-Optik (rot mit Icon rechts) zeigte. Jetzt wird der Button
bereits während des aktiven Swipes gerendert, sodass die Zieloptik
sofort sichtbar ist.