### PR TITLE
Rezept direkt nach KI-Analyse importieren statt Zwischenschritt anzuzeigen

### DIFF
--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './OcrScanModal.css';
 import { recognizeText } from '../utils/ocrService';
-import { parseOcrTextSmart, extractKulinarikFromTags } from '../utils/ocrParser';
+import { parseOcrTextSmart, buildRecipeFromAiResult } from '../utils/ocrParser';
 import { getValidationSummary } from '../utils/ocrValidation';
 import { fileToBase64 } from '../utils/imageUtils';
 import { recognizeRecipeWithAI } from '../utils/aiOcrService';
@@ -12,7 +12,7 @@ const MAX_CAMERA_PHOTOS = 10;
 // initialImages: array of base64 images to pre-fill the image-preview step
 function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [] }) {
   // initialImage starts OCR immediately; initialImages shows the preview step; neither → upload step
-  const [step, setStep] = useState(initialImage ? 'scan' : (initialImages.length > 0 ? 'image-preview' : 'upload')); // 'upload', 'scan', 'edit', 'ai-result', 'batch-processing', 'image-preview'
+  const [step, setStep] = useState(initialImage ? 'scan' : (initialImages.length > 0 ? 'image-preview' : 'upload')); // 'upload', 'scan', 'edit', 'batch-processing', 'image-preview'
   // imageBase64 tracks the current image but OCR functions receive it directly as parameter
   // This state is maintained for potential future features (e.g., image preview, retry)
   // eslint-disable-next-line no-unused-vars
@@ -24,14 +24,12 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
   const [error, setError] = useState('');
   const [cameraActive, setCameraActive] = useState(false);
   const [ocrMode, setOcrMode] = useState('ai'); // 'standard' or 'ai'
-  const [aiResult, setAiResult] = useState(null);
   const [validationResult, setValidationResult] = useState(null);
   const [remainingScans, setRemainingScans] = useState(null);
   const [aiFailed, setAiFailed] = useState(false);
   const [lastImageForRetry, setLastImageForRetry] = useState(null);
   const [uploadedImages, setUploadedImages] = useState(initialImages.length > 0 ? [...initialImages] : []);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  const [allOcrResults, setAllOcrResults] = useState([]);
   const [capturedPhotos, setCapturedPhotos] = useState([]);
   
   const videoRef = useRef(null);
@@ -103,7 +101,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     if (uploadedImages.length === 0) return;
     const images = [...uploadedImages];
     setCurrentImageIndex(0);
-    setAllOcrResults([]);
     setStep('batch-processing');
     await processBase64Batch(images);
   };
@@ -297,8 +294,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
       }
     }
 
-    setAllOcrResults(results);
-
     const allFailed = results.every(r => r.error);
     if (allFailed) {
       // Use the first individual error message (consistent with single-image performOcr)
@@ -321,8 +316,7 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
       const merged = mergeOcrResults(results, ocrMode);
 
       if (ocrMode === 'ai') {
-        setAiResult(merged);
-        setStep('ai-result');
+        onImport(buildRecipeFromAiResult(merged));
       } else {
         setOcrText(merged.text);
         setStep('edit');
@@ -340,7 +334,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     const photos = [...capturedPhotos];
     stopCamera();
     setCurrentImageIndex(0);
-    setAllOcrResults([]);
     setUploadedImages(photos);
     setStep('batch-processing');
     await processBase64Batch(photos);
@@ -387,8 +380,7 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
           setRemainingScans(result.remainingScans);
         }
 
-        setAiResult(result);
-        setStep('ai-result');
+        onImport(buildRecipeFromAiResult(result));
       } else {
         // Standard OCR using Tesseract
         const langCode = language === 'de' ? 'deu' : 'eng';
@@ -448,41 +440,9 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     }
   };
 
