### PR TITLE
Rezeptfeld: keine Transparenz mehr bei Hover/Touch über Löschbereich

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -539,6 +539,23 @@
   border-radius: 6px;
 }
 
+/* Square off the two corners that face each other across the field/red
+   seam (the field's right corners, the red area's left corners) so the
+   swiped-open boundary is a flush straight line - rounding both sides
+   there leaves a notch where neither div paints, exposing the page
+   background underneath. The row's own rounded shape still comes through:
+   the field's left corners at rest (clipped by the outer overflow:hidden)
+   and the red area's right corners once fully swiped open. */
+.selected-recipe-item-content {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.selected-recipe-item .swipe-delete-background {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 @media (max-width: 768px) {
   .delete-row-button.selected-recipe-item-delete-btn {
     display: none;

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -505,6 +505,17 @@
   border: 1px solid #402C1C;
 }
 
+/* This field sits directly above the red .swipe-delete-background (unlike
+   e.g. EventsPage's row headers, which nest inside an already-opaque
+   wrapper), so it must opt out of DeleteRowButton.css's shared hover/focus
+   row tint (a low-alpha rgba) with its own solid background rather than
+   `transparent` - otherwise the red swipe-delete area bleeds through on
+   hover/touch instead of staying hidden behind an opaque field. */
+.selected-recipe-item-content.delete-row-hover-target:hover,
+.selected-recipe-item-content.delete-row-hover-target:focus-within {
+  background: #fff;
+}
+
 /* Mobile: the delete button is only revealed via the left-swipe gesture
    (useSwipeToDelete), mirroring the swipe-to-delete used elsewhere (e.g.
    EventsPage's guest/drink rows). Compounded with .delete-row-button so this

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -2516,6 +2516,15 @@
   border-color: #555;
 }
 
+/* See MenuForm.css: this field sits directly above the red
+   .swipe-delete-background, so the shared hover/focus row tint from
+   DeleteRowButton.css must be overridden with a solid color here too,
+   or the red bleeds through on hover/touch. */
+[data-theme="dark"] .selected-recipe-item-content.delete-row-hover-target:hover,
+[data-theme="dark"] .selected-recipe-item-content.delete-row-hover-target:focus-within {
+  background: #2a2a2a;
+}
+
 [data-theme="dark"] .selected-recipes h5 {
   color: #aaa;
 }


### PR DESCRIPTION
.selected-recipe-item-content teilte sich die delete-row-hover-target-Klasse
mit anderen Zeilen, deren Hover-Tint (rgba mit niedrigem Alpha) davon ausgeht,
dass darunter ein bereits blickdichter Container liegt. Hier liegt das Feld
aber direkt über dem roten .swipe-delete-background, wodurch der rote Bereich
bei Hover/Touch durchschimmerte statt vollständig verdeckt zu bleiben.