### PR TITLE
Bottom-Nav-Pille höher machen, Icons bleiben an Position

### DIFF
--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -120,10 +120,10 @@
   position: fixed;
   left: 86px;
   right: 86px;
-  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  bottom: calc(8px + env(safe-area-inset-bottom, 0px));
   z-index: 1200;
   display: none;
-  height: 56px;
+  height: 64px;
   border-radius: 999px;
   background: #ffffff;
   border: 1px solid #ddd;


### PR DESCRIPTION
Höhe von 56px auf 64px erhöht und den bottom-Offset im Gegenzug von
16px auf 8px reduziert, damit die obere Kante (und damit die Icons)
exakt an der gleichen Bildschirmposition bleibt. Der zusätzliche Raum
entsteht unterhalb des Labels, wodurch der Inhalt nicht mehr knapp am
unteren Rand der Pille anliegt.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KdzfpPyVHzFY6zt4qohJR6