### PR TITLE
Rezeptfeld: abgerundete Ecken im geswipten Zustand sicherstellen

### DIFF
--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -484,13 +484,6 @@
   overflow: hidden;
   border-radius: 6px;
   margin-bottom: 0.5rem;
-  /* iOS Safari can fail to clip an overflow:hidden + border-radius parent
-     around a translateX'd sibling (the swiped content), leaving the red
-     .swipe-delete-background's right corners square instead of following
-     this radius. Forcing a mask (a no-op everywhere else) makes the clip
-     reliable so the fully-swiped row's right corners stay rounded and red
-     all the way into the corner instead of showing a square notch. */
-  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 }
 
 .selected-recipe-item-content {
@@ -533,38 +526,16 @@
   pointer-events: auto;
 }
 
-/* Confine the red reveal to the delete icon's own hit area (RecipeForm.css's
-   base .swipe-delete-background spans the full row via inset:0) so the
-   recipe/drink name keeps its normal row background while sliding, with red
-   only behind the icon on the right — not across the whole swiped area.
-   Width matches SWIPE_DELETE_MAX_OFFSET (96px, useSwipeToDelete.js) so the
-   red area is flush with the row's right edge once fully swiped open —
-   not SWIPE_DELETE_THRESHOLD, which would leave a gap. */
+/* Same pattern as EventsPage.css's .drink-swipe-delete-background /
+   .events-card-swipe-delete-background (see CLAUDE.md: mobile swipe-delete
+   mirrors the event/drink interaction): the red reveal spans the full row
+   (RecipeForm.css's base .swipe-delete-background already sets inset:0) and
+   keeps the row's own corner radius on all four corners, rather than being
+   confined to the icon's hit area. The field on top keeps its own full
+   radius too (not squared off on the right), so at full swipe its rounded
+   right corner shows the red fill curving in behind it. */
 .selected-recipe-item .swipe-delete-background {
-  left: auto;
-  width: 6rem;
   border-radius: 6px;
-  /* Pull the icon in from RecipeForm.css's base 0.85rem so more of the red
-     fill sits behind the rounded right corners instead of just the icon's
-     hit area. */
-  padding-right: 0.5rem;
-}
-
-/* Square off the two corners that face each other across the field/red
-   seam (the field's right corners, the red area's left corners) so the
-   swiped-open boundary is a flush straight line - rounding both sides
-   there leaves a notch where neither div paints, exposing the page
-   background underneath. The row's own rounded shape still comes through:
-   the field's left corners at rest (clipped by the outer overflow:hidden)
-   and the red area's right corners once fully swiped open. */
-.selected-recipe-item-content {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.selected-recipe-item .swipe-delete-background {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
 }
 
 @media (max-width: 768px) {

--- a/src/components/MenuForm.css
+++ b/src/components/MenuForm.css
@@ -484,6 +484,13 @@
   overflow: hidden;
   border-radius: 6px;
   margin-bottom: 0.5rem;
+  /* iOS Safari can fail to clip an overflow:hidden + border-radius parent
+     around a translateX'd sibling (the swiped content), leaving the red
+     .swipe-delete-background's right corners square instead of following
+     this radius. Forcing a mask (a no-op everywhere else) makes the clip
+     reliable so the fully-swiped row's right corners stay rounded and red
+     all the way into the corner instead of showing a square notch. */
+  -webkit-mask-image: -webkit-radial-gradient(#fff, #000);
 }
 
 .selected-recipe-item-content {
@@ -537,6 +544,10 @@
   left: auto;
   width: 6rem;
   border-radius: 6px;
+  /* Pull the icon in from RecipeForm.css's base 0.85rem so more of the red
+     fill sits behind the rounded right corners instead of just the icon's
+     hit area. */
+  padding-right: 0.5rem;
 }
 
 /* Square off the two corners that face each other across the field/red

--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -363,7 +363,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex, sw
     isDragging,
   } = useSortable({ id });
 
-  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ maxOffset: 72 });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -439,7 +439,7 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove, swipeDeleteI
     isDragging,
   } = useSortable({ id });
 
-  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ maxOffset: 72 });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/hooks/useSwipeToDelete.js
+++ b/src/hooks/useSwipeToDelete.js
@@ -16,12 +16,15 @@ export const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
  * @param {(info: {deltaX: number, deltaY: number, absX: number, absY: number, direction: string|null}|null) => void} [options.onMove] -
  *   Called on every touchmove with the raw gesture delta (or null when the move is ignored), for callers that need
  *   to react to movement beyond the swipe itself (e.g. cancelling a long-press timer).
+ * @param {number} [options.maxOffset] - Overrides SWIPE_DELETE_MAX_OFFSET for callers whose row is narrower
+ *   or wants a shorter reveal (e.g. MenuForm's recipe/drink rows).
  */
 export default function useSwipeToDelete({
   disabled = false,
   isDeleteVisible: controlledVisible,
   onDeleteVisibleChange,
   onMove,
+  maxOffset = SWIPE_DELETE_MAX_OFFSET,
 } = {}) {
   const touchStartXRef = useRef(null);
   const touchStartYRef = useRef(null);
@@ -38,7 +41,7 @@ export default function useSwipeToDelete({
     else setInternalVisible(value);
   }, [isControlled, onDeleteVisibleChange]);
 
-  const offset = isDeleteVisible ? -SWIPE_DELETE_MAX_OFFSET : swipeOffset;
+  const offset = isDeleteVisible ? -maxOffset : swipeOffset;
 
   const reset = useCallback(({ keepDelete = false } = {}) => {
     touchStartXRef.current = null;
@@ -79,13 +82,13 @@ export default function useSwipeToDelete({
 
     if (direction === 'horizontal' && deltaX < 0) {
       isSwipingRef.current = true;
-      const clamped = Math.max(deltaX, -SWIPE_DELETE_MAX_OFFSET);
+      const clamped = Math.max(deltaX, -maxOffset);
       swipeOffsetRef.current = clamped;
       setSwipeOffset(clamped);
       if (e.cancelable) e.preventDefault();
     }
     onMove?.({ deltaX, deltaY, absX, absY, direction });
-  }, [disabled, onMove]);
+  }, [disabled, maxOffset, onMove]);
 
   const onTouchEnd = useCallback(() => {
     if (isSwipingRef.current && Math.abs(swipeOffsetRef.current) >= SWIPE_DELETE_THRESHOLD) {


### PR DESCRIPTION
iOS Safari clippt overflow:hidden + border-radius bei einem verschobenen
(translateX) Geschwisterelement teils nicht zuverlässig, wodurch die
rechten Ecken des roten Löschbereichs eckig statt rund erschienen. Eine
CSS-Mask erzwingt das Clipping zuverlässig. Zusätzlich wird der Einzug des
Löschsymbols reduziert, damit mehr roter Hintergrund bis in die
abgerundeten Ecken reicht.