### PR TITLE
Show only Kochbuch, Festtafel und Atelier in der Bottom Nav Pill

### DIFF
--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -160,9 +160,10 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
     if (!isPillMode) return;
     const rail = railRef.current;
     if (!rail) return;
-    const index = tabs.findIndex((tab) => tab.key === activeKey);
+    const pillTabs = tabs.filter((tab) => PILL_TAB_KEYS.includes(tab.key));
+    const index = pillTabs.findIndex((tab) => tab.key === activeKey);
     if (index < 0) return;
-    const itemWidth = rail.clientWidth / 3;
+    const itemWidth = rail.clientWidth / pillTabs.length;
     if (typeof rail.scrollTo === 'function') {
       rail.scrollTo({ left: Math.max(0, (index - 1) * itemWidth), behavior: 'smooth' });
     }
@@ -214,7 +215,7 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
           role="navigation"
           aria-label="Hauptnavigation (kompakt)"
         >
-          {tabs.map((tab) => {
+          {tabs.filter((tab) => PILL_TAB_KEYS.includes(tab.key)).map((tab) => {
             const isActive = tab.key === activeKey;
             return (
               <button

--- a/src/components/BottomNavigation.test.js
+++ b/src/components/BottomNavigation.test.js
@@ -75,4 +75,27 @@ describe('BottomNavigation icon rendering', () => {
     expect(fullBar.getByText('📖')).toBeInTheDocument();
     expect(fullBar.queryByText('🍳')).not.toBeInTheDocument();
   });
+
+  test('pill navigation only shows Kochbuch, Festtafel and Atelier', async () => {
+    const allTabs = [
+      { key: 'home', label: 'Küche' },
+      { key: 'recipes', label: 'Kochbuch' },
+      { key: 'menus', label: 'Festtafel' },
+      { key: 'atelier', label: 'Atelier' },
+      { key: 'chef', label: 'Chefkoch' },
+    ];
+
+    const { container } = render(
+      <BottomNavigation tabs={allTabs} activeKey="recipes" isVisible onSelect={() => {}} />
+    );
+
+    await waitFor(() => expect(getButtonIcons).toHaveBeenCalled());
+
+    const pill = within(container.querySelector('.bottom-navigation-pill'));
+    expect(pill.getByLabelText('Kochbuch')).toBeInTheDocument();
+    expect(pill.getByLabelText('Festtafel')).toBeInTheDocument();
+    expect(pill.getByLabelText('Atelier')).toBeInTheDocument();
+    expect(pill.queryByLabelText('Küche')).not.toBeInTheDocument();
+    expect(pill.queryByLabelText('Chefkoch')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Die Pill-Leiste rendert nun ausschließlich die drei kompakten Tabs
statt aller fünf Hauptnavigations-Einträge; der Scroll-zu-aktivem-Tab-
Effekt verwendet dieselbe gefilterte Liste zur Indexberechnung.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HsnS3CixbvrdCZtM9DY29R