### PR TITLE
Pin pill nav icons to the same vertical position as the full bar

### DIFF
--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -110,6 +110,11 @@
  * position as the full bar but inset horizontally so it doesn't overlap the
  * existing per-page corner FABs (filter/favorites on the left, add on the
  * right) — those stay exactly where they already are.
+ *
+ * Fixed height (rather than sizing to the label's rendered content) so the
+ * icon's distance from the container top never depends on label line-height
+ * rounding — it stays pinned at the same offset from the viewport bottom as
+ * the full bar's icon, matching --bottom-nav-min-height's deterministic role.
  */
 .bottom-navigation-pill {
   position: fixed;
@@ -118,6 +123,7 @@
   bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   z-index: 1200;
   display: none;
+  height: 56px;
   border-radius: 999px;
   background: #ffffff;
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
@@ -141,6 +147,8 @@
 
 .bottom-navigation-pill__rail {
   display: flex;
+  align-items: flex-start;
+  height: 100%;
   overflow-x: auto;
   overflow-y: hidden;
   scroll-snap-type: x mandatory;


### PR DESCRIPTION
The pill's height was content-driven (padding + icon + gap + label),
so its top edge — and therefore the icon's absolute position, since
the container is bottom-anchored — shifted with whatever height the
label happened to render at. The full bar avoids this by giving the
outer nav a fixed min-height and flex-start-aligning tabs inside it,
so the icon's offset from the viewport bottom never depends on content.

Give the pill container the same treatment: a fixed height with items
flex-start-aligned in the rail. The exact height (56px) was measured
against the full bar's actual icon position (accounting for its 1px
top border) so the two line up pixel-for-pixel during the crossfade.