### PR TITLE
Menü-Rezeptzeilen: Dark Mode Abschnittskarte + runde Ecken beim Swipe-Löschbereich

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -522,6 +522,7 @@
 .selected-recipe-item .swipe-delete-background {
   left: auto;
   width: 3.5rem;
+  border-radius: 6px;
 }
 
 @media (max-width: 768px) {

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -491,7 +491,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 0.75rem;
-  background: #f9f6f3;
+  background: #fff;
+  border: 1px solid #e0d5c7;
   border-radius: 6px;
   gap: 0.5rem;
   position: relative;

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -2458,7 +2458,7 @@
   border-color: #3d3d3d;
 }
 
-[data-theme="dark"] .section-block {
+[data-theme="dark"] .menu-form-container .section-block {
   background: #1e1e1e;
   border-color: #3d3d3d;
 }
@@ -2507,7 +2507,8 @@
 }
 
 [data-theme="dark"] .selected-recipe-item-content {
-  background: #1e1e1e;
+  background: #2a2a2a;
+  border-color: #3d3d3d;
 }
 
 [data-theme="dark"] .selected-recipe-item.dragging .selected-recipe-item-content {
@@ -3785,11 +3786,11 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
 
-[data-theme="dark"] .section-header {
+[data-theme="dark"] .menu-form-container .section-header {
   border-bottom-color: #3d3d3d;
 }
 
-[data-theme="dark"] .section-header h4 {
+[data-theme="dark"] .menu-form-container .section-header h4 {
   color: #c08060;
 }
 


### PR DESCRIPTION
## Summary
- Dark Mode: Die Dark-Mode-Regeln für `.section-block`/`.section-header`/`h4` (die "Hauptspeise"-Abschnittskarte im Menü) hatten dieselbe CSS-Spezifität wie ihre Light-Pendants (`.menu-form-container .section-block` usw.) und verloren durch die Import-Reihenfolge — die Karte blieb im Dark Mode hell mit dunkler Schrift. Spezifität erhöht, damit die Dark-Mode-Regeln zuverlässig gewinnen.
- `.selected-recipe-item-content` (einzelne Rezept-/Getränkezeile) hatte in beiden Themes exakt dieselbe Hintergrundfarbe wie die umgebende Abschnittskarte, wodurch die Zeilen optisch mit der Karte verschmolzen und ihre abgerundeten Ecken nicht mehr erkennbar waren. Zeilen bekommen jetzt einen eigenen Hintergrund + Rahmen (Weiß/hellgrau bzw. `#2a2a2a` im Dark Mode).
- Der rote Swipe-Löschbereich (`.swipe-delete-background`) war nur an der rechten Zeilenkante gerundet (geerbt vom `overflow:hidden`-Clip der Zeile); die linke Kante, wo Rot an den Rezeptnamen grenzt, war eckig. Border-radius direkt am Löschbereich ergänzt, damit alle vier Ecken rund sind.

Baut auf #3029 auf (bereits gemerged); dieser PR enthält nur die zwei Folge-Commits, die nach dem Merge on top kamen.

## Test plan
- [ ] Menü öffnen, Abschnitt mit Rezepten/Getränken auf Mobile-Breite ansehen
- [ ] Dark Mode aktivieren: Abschnittskarte + Zeilen dunkel, Titel hell
- [ ] Eine Zeile nach links wischen: roter Bereich nur im Icon-Bereich, alle vier Ecken rund


---
_Generated by [Claude Code](https://claude.ai/code/session_01TemgQtUXnTvbQhayKbkM9m)_