### PR TITLE
Vereinheitliche Getränke-/Gäste-FABs mit dem Neues-Event-FAB

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -121,6 +121,8 @@
   .App .add-menu-fab-button,
   .App .events-add-fab-button,
   .App .events-page-container .edit-fab-button,
+  .App .events-page-container .events-drinks-fab-button,
+  .App .events-page-container .events-guests-fab-button,
   .App .menu-favorites-filter-button,
   .App .recipe-detail-container .edit-fab-button,
   .App .recipe-detail-container .new-version-fab-button,

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -333,13 +333,11 @@
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
 }
 
-/* Getränke/Gästeübersicht FABs (Events-Übersicht, unten links) - ersetzen die
-   frühere "Getränke verwalten"/"Gäste verwalten"-Textlinks und übernehmen
-   dieselbe Formatierung wie der "Neues Event"-FAB (weiß/umrandet, rund),
-   auf Desktop wie Mobile sichtbar. */
+/* Getränke/Gästeübersicht FABs (mobile Events-Übersicht, unten links) -
+   gleiche Formatierung wie der "Neues Event"-FAB (weiß/umrandet, rund). */
 .events-drinks-fab-button,
 .events-guests-fab-button {
-  display: flex;
+  display: none;
   position: fixed;
   bottom: 20px;
   z-index: 1101;
@@ -1271,6 +1269,13 @@
   color: #888;
 }
 