-  // Handle import of OCR text
+  // Handle import of OCR text (standard/text mode; AI results import immediately after analysis)
   const handleImport = () => {
     setError('');
-
-    // AI result import
-    if (step === 'ai-result' && aiResult) {
-      try {
-        // Parse time values more robustly
-        const parseTime = (timeStr) => {
-          if (!timeStr) return 0;
-          const numMatch = String(timeStr).match(/\d+/);
-          return numMatch ? parseInt(numMatch[0], 10) : 0;
-        };
-
-        const kulinarikFromCuisine = aiResult.cuisine ? [aiResult.cuisine] : [];
-        const kulinarikFromTags = extractKulinarikFromTags(aiResult.tags || []);
-        const kulinarikSet = new Set(kulinarikFromCuisine);
-        kulinarikFromTags.forEach(k => kulinarikSet.add(k));
-
-        const recipe = {
-          title: aiResult.title || '',
-          ingredients: aiResult.ingredients || [],
-          steps: aiResult.steps || [],
-          portionen: aiResult.servings || 4,
-          kochdauer: parseTime(aiResult.prepTime) || parseTime(aiResult.cookTime) || 30,
-          kulinarik: [...kulinarikSet],
-          schwierigkeit: aiResult.difficulty || 3,
-          speisekategorie: aiResult.category || '',
-        };
-        onImport(recipe);
-      } catch (err) {
-        setError(err.message);
-      }
-      return;
-    }
 
     // Standard text import with validation
     if (!ocrText.trim()) {
@@ -529,14 +489,12 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     setImageBase64('');
     setOcrText('');
     setError('');
-    setAiResult(null);
     setOcrMode('ai');
     setValidationResult(null);
     setAiFailed(false);
     setLastImageForRetry(null);
     setUploadedImages([]);
     setCurrentImageIndex(0);
-    setAllOcrResults([]);
     setCapturedPhotos([]);
   };
 
@@ -544,63 +502,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
   const handleCancel = () => {
     stopCamera();
     onCancel();
-  };
-
-  // Convert AI result to text format for editing
-  const convertAiResultToText = () => {
-    if (!aiResult) return;
-
-    let text = '';
-    
-    // Title
-    if (aiResult.title) {
-      text += aiResult.title + '\n\n';
-    }
-
-    // Meta information
-    if (aiResult.servings) {
-      text += `Portionen: ${aiResult.servings}\n`;
-    }
-    if (aiResult.prepTime || aiResult.cookTime) {
-      const time = aiResult.prepTime || aiResult.cookTime;
-      text += `Zeit: ${time}\n`;
-    }
-    if (aiResult.difficulty) {
-      text += `Schwierigkeit: ${aiResult.difficulty}\n`;
-    }
-    if (aiResult.cuisine) {
-      text += `Kulinarik: ${aiResult.cuisine}\n`;
-    }
-    if (aiResult.category) {
-      text += `Kategorie: ${aiResult.category}\n`;
-    }
-    text += '\n';
-
-    // Ingredients
-    if (aiResult.ingredients && aiResult.ingredients.length > 0) {
-      text += 'Zutaten\n\n';
-      aiResult.ingredients.forEach(ingredient => {
-        text += ingredient + '\n';
-      });
-      text += '\n';
-    }
-
-    // Steps
-    if (aiResult.steps && aiResult.steps.length > 0) {
-      text += 'Zubereitung\n\n';
-      aiResult.steps.forEach((step, index) => {
-        text += `${index + 1}. ${step}\n`;
-      });
-      text += '\n';
-    }
-
-    // Notes
-    if (aiResult.notes) {
-      text += `Notizen: ${aiResult.notes}\n`;
-    }
-
-    setOcrText(text.trim());
-    setStep('edit');
   };
 
   return (
@@ -855,74 +756,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
             </div>
           )}
 
