### PR TITLE
Make Kind and Alkoholische Getränke toggles mutually exclusive

### DIFF
--- a/src/components/GuestManagementPage.js
+++ b/src/components/GuestManagementPage.js
@@ -396,7 +396,14 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
               type="checkbox"
               role="switch"
               checked={form.kind}
-              onChange={(e) => setForm((f) => ({ ...f, kind: e.target.checked }))}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setForm((f) => ({
+                  ...f,
+                  kind: checked,
+                  alkoholischeGetraenke: checked ? false : f.alkoholischeGetraenke,
+                }));
+              }}
             />
             <span>Kind</span>
           </label>
@@ -406,7 +413,14 @@ function GuestManagementPage({ onBack, currentUser, recipes }) {
               type="checkbox"
               role="switch"
               checked={form.alkoholischeGetraenke}
-              onChange={(e) => setForm((f) => ({ ...f, alkoholischeGetraenke: e.target.checked }))}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setForm((f) => ({
+                  ...f,
+                  alkoholischeGetraenke: checked,
+                  kind: checked ? false : f.kind,
+                }));
+              }}
             />
             <span>Alkoholische Getränke</span>
           </label>

--- a/src/components/GuestManagementPage.test.js
+++ b/src/components/GuestManagementPage.test.js
@@ -187,6 +187,24 @@ describe('GuestManagementPage – Bevorzugte Getränke', () => {
     });
   });
 
+  test('enabling Kind disables Alkoholische Getränke and vice versa', () => {
+    openNewGuestForm();
+
+    const kindCheckbox = screen.getByLabelText('Kind');
+    const alkoholCheckbox = screen.getByLabelText('Alkoholische Getränke');
+
+    expect(kindCheckbox).not.toBeChecked();
+    expect(alkoholCheckbox).toBeChecked();
+
+    fireEvent.click(kindCheckbox);
+    expect(kindCheckbox).toBeChecked();
+    expect(alkoholCheckbox).not.toBeChecked();
+
+    fireEvent.click(alkoholCheckbox);
+    expect(alkoholCheckbox).toBeChecked();
+    expect(kindCheckbox).not.toBeChecked();
+  });
+
   test('shows a category dropdown with standard drink categories', () => {
     openNewGuestForm();
     const categorySelect = screen.getByRole('combobox', { name: 'Getränkekategorie auswählen' });


### PR DESCRIPTION
Activating one on a guest profile now deactivates the other, since a
child guest shouldn't be flagged for alcoholic drinks and vice versa.