### PR TITLE
Rezept-Swipe im Menü: sofortiges Icon, Dark Mode und roter Bereich nur beim Icon

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -514,6 +514,15 @@
   pointer-events: auto;
 }
 
+/* Confine the red reveal to the delete icon's own hit area (RecipeForm.css's
+   base .swipe-delete-background spans the full row via inset:0) so the
+   recipe/drink name keeps its normal row background while sliding, with red
+   only behind the icon on the right — not across the whole swiped area. */
+.selected-recipe-item .swipe-delete-background {
+  left: auto;
+  width: 3.5rem;
+}
+
 @media (max-width: 768px) {
   .delete-row-button.selected-recipe-item-delete-btn {
     display: none;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -2490,6 +2490,15 @@
   background: #2a2a2a;
 }
 
+[data-theme="dark"] .selected-recipe-item-content {
+  background: #1e1e1e;
+}
+
+[data-theme="dark"] .selected-recipe-item.dragging .selected-recipe-item-content {
+  background: #2a2a2a;
+  border-color: #555;
+}
+
 [data-theme="dark"] .selected-recipes h5 {
   color: #aaa;
 }


### PR DESCRIPTION
## Summary
- Löschicon beim Linksswipe der Rezept-/Getränkezeilen im Menü (`MenuForm.js`) erscheint jetzt sofort während der Geste, nicht erst nachdem über die Schwelle hinaus losgelassen wurde
- Dark Mode: `.selected-recipe-item-content` hatte keinen Dark-Mode-Hintergrund und wirkte in "Abschnitte & Rezepte" hell/verwaschen — jetzt ergänzt
- Der rote Swipe-Reveal-Hintergrund war zeilenbreit (`inset: 0` aus `RecipeForm.css`); jetzt auf die Icon-Breite rechtsbündig begrenzt, sodass nur der Bereich hinter dem Löschicon rot wird und der Rezept-/Getränkename auf normalem Zeilenhintergrund bleibt

## Test plan
- [ ] Menü öffnen, Abschnitt mit Rezepten/Getränken auf Mobile-Breite ansehen
- [ ] Eine Zeile nach links wischen: Icon erscheint direkt während des Wischens, rot nur im Icon-Bereich
- [ ] Dark Mode aktivieren und dieselbe Ansicht prüfen: Zeilen haben dunklen Hintergrund


---
_Generated by [Claude Code](https://claude.ai/code/session_01TemgQtUXnTvbQhayKbkM9m)_