### PR TITLE
Match bottom nav pill styling to FAB and keep it visible in Kochatelier

### DIFF
--- a/src/App.auth.test.js
+++ b/src/App.auth.test.js
@@ -517,7 +517,7 @@ describe('App authentication view handling', () => {
     expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
   });
 
-  test('bottom navigation stays visible while scrolling in Kochbuch and hides immediately in atelier mode', async () => {
+  test('bottom navigation stays visible while scrolling in Kochbuch and remains visible in atelier mode', async () => {
     render(<App />);
     expect(await screen.findByTestId('login-view')).toBeInTheDocument();
 
@@ -553,7 +553,8 @@ describe('App authentication view handling', () => {
     localStorage.setItem('atelierOnboardingSeen', 'true');
     fireEvent.click(navQueries.getByRole('button', { name: 'Atelier' }));
     expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
-    expect(nav).toHaveAttribute('data-visible', 'false');
+    // Kochatelier keeps the compact pill visible instead of hiding the bottom nav.
+    expect(nav).toHaveAttribute('data-visible', 'true');
   });
 
   test('atelier opens directly without onboarding overlay when global onboarding testmode is disabled', async () => {
@@ -784,9 +785,10 @@ describe('App authentication view handling', () => {
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
     expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
-    expect(nav).toHaveAttribute('data-visible', 'false');
-    expect(app.style.getPropertyValue('--bottom-nav-offset')).toBe('0px');
-    expect(app.style.getPropertyValue('--bottom-spacing')).toBe('0px');
+    // Kochatelier keeps the compact pill visible instead of hiding the bottom nav.
+    expect(nav).toHaveAttribute('data-visible', 'true');
+    expect(app.style.getPropertyValue('--bottom-nav-offset')).toBe('var(--bottom-nav-height)');
+    expect(app.style.getPropertyValue('--bottom-spacing')).toBe('calc(var(--bottom-nav-height) + 16px)');
   });
 
   test('seasonal startseite navigation opens the seasonal recipe overview', async () => {

--- a/src/App.js
+++ b/src/App.js
@@ -315,7 +315,7 @@ function getBottomNavActiveKey(currentView) {
 }
 
 function getBottomNavBehavior(currentView) {
-  if (currentView === 'tagesmenu' || currentView === 'atelierCategorySelection' || currentView === 'events') return 'hidden';
+  if (currentView === 'atelierCategorySelection' || currentView === 'events') return 'hidden';
   return 'visible';
 }
 

--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -120,9 +120,10 @@
   display: none;
   border-radius: 999px;
   background: #ffffff;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.14);
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   overflow: hidden;
-  opacity: 1;
+  opacity: 0.85;
   transform: translateY(0);
   transition: opacity 0.28s ease, transform 0.34s cubic-bezier(.22,1,.36,1);
 }
@@ -213,8 +214,8 @@
 }
 
 [data-theme="dark"] .bottom-navigation-pill {
-  background: #1E1E1C;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.4);
+  background: #2a2a2a;
+  border-color: #555;
 }
 
 [data-theme="dark"] .bottom-navigation__tab {


### PR DESCRIPTION
Give the compact bottom-nav pill the same border, transparency and
shadow as the FAB buttons (1px #ddd border, opacity 0.85, 0 4px 8px
rgba(0,0,0,0.3) shadow) instead of its own bespoke shadow/opacity, in
both light and dark mode. Also stop hiding the bottom nav/pill when
the Kochatelier (tagesmenu) view is active, so the pill stays visible
there like it does on the other pill tabs.