### PR TITLE
Pillendarstellung für Bottom Navigation (Kochbuch/Festtafel/Atelier)

### DIFF
--- a/src/App.auth.test.js
+++ b/src/App.auth.test.js
@@ -517,9 +517,7 @@ describe('App authentication view handling', () => {
     expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
   });
 
-  test('bottom navigation auto-hides on recipe scrolling and hides immediately in atelier mode', async () => {
-    jest.useFakeTimers();
-
+  test('bottom navigation stays visible while scrolling in Kochbuch and hides immediately in atelier mode', async () => {
     render(<App />);
     expect(await screen.findByTestId('login-view')).toBeInTheDocument();
 
@@ -542,22 +540,13 @@ describe('App authentication view handling', () => {
     fireEvent.click(navQueries.getByRole('button', { name: 'Kochbuch' }));
     expect(nav).toHaveAttribute('data-visible', 'true');
 
+    // Kochbuch switches to the compact pill representation, so the full bar
+    // crossfades out but stays mounted (and "visible" in the isVisible sense).
+    expect(nav.className).toContain('bottom-navigation--crossfaded');
+
     await act(async () => {
       window.scrollY = 24;
       window.dispatchEvent(new Event('scroll'));
-    });
-    expect(nav).toHaveAttribute('data-visible', 'false');
-
-    await act(async () => {
-      window.scrollY = 10;
-      window.dispatchEvent(new Event('scroll'));
-    });
-    expect(nav).toHaveAttribute('data-visible', 'true');
-
-    await act(async () => {
-      window.scrollY = 30;
-      window.dispatchEvent(new Event('scroll'));
-      jest.advanceTimersByTime(2000);
     });
     expect(nav).toHaveAttribute('data-visible', 'true');
 
@@ -565,8 +554,6 @@ describe('App authentication view handling', () => {
     fireEvent.click(navQueries.getByRole('button', { name: 'Atelier' }));
     expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
     expect(nav).toHaveAttribute('data-visible', 'false');
-
-    jest.useRealTimers();
   });
 
   test('atelier opens directly without onboarding overlay when global onboarding testmode is disabled', async () => {

--- a/src/App.js
+++ b/src/App.js
@@ -315,9 +315,7 @@ function getBottomNavActiveKey(currentView) {
 }
 
 function getBottomNavBehavior(currentView) {
-  if (currentView === 'startseite') return 'visible';
   if (currentView === 'tagesmenu' || currentView === 'atelierCategorySelection' || currentView === 'events') return 'hidden';
-  if (['recipes', 'seasonalRecipes', 'trendingRecipes', 'menus', 'groups'].includes(currentView)) return 'auto';
   return 'visible';
 }
 
@@ -351,8 +349,6 @@ function App() {
   const [allUsers, setAllUsers] = useState([]);
   const [headerVisible, setHeaderVisible] = useState(true);
   const headerRef = useRef(null);
-  const bottomNavTimeoutRef = useRef(null);
-  const bottomNavLastScrollYRef = useRef(0);
   const [kuecheOpenPersonalData, setKuecheOpenPersonalData] = useState(false);
   const [appCallsActiveTab, setAppCallsActiveTab] = useState('app');
   const [appCallsVisibleTabs, setAppCallsVisibleTabs] = useState(null);
@@ -1159,60 +1155,8 @@ function App() {
   };
 
   useEffect(() => {
-    if (!showBottomNav) return undefined;
-
-    if (bottomNavTimeoutRef.current) {
-      clearTimeout(bottomNavTimeoutRef.current);
-      bottomNavTimeoutRef.current = null;
-    }
-
-    if (bottomNavBehavior === 'hidden') {
-      setIsBottomNavVisible(false);
-      return undefined;
-    }
-
-    const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
-    if (bottomNavBehavior === 'visible' || prefersReducedMotion) {
-      setIsBottomNavVisible(true);
-      return undefined;
-    }
-
-    const showBottomNavAfterPause = () => {
-      if (bottomNavTimeoutRef.current) {
-        clearTimeout(bottomNavTimeoutRef.current);
-      }
-      bottomNavTimeoutRef.current = setTimeout(() => {
-        setIsBottomNavVisible(true);
-      }, 2000);
-    };
-
-    bottomNavLastScrollYRef.current = window.scrollY;
-    setIsBottomNavVisible(true);
-    showBottomNavAfterPause();
-
-    const handleScroll = () => {
-      const nextScrollY = Math.max(window.scrollY, 0);
-      const delta = nextScrollY - bottomNavLastScrollYRef.current;
-
-      if (nextScrollY <= 0 || delta < 0) {
-        setIsBottomNavVisible(true);
-      } else if (delta > 10) {
-        setIsBottomNavVisible(false);
-      }
-
-      bottomNavLastScrollYRef.current = nextScrollY;
-      showBottomNavAfterPause();
-    };
-
-    window.addEventListener('scroll', handleScroll, { passive: true });
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (bottomNavTimeoutRef.current) {
-        clearTimeout(bottomNavTimeoutRef.current);
-        bottomNavTimeoutRef.current = null;
-      }
-    };
+    if (!showBottomNav) return;
+    setIsBottomNavVisible(bottomNavBehavior !== 'hidden');
   }, [bottomNavBehavior, showBottomNav]);
 
   const handleBottomNavSelect = (tab) => {

--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -23,6 +23,13 @@
   transform: translateY(100%);
 }
 
+.bottom-navigation--crossfaded {
+  opacity: 0;
+  transform: translateY(14px);
+  pointer-events: none;
+  transition: opacity 0.28s ease, transform 0.34s cubic-bezier(.22,1,.36,1);
+}
+
 .bottom-navigation__tab {
   display: flex;
   flex: 1 1 0;
@@ -96,9 +103,117 @@
   }
 }
 
+/*
+ * Compact "pill" carousel shown instead of the full bar while Kochbuch,
+ * Festtafel or Atelier is the active tab. Sits in the same fixed bottom
+ * position as the full bar but inset horizontally so it doesn't overlap the
+ * existing per-page corner FABs (filter/favorites on the left, add on the
+ * right) — those stay exactly where they already are.
+ */
+.bottom-navigation-pill {
+  position: fixed;
+  left: 86px;
+  right: 86px;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  z-index: 1200;
+  display: none;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
+  overflow: hidden;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.28s ease, transform 0.34s cubic-bezier(.22,1,.36,1);
+}
+
+.bottom-navigation-pill--crossfaded {
+  opacity: 0;
+  transform: translateY(14px);
+  pointer-events: none;
+}
+
+.bottom-navigation-pill--hidden {
+  opacity: 0;
+  transform: translateY(100%);
+  pointer-events: none;
+}
+
+.bottom-navigation-pill__rail {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.bottom-navigation-pill__rail::-webkit-scrollbar {
+  display: none;
+}
+
+.bottom-navigation-pill__item {
+  flex: 0 0 33.333%;
+  scroll-snap-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  min-height: 44px;
+  padding: 0.4rem 0.15rem;
+  color: #78716c;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.bottom-navigation-pill__item--active {
+  color: #d97f0d;
+}
+
+.bottom-navigation-pill__item:focus-visible {
+  outline: 2px solid #d97f0d;
+  outline-offset: -2px;
+}
+
+.bottom-navigation-pill__icon {
+  min-height: 24px;
+}
+
+.bottom-navigation-pill__icon svg {
+  width: 28px;
+  height: 24px;
+}
+
+.bottom-navigation-pill__icon .bottom-navigation__icon-image {
+  width: 28px;
+  height: 24px;
+}
+
+.bottom-navigation-pill__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.3px;
+}
+
+@media (max-width: 768px) {
+  .bottom-navigation-pill {
+    display: block;
+  }
+}
+
 [data-theme="dark"] .bottom-navigation {
   background: #1E1E1C;
   border-top: 1px solid #3B3B38;
+}
+
+[data-theme="dark"] .bottom-navigation-pill {
+  background: #1E1E1C;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.4);
 }
 
 [data-theme="dark"] .bottom-navigation__tab {
@@ -114,7 +229,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .bottom-navigation {
+  .bottom-navigation,
+  .bottom-navigation-pill {
     transition: none;
   }
 }

--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './BottomNavigation.css';
 import { DEFAULT_BUTTON_ICONS, getButtonIcons, getDarkModePreference, getEffectiveIcon } from '../utils/customLists';
 import { isBase64Image } from '../utils/imageUtils';
 
-function NavIcon({ children }) {
+function NavIcon({ children, className }) {
   return (
-    <span className="bottom-navigation__icon" aria-hidden="true">
+    <span className={`bottom-navigation__icon${className ? ` ${className}` : ''}`} aria-hidden="true">
       <svg
         width="24"
         height="24"
@@ -19,9 +19,9 @@ function NavIcon({ children }) {
   );
 }
 
-function KitchenIcon() {
+function KitchenIcon(props) {
   return (
-    <NavIcon>
+    <NavIcon {...props}>
       <path d="M4 5H20" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M6.5 5V19" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M17.5 5V19" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
@@ -31,9 +31,9 @@ function KitchenIcon() {
   );
 }
 
-function BookIcon() {
+function BookIcon(props) {
   return (
-    <NavIcon>
+    <NavIcon {...props}>
       <path d="M7 5.5H16.5C17.3284 5.5 18 6.17157 18 7V18.5H8.5C7.67157 18.5 7 17.8284 7 17V5.5Z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
       <path d="M7 7.5H16.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M8.5 18.5V7C8.5 6.17157 7.82843 5.5 7 5.5H6.5C5.67157 5.5 5 6.17157 5 7V17C5 17.8284 5.67157 18.5 6.5 18.5H8.5Z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
@@ -41,9 +41,9 @@ function BookIcon() {
   );
 }
 
-function TableIcon() {
+function TableIcon(props) {
   return (
-    <NavIcon>
+    <NavIcon {...props}>
       <path d="M12 4.5V8.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M9.5 6.25V8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M14.5 6.25V8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
@@ -53,9 +53,9 @@ function TableIcon() {
   );
 }
 
-function AtelierIcon() {
+function AtelierIcon(props) {
   return (
-    <NavIcon>
+    <NavIcon {...props}>
       <rect x="6" y="5" width="10" height="14" rx="2" stroke="currentColor" strokeWidth="1.8" />
       <rect x="9" y="3" width="10" height="14" rx="2" stroke="currentColor" strokeWidth="1.8" opacity="0.8" />
       <path d="M10 11.75L11.75 13.5L15 9.75" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
@@ -63,9 +63,9 @@ function AtelierIcon() {
   );
 }
 
-function ProfileIcon() {
+function ProfileIcon(props) {
   return (
-    <NavIcon>
+    <NavIcon {...props}>
       <circle cx="12" cy="8" r="3" stroke="currentColor" strokeWidth="1.8" />
       <path d="M5 18.5C6.05034 15.9462 8.53583 14.25 11.2975 14.25H12.7025C15.4642 14.25 17.9497 15.9462 19 18.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
       <path d="M17.25 6.25C18.2165 6.25 19 7.0335 19 8C19 8.9665 18.2165 9.75 17.25 9.75" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
@@ -97,9 +97,46 @@ const NAV_ICON_KEYS_ACTIVE = {
   chef: 'bottomNavChefActive',
 };
 
+// Tabs shown in the compact pill/carousel representation instead of the full bar.
+const PILL_TAB_KEYS = ['recipes', 'menus', 'atelier'];
+
+function resolveTabIcon(tab, isActive, buttonIcons, isDarkMode) {
+  const Icon = ICONS[tab.key];
+  const iconKey = NAV_ICON_KEYS[tab.key];
+  const activeIconKey = NAV_ICON_KEYS_ACTIVE[tab.key];
+  const normalIconValue = iconKey ? getEffectiveIcon(buttonIcons, iconKey, isDarkMode) : '';
+  const activeIconValue = isActive && activeIconKey
+    ? getEffectiveIcon(buttonIcons, activeIconKey, isDarkMode)
+    : '';
+  return { Icon, iconValue: activeIconValue || normalIconValue };
+}
+
+function TabIcon({ tab, isActive, buttonIcons, isDarkMode, iconClassName }) {
+  const { Icon, iconValue } = resolveTabIcon(tab, isActive, buttonIcons, isDarkMode);
+
+  if (isBase64Image(iconValue)) {
+    return (
+      <span className={`bottom-navigation__icon${iconClassName ? ` ${iconClassName}` : ''}`} aria-hidden="true">
+        <img src={iconValue} alt="" className="bottom-navigation__icon-image" draggable="false" />
+      </span>
+    );
+  }
+  if (iconValue) {
+    return (
+      <span className={`bottom-navigation__icon bottom-navigation__icon-text${iconClassName ? ` ${iconClassName}` : ''}`} aria-hidden="true">
+        {iconValue}
+      </span>
+    );
+  }
+  return Icon ? <Icon className={iconClassName} /> : null;
+}
+
 function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
+  const railRef = useRef(null);
+
+  const isPillMode = PILL_TAB_KEYS.includes(activeKey);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,47 +156,89 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
     return () => window.removeEventListener('darkModeChange', handler);
   }, []);
 
-  return (
-    <nav
-      className={`bottom-navigation${isVisible ? '' : ' bottom-navigation--hidden'}`}
-      role="navigation"
-      aria-label="Hauptnavigation"
-      data-visible={isVisible ? 'true' : 'false'}
-    >
-      {tabs.map((tab) => {
-        const Icon = ICONS[tab.key];
-        const isActive = tab.key === activeKey;
-        const iconKey = NAV_ICON_KEYS[tab.key];
-        const activeIconKey = NAV_ICON_KEYS_ACTIVE[tab.key];
-        const normalIconValue = iconKey ? getEffectiveIcon(buttonIcons, iconKey, isDarkMode) : '';
-        const activeIconValue = isActive && activeIconKey
-          ? getEffectiveIcon(buttonIcons, activeIconKey, isDarkMode)
-          : '';
-        const iconValue = activeIconValue || normalIconValue;
+  useEffect(() => {
+    if (!isPillMode) return;
+    const rail = railRef.current;
+    if (!rail) return;
+    const index = tabs.findIndex((tab) => tab.key === activeKey);
+    if (index < 0) return;
+    const itemWidth = rail.clientWidth / 3;
+    if (typeof rail.scrollTo === 'function') {
+      rail.scrollTo({ left: Math.max(0, (index - 1) * itemWidth), behavior: 'smooth' });
+    }
+  }, [activeKey, tabs, isPillMode]);
 
-        return (
-          <button
-            key={tab.key}
-            type="button"
-            className={`bottom-navigation__tab${isActive ? ' bottom-navigation__tab--active' : ''}`}
-            onClick={() => onSelect(tab)}
-            aria-label={tab.label}
-            aria-current={isActive ? 'page' : undefined}
-          >
-            {isBase64Image(iconValue) ? (
-              <span className="bottom-navigation__icon" aria-hidden="true">
-                <img src={iconValue} alt="" className="bottom-navigation__icon-image" draggable="false" />
-              </span>
-            ) : iconValue ? (
-              <span className="bottom-navigation__icon bottom-navigation__icon-text" aria-hidden="true">{iconValue}</span>
-            ) : (
-              Icon ? <Icon /> : null
-            )}
-            <span className="bottom-navigation__label">{tab.label}</span>
-          </button>
-        );
-      })}
-    </nav>
+  const navStateClass = !isVisible
+    ? ' bottom-navigation--hidden'
+    : isPillMode
+      ? ' bottom-navigation--crossfaded'
+      : '';
+  const pillStateClass = !isVisible
+    ? ' bottom-navigation-pill--hidden'
+    : !isPillMode
+      ? ' bottom-navigation-pill--crossfaded'
+      : '';
+
+  return (
+    <>
+      <nav
+        className={`bottom-navigation${navStateClass}`}
+        role="navigation"
+        aria-label="Hauptnavigation"
+        data-visible={isVisible ? 'true' : 'false'}
+      >
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeKey;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              className={`bottom-navigation__tab${isActive ? ' bottom-navigation__tab--active' : ''}`}
+              onClick={() => onSelect(tab)}
+              aria-label={tab.label}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <TabIcon tab={tab} isActive={isActive} buttonIcons={buttonIcons} isDarkMode={isDarkMode} />
+              <span className="bottom-navigation__label">{tab.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+      <div
+        className={`bottom-navigation-pill${pillStateClass}`}
+        data-visible={isPillMode && isVisible ? 'true' : 'false'}
+      >
+        <div
+          className="bottom-navigation-pill__rail"
+          ref={railRef}
+          role="navigation"
+          aria-label="Hauptnavigation (kompakt)"
+        >
+          {tabs.map((tab) => {
+            const isActive = tab.key === activeKey;
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                className={`bottom-navigation-pill__item${isActive ? ' bottom-navigation-pill__item--active' : ''}`}
+                onClick={() => onSelect(tab)}
+                aria-label={tab.label}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <TabIcon
+                  tab={tab}
+                  isActive={isActive}
+                  buttonIcons={buttonIcons}
+                  isDarkMode={isDarkMode}
+                  iconClassName="bottom-navigation-pill__icon"
+                />
+                <span className="bottom-navigation-pill__label">{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/src/components/BottomNavigation.test.js
+++ b/src/components/BottomNavigation.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor, within } from '@testing-library/react';
 import BottomNavigation from './BottomNavigation';
 
 jest.mock('../utils/customLists', () => ({
@@ -36,9 +36,12 @@ describe('BottomNavigation icon rendering', () => {
   test('renders configured text icon from button icon list', async () => {
     getButtonIcons.mockResolvedValue({ bottomNavHome: '🍳' });
 
-    render(<BottomNavigation tabs={tabs} activeKey="home" isVisible onSelect={() => {}} />);
+    const { container } = render(
+      <BottomNavigation tabs={tabs} activeKey="home" isVisible onSelect={() => {}} />
+    );
+    const fullBar = within(container.querySelector('.bottom-navigation'));
 
-    expect(await screen.findByText('🍳')).toBeInTheDocument();
+    expect(await fullBar.findByText('🍳')).toBeInTheDocument();
   });
 
   test('renders configured image icon from button icon list', async () => {
@@ -63,10 +66,13 @@ describe('BottomNavigation icon rendering', () => {
       bottomNavRecipes: '📖',
     });
 
-    render(<BottomNavigation tabs={tabs} activeKey="home" isVisible onSelect={() => {}} />);
+    const { container } = render(
+      <BottomNavigation tabs={tabs} activeKey="home" isVisible onSelect={() => {}} />
+    );
+    const fullBar = within(container.querySelector('.bottom-navigation'));
 
-    expect(await screen.findByText('🔥')).toBeInTheDocument();
-    expect(screen.getByText('📖')).toBeInTheDocument();
-    expect(screen.queryByText('🍳')).not.toBeInTheDocument();
+    expect(await fullBar.findByText('🔥')).toBeInTheDocument();
+    expect(fullBar.getByText('📖')).toBeInTheDocument();
+    expect(fullBar.queryByText('🍳')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
BottomNavigation rendert jetzt zusätzlich zur bestehenden vollen Leiste
eine kompakte Pille mit horizontalem Karussell (alle 5 Tabs, 3 sichtbar,
scroll-snap, automatisches Zentrieren des aktiven Tabs). Beide Container
liegen fest am unteren Rand übereinander und werden per Opacity/Transform
gekreuzt ein-/ausgeblendet, abhängig davon ob Küche/Chefkoch (volle Leiste)
oder Kochbuch/Festtafel/Atelier (Pille) aktiv ist. Die Pille ist horizontal
so eingerückt, dass sie die bestehenden Eck-FABs (Filter/Favoriten links,
Hinzufügen rechts) nicht überdeckt.

Zusätzlich entfällt das scroll-basierte automatische Ausblenden der
Navigation in Rezept-/Menüübersicht und Mise-en-Place – sie bleibt dort
jetzt durchgehend sichtbar; nur die eigenständigen Vollbild-Ansichten
(Tagesmenü, Kategorieauswahl, Events) blenden sie weiterhin komplett aus.