### PR TITLE
Fix FAB button positioning for pill-nav tabs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,10 +42,7 @@
   .App .recipe-detail-container .new-version-fab-button,
   .App .recipe-detail-container .delete-fab-button,
   .App .recipe-detail-container .publish-fab-button,
-  .App .recipe-detail-container .reset-thumbnail-fab-button,
-  .App .tagesmenu-filter-btn,
-  .App .tagesmenu-meine-auswahl-btn,
-  .App .tagesmenu-zum-tagesMenu-btn {
+  .App .recipe-detail-container .reset-thumbnail-fab-button {
     bottom: calc(16px + env(safe-area-inset-bottom, 0px) + var(--bottom-nav-offset, 0px));
     transition:
       bottom 250ms ease-in-out,
@@ -54,11 +51,22 @@
       box-shadow 0.15s ease;
   }
 
+  /*
+   * Corner FABs on the pill-nav tabs (Kochbuch/recipes, Festtafel/menus,
+   * Atelier/tagesmenu — see PILL_TAB_KEYS in BottomNavigation.js). The
+   * compact pill sits inset horizontally (left/right: 86px) at this same
+   * bottom offset specifically so it never overlaps these corner FABs, so
+   * unlike the full-bar pages above, these must NOT get --bottom-nav-offset
+   * added or they'd float noticeably higher than the pill needs.
+   */
   .App .add-icon-button,
   .App .filter-button,
   .App .menu-favorites-filter-button,
   .App .add-menu-fab-button,
-  .App .events-add-fab-button {
+  .App .events-add-fab-button,
+  .App .tagesmenu-filter-btn,
+  .App .tagesmenu-meine-auswahl-btn,
+  .App .tagesmenu-zum-tagesMenu-btn {
     bottom: calc(16px + env(safe-area-inset-bottom, 0px));
     transition:
       transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1),

--- a/src/App.css.test.js
+++ b/src/App.css.test.js
@@ -59,7 +59,7 @@ describe('App CSS FAB bottom offset selectors', () => {
       '.App .recipe-detail-container .new-version-fab-button,',
       '.App .recipe-detail-container .delete-fab-button,',
       '.App .recipe-detail-container .publish-fab-button,',
-      '.App .recipe-detail-container .reset-thumbnail-fab-button,',
+      '.App .recipe-detail-container .reset-thumbnail-fab-button {',
     ];
 
     requiredSelectors.forEach((selector) => {
@@ -68,7 +68,7 @@ describe('App CSS FAB bottom offset selectors', () => {
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px) + var(--bottom-nav-offset, 0px));');
   });
 
-  test('keeps recipe and menu overview FAB buttons at fixed hidden-nav position', () => {
+  test('keeps pill-nav tab FAB buttons (recipes, menus, tagesmenu) at fixed pill-level position', () => {
     const cssPath = path.join(__dirname, 'App.css');
     const css = fs.readFileSync(cssPath, 'utf8');
     const mobileBlock = getMediaBlock(css, '(max-width: 768px)');
@@ -77,7 +77,10 @@ describe('App CSS FAB bottom offset selectors', () => {
     expect(mobileBlock).toContain('.App .filter-button,');
     expect(mobileBlock).toContain('.App .menu-favorites-filter-button,');
     expect(mobileBlock).toContain('.App .add-menu-fab-button,');
-    expect(mobileBlock).toContain('.App .events-add-fab-button {');
+    expect(mobileBlock).toContain('.App .events-add-fab-button,');
+    expect(mobileBlock).toContain('.App .tagesmenu-filter-btn,');
+    expect(mobileBlock).toContain('.App .tagesmenu-meine-auswahl-btn,');
+    expect(mobileBlock).toContain('.App .tagesmenu-zum-tagesMenu-btn {');
     expect(mobileBlock).toContain('bottom: calc(16px + env(safe-area-inset-bottom, 0px));');
   });
 


### PR DESCRIPTION
## Summary
Reorganized FAB button CSS rules to correctly position buttons on pill-nav tabs (recipes, menus, tagesmenu) without the `--bottom-nav-offset` variable, which should only apply to full-width bottom navigation pages.

## Changes
- **CSS restructuring**: Moved tagesmenu FAB button selectors (`.tagesmenu-filter-btn`, `.tagesmenu-meine-auswahl-btn`, `.tagesmenu-zum-tagesMenu-btn`) from the recipe-detail container rule (which includes `--bottom-nav-offset`) to the pill-nav tab rule (which does not)
- **Added clarifying comment**: Documented why pill-nav tab FABs must NOT include `--bottom-nav-offset` — the compact pill nav sits inset at 86px horizontally and uses the same bottom offset, so adding the offset variable would cause FABs to float higher than intended and overlap the pill
- **Updated test coverage**: 
  - Fixed selector assertion to match the new CSS structure (closing brace moved)
  - Updated test name and assertions to reflect pill-nav tab positioning logic
  - Added assertions for the three tagesmenu FAB selectors in the correct rule group

## Implementation Details
The pill-nav tabs use a compact horizontal layout that sits inset from the edges, unlike full-width bottom navigation. The FABs on these tabs must align with the pill's bottom offset without the additional `--bottom-nav-offset` variable to prevent visual misalignment.

https://claude.ai/code/session_01APWFHwgjxidDabVH7Kvtey