-          {/* AI Result Step */}
-          {step === 'ai-result' && aiResult && (
-            <div className={`ai-result-section${allOcrResults.length > 1 ? ' merged' : ''}`}>
-              <p className="ocr-instructions">
-                KI-Analyse abgeschlossen - Überprüfen Sie die erkannten Daten
-              </p>
-
-              <h3 className="ai-result-title">{aiResult.title || 'Unbenanntes Rezept'}</h3>
-
-              {(aiResult.servings || aiResult.prepTime || aiResult.cookTime || aiResult.difficulty || aiResult.cuisine || aiResult.category) && (
-                <div className="ai-result-meta">
-                  {aiResult.servings && (
-                    <span className="ai-meta-badge">{aiResult.servings} Portionen</span>
-                  )}
-                  {(aiResult.prepTime || aiResult.cookTime) && (
-                    <span className="ai-meta-badge">{aiResult.prepTime || aiResult.cookTime}</span>
-                  )}
-                  {aiResult.difficulty && (
-                    <span className="ai-meta-badge">Schwierigkeit: {aiResult.difficulty}/5</span>
-                  )}
-                  {aiResult.cuisine && (
-                    <span className="ai-meta-badge">{aiResult.cuisine}</span>
-                  )}
-                  {aiResult.category && (
-                    <span className="ai-meta-badge">{aiResult.category}</span>
-                  )}
-                </div>
-              )}
-
-              {aiResult.ingredients && aiResult.ingredients.length > 0 && (
-                <div className="ai-result-ingredients">
-                  <h4>Zutaten</h4>
-                  <ul>
-                    {aiResult.ingredients.map((ingredient, index) => (
-                      <li key={index}>{ingredient}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {aiResult.steps && aiResult.steps.length > 0 && (
-                <div className="ai-result-steps">
-                  <h4>Zubereitung</h4>
-                  <ol>
-                    {aiResult.steps.map((step, index) => (
-                      <li key={index}>{step}</li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-
-              {aiResult.tags && aiResult.tags.length > 0 && (
-                <div className="ai-result-tags">
-                  <h4>Tags</h4>
-                  <div className="ai-tags-list">
-                    {aiResult.tags.map((tag, index) => (
-                      <span key={index} className="ai-tag">{tag}</span>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              <button className="edit-text-button" onClick={convertAiResultToText}>
-                Als Text bearbeiten
-              </button>
-            </div>
-          )}
-
           {/* Edit Step */}
           {step === 'edit' && (
             <div className="edit-section">
@@ -993,7 +826,7 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
             Abbrechen
           </button>
           
-          {(step === 'edit' || step === 'ai-result') && (
+          {step === 'edit' && (
             <button className="import-button" onClick={handleImport}>
               Übernehmen
             </button>

--- a/src/components/OcrScanModal.test.js
+++ b/src/components/OcrScanModal.test.js
@@ -15,7 +15,8 @@ jest.mock('../utils/ocrService', () => ({
 jest.mock('../utils/ocrParser', () => ({
   parseOcrText: jest.fn(),
   parseOcrTextSmart: jest.fn(),
-  extractKulinarikFromTags: jest.requireActual('../utils/ocrParser').extractKulinarikFromTags
+  extractKulinarikFromTags: jest.requireActual('../utils/ocrParser').extractKulinarikFromTags,
+  buildRecipeFromAiResult: jest.requireActual('../utils/ocrParser').buildRecipeFromAiResult
 }));
 
 // Mock the OCR validation
@@ -100,9 +101,11 @@ describe('OcrScanModal', () => {
     // Start analysis
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    // OCR should complete and show results
+    // OCR should complete and import the recipe directly, without a review step
     await waitFor(() => {
-      expect(screen.getByText('Test Recipe')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Test Recipe' })
+      );
     }, { timeout: OCR_TIMEOUT });
   });
 
@@ -120,12 +123,12 @@ describe('OcrScanModal', () => {
     expect(englishButton).toHaveClass('active');
   });
 
-  test('import button parses OCR text and calls onImport', async () => {
+  test('AI OCR result is imported automatically once analysis completes', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
+
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    
+
     const mockAiResult = {
       title: 'Test Recipe',
       ingredients: ['200g Zutat'],
@@ -133,7 +136,7 @@ describe('OcrScanModal', () => {
       servings: 4,
       prepTime: '30 min'
     };
-    
+
     recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
 
     render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
@@ -148,24 +151,19 @@ describe('OcrScanModal', () => {
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
+    // Verify AI import was called without any review/confirm step
     await waitFor(() => {
-      expect(screen.getByText('Übernehmen')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith({
+        title: 'Test Recipe',
+        ingredients: ['200g Zutat'],
+        steps: ['Mix'],
+        portionen: 4,
+        kochdauer: 30,
+        kulinarik: [],
+        schwierigkeit: 3,
+        speisekategorie: ''
+      });
     }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
-
-    // Verify AI import was called
-    expect(mockOnImport).toHaveBeenCalledWith({
-      title: 'Test Recipe',
-      ingredients: ['200g Zutat'],
-      steps: ['Mix'],
-      portionen: 4,
-      kochdauer: 30,
-      kulinarik: [],
-      schwierigkeit: 3,
-      speisekategorie: ''
-    });
   });
 
   test('displays error when AI OCR returns empty results', async () => {
@@ -191,64 +189,18 @@ describe('OcrScanModal', () => {
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
+    // AI results are imported as-is, even if empty (with defaults) — no review step needed
     await waitFor(() => {
-      expect(screen.getByText('Übernehmen')).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
-
-    // AI results are imported as-is, even if empty (with defaults)
-    expect(mockOnImport).toHaveBeenCalledWith({
-      title: '',
-      ingredients: [],
-      steps: [],
-      portionen: 4,
-      kochdauer: 30,
-      kulinarik: [],
-      schwierigkeit: 3,
-      speisekategorie: ''
-    });
-  });
-
-  test('editable textarea allows text modification', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Original Text',
-      ingredients: ['Ingredient'],
-      steps: ['Step'],
-      servings: 4
-    });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(screen.getByText('Original Text')).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-
-    // Convert to text editing mode
-    const editButton = screen.getByText(/Als Text bearbeiten/i);
-    fireEvent.click(editButton);
-
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText('Erkannter Text...');
-      expect(textarea).toBeInTheDocument();
-      
-      fireEvent.change(textarea, { target: { value: 'Modified Text' } });
-      expect(textarea).toHaveValue('Modified Text');
+      expect(mockOnImport).toHaveBeenCalledWith({
+        title: '',
+        ingredients: [],
+        steps: [],
+        portionen: 4,
+        kochdauer: 30,
+        kulinarik: [],
+        schwierigkeit: 3,
+        speisekategorie: ''
+      });
     }, { timeout: OCR_TIMEOUT });
   });
 
@@ -316,61 +268,17 @@ describe('OcrScanModal', () => {
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
     await waitFor(() => {
-      expect(screen.getByText('Übernehmen')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith({
+        title: 'Test',
+        ingredients: ['Ingredient'],
+        steps: ['Step'],
+        portionen: 4,
+        kochdauer: 30,
+        kulinarik: [],
+        schwierigkeit: 3,
+        speisekategorie: ''
+      });
     }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
-
-    expect(mockOnImport).toHaveBeenCalledWith({
-      title: 'Test',
-      ingredients: ['Ingredient'],
-      steps: ['Step'],
-      portionen: 4,
-      kochdauer: 30,
-      kulinarik: [],
-      schwierigkeit: 3,
-      speisekategorie: ''
-    });
-  });
-
-  test('new scan button is available after OCR completes', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Test Recipe',
-      ingredients: ['Ingredient'],
-      steps: ['Step']
-    });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    // Wait for OCR to complete and results to show
-    await waitFor(() => {
-      expect(screen.getByText('Test Recipe')).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-
-    // Convert to text editing mode to see "Neuer Scan" button
-    const editButton = screen.getByText(/Als Text bearbeiten/i);
-    fireEvent.click(editButton);
-
-    // Verify that "Neuer Scan" button exists and is available
-    await waitFor(() => {
-      const newScanButton = screen.getByText(/Neuer Scan/i);
-      expect(newScanButton).toBeInTheDocument();
-    });
   });
 
   test('progress callback is passed to recognizeRecipeWithAI', async () => {
@@ -504,13 +412,13 @@ describe('OcrScanModal', () => {
     });
   });
 
-  test('AI OCR mode processes image with Gemini by default', async () => {
+  test('AI OCR mode processes image with Gemini and imports the result directly', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
+
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
     isAiOcrAvailable.mockReturnValue(true);
-    
+
     const mockAiResult = {
       title: 'AI-erkanntes Rezept',
       servings: 4,
@@ -537,21 +445,23 @@ describe('OcrScanModal', () => {
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    // Should display AI result after analysis
+    // Should import directly after analysis, without a review step
     await waitFor(() => {
-      expect(screen.getByText('AI-erkanntes Rezept')).toBeInTheDocument();
-      expect(screen.getByText(/200g Pasta/i)).toBeInTheDocument();
-      expect(screen.getByText(/Pasta kochen/i)).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'AI-erkanntes Rezept',
+        ingredients: ['200g Pasta', '100g Tomaten'],
+        steps: ['Pasta kochen', 'Mit Tomaten servieren']
+      }));
     }, { timeout: OCR_TIMEOUT });
   });
 
   test('AI result can be imported directly', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
+
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
     isAiOcrAvailable.mockReturnValue(true);
-    
+
     const mockAiResult = {
       title: 'Testrezept',
       servings: 2,
@@ -577,22 +487,17 @@ describe('OcrScanModal', () => {
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
     await waitFor(() => {
-      expect(screen.getByText('Testrezept')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith({
+        title: 'Testrezept',
+        ingredients: ['100g Zucker'],
+        steps: ['Zucker schmelzen'],
+        portionen: 2,
+        kochdauer: 20,
+        kulinarik: ['Deutsch'],
+        schwierigkeit: 2,
+        speisekategorie: 'Dessert'
+      });
     }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
-
-    expect(mockOnImport).toHaveBeenCalledWith({
-      title: 'Testrezept',
-      ingredients: ['100g Zucker'],
-      steps: ['Zucker schmelzen'],
-      portionen: 2,
-      kochdauer: 20,
-      kulinarik: ['Deutsch'],
-      schwierigkeit: 2,
-      speisekategorie: 'Dessert'
-    });
   });
 
   test('AI result adds vegetarisch and vegan tags to kulinarik', async () => {
@@ -628,15 +533,10 @@ describe('OcrScanModal', () => {
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
     await waitFor(() => {
-      expect(screen.getByText('Veganer Salat')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith(expect.objectContaining({
+        kulinarik: expect.arrayContaining(['Mediterran', 'Vegan', 'Vegetarisch'])
+      }));
     }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
-
-    expect(mockOnImport).toHaveBeenCalledWith(expect.objectContaining({
-      kulinarik: expect.arrayContaining(['Mediterran', 'Vegan', 'Vegetarisch'])
-    }));
   });
 
   test('AI result does not duplicate kulinarik when tag matches cuisine', async () => {
@@ -672,61 +572,11 @@ describe('OcrScanModal', () => {
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
     await waitFor(() => {
-      expect(screen.getByText('Veggie Burger')).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalled();
     }, { timeout: OCR_TIMEOUT });
-
-    const importButton = screen.getByText('Übernehmen');
-    fireEvent.click(importButton);
 
     const calledWith = mockOnImport.mock.calls[0][0];
     expect(calledWith.kulinarik.filter(k => k === 'Vegetarisch')).toHaveLength(1);
-  });
-
-  test('AI result can be converted to text for editing', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
-    
-    const mockAiResult = {
-      title: 'Kuchen',
-      servings: 8,
-      prepTime: '45 min',
-      difficulty: 3,
-      cuisine: 'International',
-      category: 'Dessert',
-      ingredients: ['200g Mehl', '100g Zucker'],
-      steps: ['Teig mischen', 'Backen']
-    };
-    recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(screen.getByText('Kuchen')).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-
-    const editButton = screen.getByText(/Als Text bearbeiten/i);
-    fireEvent.click(editButton);
-
-    await waitFor(() => {
-      const textarea = screen.getByPlaceholderText('Erkannter Text...');
-      expect(textarea).toBeInTheDocument();
-      expect(textarea.value).toContain('Kuchen');
-      expect(textarea.value).toContain('200g Mehl');
-      expect(textarea.value).toContain('Teig mischen');
-    });
   });
 
   test('handles AI OCR error gracefully', async () => {
@@ -804,7 +654,7 @@ describe('OcrScanModal', () => {
     }, { timeout: OCR_TIMEOUT });
   });
 
-  test('displays remaining scans info when AI scan succeeds', async () => {
+  test('AI import includes the recipe data even when remainingScans is reported', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
 
@@ -831,18 +681,9 @@ describe('OcrScanModal', () => {
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
     await waitFor(() => {
-      expect(screen.getByText('Test Recipe')).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-
-    // Reset to upload step to see quota info
-    const editButton = screen.getByText(/Als Text bearbeiten/i);
-    fireEvent.click(editButton);
-
-    const newScanButton = screen.getByText(/Neuer Scan/i);
-    fireEvent.click(newScanButton);
-
-    await waitFor(() => {
-      expect(screen.getByText(/3 KI-Scans/i)).toBeInTheDocument();
+      expect(mockOnImport).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Test Recipe' })
+      );
     }, { timeout: OCR_TIMEOUT });
   });
 
@@ -1038,12 +879,12 @@ describe('OcrScanModal', () => {
       // Start analysis
       fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
+      // Should import the recipe directly, without a review step
       await waitFor(() => {
-        expect(screen.getByText('Kamera Rezept')).toBeInTheDocument();
+        expect(mockOnImport).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Kamera Rezept' })
+        );
       }, { timeout: OCR_TIMEOUT });
-
-      // Should show import button
-      expect(screen.getByText('Übernehmen')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/UniversalImportModal.js
+++ b/src/components/UniversalImportModal.js
@@ -3,7 +3,7 @@ import './UniversalImportModal.css';
 import { fileToBase64 } from '../utils/imageUtils';
 import { recognizeRecipeWithAI } from '../utils/aiOcrService';
 import { captureWebsiteScreenshot } from '../utils/webImportService';
-import { extractKulinarikFromTags } from '../utils/ocrParser';
+import { buildRecipeFromAiResult } from '../utils/ocrParser';
 
 function buildInitialText(title, text) {
   return [title, text].filter(Boolean).join('\n\n');
@@ -13,10 +13,9 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
   const [images, setImages] = useState(initialImages);
   const [text, setText] = useState(buildInitialText(initialTitle, initialText));
   const [url, setUrl] = useState(initialUrl);
-  const [step, setStep] = useState('preview'); // 'preview' | 'processing' | 'result'
+  const [step, setStep] = useState('preview'); // 'preview' | 'processing'
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [scanProgress, setScanProgress] = useState(0);
-  const [aiResult, setAiResult] = useState(null);
   const [error, setError] = useState('');
   const [processingLabel, setProcessingLabel] = useState('');
 
@@ -181,42 +180,10 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
 
     try {
       const merged = mergeAiResults(results);
-      setAiResult(merged);
-      setStep('result');
+      onImport(buildRecipeFromAiResult(merged));
     } catch (err) {
       setError(err.message);
       setStep('preview');
-    }
-  };
-
-  const handleImport = () => {
-    if (!aiResult) return;
-    setError('');
-    try {
-      const parseTime = (timeStr) => {
-        if (!timeStr) return 0;
-        const numMatch = String(timeStr).match(/\d+/);
-        return numMatch ? parseInt(numMatch[0], 10) : 0;
-      };
-
-      const kulinarikFromCuisine = aiResult.cuisine ? [aiResult.cuisine] : [];
-      const kulinarikFromTags = extractKulinarikFromTags(aiResult.tags || []);
-      const kulinarikSet = new Set(kulinarikFromCuisine);
-      kulinarikFromTags.forEach(k => kulinarikSet.add(k));
-
-      const recipe = {
-        title: aiResult.title || '',
-        ingredients: aiResult.ingredients || [],
-        steps: aiResult.steps || [],
-        portionen: aiResult.servings || 4,
-        kochdauer: parseTime(aiResult.prepTime) || parseTime(aiResult.cookTime) || 30,
-        kulinarik: [...kulinarikSet],
-        schwierigkeit: aiResult.difficulty || 3,
-        speisekategorie: aiResult.category || '',
-      };
-      onImport(recipe);
-    } catch (err) {
-      setError(err.message);
     }
   };
 
@@ -339,56 +306,6 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
             </div>
           )}
 
-          {/* Result Step */}
-          {step === 'result' && aiResult && (
-            <div className="universal-result">
-              {totalItems > 1 && (
-                <div className="universal-merged-notice">
-                  Aus {totalItems} Inhalten zusammengeführt
-                </div>
-              )}
-              {aiResult.title && (
-                <h3 className="universal-result-title">{aiResult.title}</h3>
-              )}
-              <div className="universal-result-meta">
-                {aiResult.servings && (
-                  <span className="universal-meta-badge">{aiResult.servings} Portionen</span>
-                )}
-                {(aiResult.prepTime || aiResult.cookTime) && (
-                  <span className="universal-meta-badge">
-                    {aiResult.prepTime || aiResult.cookTime}
-                  </span>
-                )}
-                {aiResult.difficulty && (
-                  <span className="universal-meta-badge">Schwierigkeit: {aiResult.difficulty}</span>
-                )}
-                {aiResult.cuisine && (
-                  <span className="universal-meta-badge">{aiResult.cuisine}</span>
-                )}
-              </div>
-              {aiResult.ingredients && aiResult.ingredients.length > 0 && (
-                <div className="universal-result-section">
-                  <h4>Zutaten</h4>
-                  <ul>
-                    {aiResult.ingredients.map((ing, i) => (
-                      <li key={i}>{ing}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {aiResult.steps && aiResult.steps.length > 0 && (
-                <div className="universal-result-section">
-                  <h4>Zubereitung</h4>
-                  <ol>
-                    {aiResult.steps.map((s, i) => (
-                      <li key={i}>{s}</li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-              {error && <div className="universal-error">{error}</div>}
-            </div>
-          )}
         </div>
 
         <div className="universal-import-actions">
@@ -403,22 +320,6 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
             >
               Analyse starten
             </button>
-          )}
-          {step === 'result' && (
-            <>
-              <button
-                className="universal-back-button"
-                onClick={() => setStep('preview')}
-              >
-                ← Zurück
-              </button>
-              <button
-                className="universal-import-button"
-                onClick={handleImport}
-              >
-                ✓ Rezept importieren
-              </button>
-            </>
           )}
         </div>
       </div>

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -9,14 +9,13 @@ import {
   importInstagramReel,
   importRecipeFromUrl,
 } from '../utils/webImportService';
-import { extractKulinarikFromTags } from '../utils/ocrParser';
+import { buildRecipeFromAiResult } from '../utils/ocrParser';
 
 function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) {
-  const [step, setStep] = useState('url'); // 'url', 'loading', 'result'
+  const [step, setStep] = useState('url'); // 'url', 'loading'
   const [url, setUrl] = useState(() => normalizeImportedUrl(initialUrl));
   const [error, setError] = useState('');
   const [progress, setProgress] = useState(0);
-  const [aiResult, setAiResult] = useState(null);
 
   useEffect(() => {
     setUrl(normalizeImportedUrl(initialUrl));
@@ -65,8 +64,7 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
       }
 
       setProgress(100);
-      setAiResult(result);
-      setStep('result');
+      onImport(buildRecipeFromAiResult(result, authorId));
     } catch (err) {
       console.error('Web import error:', err);
       setError(err.message || 'Fehler beim Importieren der Website');
@@ -77,53 +75,6 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
 
   // Handle URL submission from the form
   const handleSubmit = () => submitUrl(url);
-
-  // Handle import of AI result
-  const handleImport = () => {
-    if (!aiResult) {
-      setError('Keine Daten zum Importieren verfügbar');
-      return;
-    }
-
-    try {
-      // Parse time values more robustly
-      const parseTime = (timeStr) => {
-        if (!timeStr) return 0;
-        const numMatch = String(timeStr).match(/\d+/);
-        return numMatch ? parseInt(numMatch[0], 10) : 0;
-      };
-
-      const kulinarikFromCuisine = aiResult.cuisine ? [aiResult.cuisine] : [];
-      const kulinarikFromTags = extractKulinarikFromTags(aiResult.tags || []);
-      const kulinarikSet = new Set(kulinarikFromCuisine);
-      kulinarikFromTags.forEach(k => kulinarikSet.add(k));
-
-      const recipe = {
-        title: aiResult.title || '',
-        ingredients: aiResult.ingredients || [],
-        steps: aiResult.steps || [],
-        portionen: aiResult.servings || 4,
-        kochdauer: parseTime(aiResult.prepTime) || parseTime(aiResult.cookTime) || 30,
-        kulinarik: [...kulinarikSet],
-        schwierigkeit: aiResult.difficulty || 3,
-        speisekategorie: aiResult.category || '',
-        ...(authorId ? { authorId } : {}),
-      };
-      
-      onImport(recipe);
-    } catch (err) {
-      setError(err.message);
-    }
-  };
-
-  // Handle reset
-  const handleReset = () => {
-    setStep('url');
-    setUrl('');
-    setError('');
-    setProgress(0);
-    setAiResult(null);
-  };
 
   // Auto-submit when initialUrl is provided and valid
   useEffect(() => {
@@ -200,67 +151,6 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
             </div>
           )}
 
-          {/* Result Step */}
-          {step === 'result' && aiResult && (
-            <div className="result-section">
-              <p className="web-import-instructions">
-                Analyse abgeschlossen - Überprüfe die erkannten Daten
-              </p>
-
-              <div className="source-url">
-                <strong>Quelle:</strong> <a href={url} target="_blank" rel="noopener noreferrer">{url}</a>
-              </div>
-
-              <h3 className="result-title">{aiResult.title || 'Unbenanntes Rezept'}</h3>
-
-              {(aiResult.servings || aiResult.prepTime || aiResult.cookTime || aiResult.difficulty || aiResult.cuisine || aiResult.category) && (
-                <div className="result-meta">
-                  {aiResult.servings && (
-                    <span className="meta-badge">{aiResult.servings} Portionen</span>
-                  )}
-                  {(aiResult.prepTime || aiResult.cookTime) && (
-                    <span className="meta-badge">{aiResult.prepTime || aiResult.cookTime}</span>
-                  )}
-                  {aiResult.difficulty && (
-                    <span className="meta-badge">Schwierigkeit: {aiResult.difficulty}/5</span>
-                  )}
-                  {aiResult.cuisine && (
-                    <span className="meta-badge">{aiResult.cuisine}</span>
-                  )}
-                  {aiResult.category && (
-                    <span className="meta-badge">{aiResult.category}</span>
-                  )}
-                </div>
-              )}
-
-              {aiResult.ingredients && aiResult.ingredients.length > 0 && (
-                <div className="result-ingredients">
-                  <h4>Zutaten</h4>
-                  <ul>
-                    {aiResult.ingredients.map((ingredient, index) => (
-                      <li key={index}>{ingredient}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {aiResult.steps && aiResult.steps.length > 0 && (
-                <div className="result-steps">
-                  <h4>Zubereitung</h4>
-                  <ol>
-                    {aiResult.steps.map((step, index) => (
-                      <li key={index}>{step}</li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-
-              <button className="new-import-button" onClick={handleReset}>
-                ↻ Neue URL importieren
-              </button>
-            </div>
-          )}
-
           {error && (
             <div className="web-import-error">
               {error}
@@ -276,12 +166,6 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
           {step === 'url' && (
             <button className="submit-button" onClick={handleSubmit}>
               Weiter
-            </button>
-          )}
-
-          {step === 'result' && (
-            <button className="import-button" onClick={handleImport}>
-              Übernehmen
             </button>
           )}
         </div>

--- a/src/utils/ocrParser.js
+++ b/src/utils/ocrParser.js
@@ -125,6 +125,38 @@ export function extractKulinarikFromTags(tags) {
 }
 
 /**
+ * Convert an AI OCR/import result (from recognizeRecipeWithAI, web import, etc.)
+ * into the recipe object shape expected by RecipeForm's handleImport().
+ * @param {Object} aiResult - Raw AI result (title, ingredients, steps, servings, ...)
+ * @param {string} [authorId] - Optional author id to attach to the recipe
+ * @returns {Object} - Recipe object ready for onImport()
+ */
+export function buildRecipeFromAiResult(aiResult, authorId = '') {
+  const parseTime = (timeStr) => {
+    if (!timeStr) return 0;
+    const numMatch = String(timeStr).match(/\d+/);
+    return numMatch ? parseInt(numMatch[0], 10) : 0;
+  };
+
+  const kulinarikFromCuisine = aiResult.cuisine ? [aiResult.cuisine] : [];
+  const kulinarikFromTags = extractKulinarikFromTags(aiResult.tags || []);
+  const kulinarikSet = new Set(kulinarikFromCuisine);
+  kulinarikFromTags.forEach(k => kulinarikSet.add(k));
+
+  return {
+    title: aiResult.title || '',
+    ingredients: aiResult.ingredients || [],
+    steps: aiResult.steps || [],
+    portionen: aiResult.servings || 4,
+    kochdauer: parseTime(aiResult.prepTime) || parseTime(aiResult.cookTime) || 30,
+    kulinarik: [...kulinarikSet],
+    schwierigkeit: aiResult.difficulty || 3,
+    speisekategorie: aiResult.category || '',
+    ...(authorId ? { authorId } : {}),
+  };
+}
+
+/**
  * Parse OCR text into structured recipe data
  * @param {string} text - OCR-recognized text
  * @param {string} lang - Language code ('de' or 'en'), optional


### PR DESCRIPTION
URL-Import, Foto-OCR-Scan und der Universal-Import (Web-Share-Target)
zeigten nach der KI-Analyse einen reinen Lesevorschau-Screen, bevor der
Nutzer per Klick auf "Übernehmen" ins (ohnehin voll editierbare)
Rezeptformular gelangte. Dieser Zwischenschritt war technisch nicht
notwendig - er diente nur als Bestätigungs-Gate. Die Ergebnisse werden
jetzt direkt nach Abschluss der Analyse importiert, der Nutzer landet
sofort im editierbaren Formular.

Die gemeinsame Recipe-Objekt-Erstellung aus einem KI-Ergebnis wurde nach
buildRecipeFromAiResult() in ocrParser.js ausgelagert, da sie zuvor
dreifach dupliziert war.