+.events-manage-links {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
 .events-manage-link-btn {
   background: none;
   border: 1px solid #2F5D50;
@@ -1376,6 +1381,10 @@
     min-width: 56px;
     max-width: 56px;
     opacity: 0.85;
+  }
+
+  .events-manage-links {
+    display: none;
   }
 
   .events-cancel-fab-button {

--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -333,11 +333,13 @@
   box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
 }
 
-/* Getränke/Gästeübersicht FABs (mobile Events-Übersicht, unten links) -
-   gleiche Formatierung wie der "Neues Event"-FAB (weiß/umrandet). */
+/* Getränke/Gästeübersicht FABs (Events-Übersicht, unten links) - ersetzen die
+   frühere "Getränke verwalten"/"Gäste verwalten"-Textlinks und übernehmen
+   dieselbe Formatierung wie der "Neues Event"-FAB (weiß/umrandet, rund),
+   auf Desktop wie Mobile sichtbar. */
 .events-drinks-fab-button,
 .events-guests-fab-button {
-  display: none;
+  display: flex;
   position: fixed;
   bottom: 20px;
   z-index: 1101;
@@ -383,6 +385,13 @@
 .events-drinks-fab-button:active,
 .events-guests-fab-button:active {
   background: white;
+  outline: none;
+}
+
+.events-drinks-fab-button:focus,
+.events-drinks-fab-button:focus-visible,
+.events-guests-fab-button:focus,
+.events-guests-fab-button:focus-visible {
   outline: none;
 }
 
@@ -1262,13 +1271,6 @@
   color: #888;
 }
 
-.events-manage-links {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 16px;
-  flex-wrap: wrap;
-}
-
 .events-manage-link-btn {
   background: none;
   border: 1px solid #2F5D50;
@@ -1374,10 +1376,6 @@
     min-width: 56px;
     max-width: 56px;
     opacity: 0.85;
-  }
-
-  .events-manage-links {
-    display: none;
   }
 
   .events-cancel-fab-button {

--- a/src/components/EventsPage.darkMode.css.test.js
+++ b/src/components/EventsPage.darkMode.css.test.js
@@ -38,6 +38,16 @@ describe('EventsPage dark mode FAB styles', () => {
     expect(rule).toContain('border-color: #555;');
   });
 
+  test('styles the events-drinks-fab-button for dark mode', () => {
+    const cssPath = path.join(__dirname, '..', 'darkMode.css');
+    const css = fs.readFileSync(cssPath, 'utf8');
+    const rule = getRuleBody(css, '[data-theme="dark"] .events-drinks-fab-button,\n[data-theme="dark"] .events-guests-fab-button');
+
+    expect(rule).toContain('background: #2a2a2a;');
+    expect(rule).toContain('color: #e8e8e8;');
+    expect(rule).toContain('border-color: #555;');
+  });
+
   test('styles the events table for dark mode', () => {
     const cssPath = path.join(__dirname, '..', 'darkMode.css');
     const css = fs.readFileSync(cssPath, 'utf8');

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -580,6 +580,17 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         )}
       </div>
 
+      <div className="events-manage-links">
+        <button type="button" className="events-manage-link-btn" onClick={() => setSubView('drinks')}>
+          Getränke verwalten
+        </button>
+        {canEditRecipes(currentUser) && (
+          <button type="button" className="events-manage-link-btn" onClick={() => setSubView('guests')}>
+            Gäste verwalten
+          </button>
+        )}
+      </div>
+
       {isAdmin ? (
         allEventsLoading ? (
           <div className="events-empty-state">Laden...</div>
@@ -634,26 +645,28 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         </div>
       ))}
       <OverviewAddFab onClick={() => setSubView('new')} title="Event erstellen" ariaLabel="Event erstellen" />
-      <button
-        type="button"
-        className={`events-drinks-fab-button${drinksFabPressed ? ' pressed' : ''}`}
-        onClick={() => setSubView('drinks')}
-        onTouchStart={() => setDrinksFabPressed(true)}
-        onTouchEnd={() => setDrinksFabPressed(false)}
-        onTouchCancel={() => setDrinksFabPressed(false)}
-        onMouseDown={() => setDrinksFabPressed(true)}
-        onMouseUp={() => setDrinksFabPressed(false)}
-        onMouseLeave={() => setDrinksFabPressed(false)}
-        title="Getränke verwalten"
-        aria-label="Getränke verwalten"
-      >
-        {isBase64Image(drinksFabIcon) ? (
-          <img src={drinksFabIcon} alt="Getränke" className="button-icon-image" draggable="false" />
-        ) : (
-          drinksFabIcon
-        )}
-      </button>
-      {canEditRecipes(currentUser) && (
+      {isMobileView && (
+        <button
+          type="button"
+          className={`events-drinks-fab-button${drinksFabPressed ? ' pressed' : ''}`}
+          onClick={() => setSubView('drinks')}
+          onTouchStart={() => setDrinksFabPressed(true)}
+          onTouchEnd={() => setDrinksFabPressed(false)}
+          onTouchCancel={() => setDrinksFabPressed(false)}
+          onMouseDown={() => setDrinksFabPressed(true)}
+          onMouseUp={() => setDrinksFabPressed(false)}
+          onMouseLeave={() => setDrinksFabPressed(false)}
+          title="Getränke verwalten"
+          aria-label="Getränke verwalten"
+        >
+          {isBase64Image(drinksFabIcon) ? (
+            <img src={drinksFabIcon} alt="Getränke" className="button-icon-image" draggable="false" />
+          ) : (
+            drinksFabIcon
+          )}
+        </button>
+      )}
+      {isMobileView && canEditRecipes(currentUser) && (
         <button
           type="button"
           className={`events-guests-fab-button${guestsFabPressed ? ' pressed' : ''}`}

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -580,17 +580,6 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         )}
       </div>
 
-      <div className="events-manage-links">
-        <button type="button" className="events-manage-link-btn" onClick={() => setSubView('drinks')}>
-          Getränke verwalten
-        </button>
-        {canEditRecipes(currentUser) && (
-          <button type="button" className="events-manage-link-btn" onClick={() => setSubView('guests')}>
-            Gäste verwalten
-          </button>
-        )}
-      </div>
-
       {isAdmin ? (
         allEventsLoading ? (
           <div className="events-empty-state">Laden...</div>
@@ -645,28 +634,26 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
         </div>
       ))}
       <OverviewAddFab onClick={() => setSubView('new')} title="Event erstellen" ariaLabel="Event erstellen" />
-      {isMobileView && (
-        <button
-          type="button"
-          className={`events-drinks-fab-button${drinksFabPressed ? ' pressed' : ''}`}
-          onClick={() => setSubView('drinks')}
-          onTouchStart={() => setDrinksFabPressed(true)}
-          onTouchEnd={() => setDrinksFabPressed(false)}
-          onTouchCancel={() => setDrinksFabPressed(false)}
-          onMouseDown={() => setDrinksFabPressed(true)}
-          onMouseUp={() => setDrinksFabPressed(false)}
-          onMouseLeave={() => setDrinksFabPressed(false)}
-          title="Getränke verwalten"
-          aria-label="Getränke verwalten"
-        >
-          {isBase64Image(drinksFabIcon) ? (
-            <img src={drinksFabIcon} alt="Getränke" className="button-icon-image" draggable="false" />
-          ) : (
-            drinksFabIcon
-          )}
-        </button>
-      )}
-      {isMobileView && canEditRecipes(currentUser) && (
+      <button
+        type="button"
+        className={`events-drinks-fab-button${drinksFabPressed ? ' pressed' : ''}`}
+        onClick={() => setSubView('drinks')}
+        onTouchStart={() => setDrinksFabPressed(true)}
+        onTouchEnd={() => setDrinksFabPressed(false)}
+        onTouchCancel={() => setDrinksFabPressed(false)}
+        onMouseDown={() => setDrinksFabPressed(true)}
+        onMouseUp={() => setDrinksFabPressed(false)}
+        onMouseLeave={() => setDrinksFabPressed(false)}
+        title="Getränke verwalten"
+        aria-label="Getränke verwalten"
+      >
+        {isBase64Image(drinksFabIcon) ? (
+          <img src={drinksFabIcon} alt="Getränke" className="button-icon-image" draggable="false" />
+        ) : (
+          drinksFabIcon
+        )}
+      </button>
+      {canEditRecipes(currentUser) && (
         <button
           type="button"
           className={`events-guests-fab-button${guestsFabPressed ? ' pressed' : ''}`}
@@ -677,8 +664,8 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
           onMouseDown={() => setGuestsFabPressed(true)}
           onMouseUp={() => setGuestsFabPressed(false)}
           onMouseLeave={() => setGuestsFabPressed(false)}
-          title="Gästeübersicht"
-          aria-label="Gästeübersicht"
+          title="Gäste verwalten"
+          aria-label="Gäste verwalten"
         >
           {isBase64Image(guestsFabIcon) ? (
             <img src={guestsFabIcon} alt="Gäste" className="button-icon-image" draggable="false" />

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -1015,6 +1015,18 @@
   border-color: #555;
 }
 
+[data-theme="dark"] .events-drinks-fab-button,
+[data-theme="dark"] .events-guests-fab-button {
+  background: #2a2a2a;
+  color: #e8e8e8;
+  border-color: #555;
+}
+
+[data-theme="dark"] .events-drinks-fab-button:active,
+[data-theme="dark"] .events-guests-fab-button:active {
+  background: #2a2a2a;
+}
+
 [data-theme="dark"] .menu-favorite-badge {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Die "Getränke verwalten"/"Gäste verwalten"-FABs auf der Events-Seite
übernehmen jetzt dieselbe Formatierung (Fokus-Outline, Darkmode) wie der
"Neues Event"-FAB und sind nicht mehr auf die mobile Ansicht beschränkt.
Die alten Textlink-Buttons zum Öffnen der Getränke-/Gästeübersicht
entfallen dadurch, da die FABs diese Funktion auf allen Bildschirmgrößen
übernehmen.