### PR TITLE
Bottom-Nav-Pille: Rand oben angleichen, Karussell wieder bewegbar

### DIFF
--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -148,7 +148,7 @@
 
 .bottom-navigation-pill__rail {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   height: 100%;
   overflow-x: auto;
   overflow-y: hidden;
@@ -162,7 +162,7 @@
 }
 
 .bottom-navigation-pill__item {
-  flex: 0 0 33.333%;
+  flex: 0 0 42%;
   scroll-snap-align: center;
   display: flex;
   flex-direction: column;

--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -163,9 +163,11 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
     const pillTabs = tabs.filter((tab) => PILL_TAB_KEYS.includes(tab.key));
     const index = pillTabs.findIndex((tab) => tab.key === activeKey);
     if (index < 0) return;
-    const itemWidth = rail.clientWidth / pillTabs.length;
+    const target = rail.children[index];
+    if (!target) return;
+    const left = target.offsetLeft - (rail.clientWidth - target.offsetWidth) / 2;
     if (typeof rail.scrollTo === 'function') {
-      rail.scrollTo({ left: Math.max(0, (index - 1) * itemWidth), behavior: 'smooth' });
+      rail.scrollTo({ left: Math.max(0, left), behavior: 'smooth' });
     }
   }, [activeKey, tabs, isPillMode]);
 


### PR DESCRIPTION
Der Rail wurde per align-items:flex-start oben angepinnt, wodurch der
gesamte zusätzliche Raum aus der Höhenerhöhung unterhalb der Icons
landete (Rand oben schmaler als unten). Center-Ausrichtung verteilt
ihn gleichmäßig.

Seit die Pille nur noch 3 Tabs zeigt, füllten sie bei 33.333%
Flex-Basis exakt die Breite des Rails aus – es gab nichts mehr zum
Scrollen, das Karussell ließ sich nicht mehr bewegen. Größere
Flex-Basis (42%) sorgt wieder für Überlauf mit Peek-Effekt an den
Rändern; die Scroll-Zentrierung nutzt jetzt offsetLeft/offsetWidth
statt einer an die alte 3-Spalten-Aufteilung gekoppelten Berechnung.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019pwXHVHwQcTR56NHbjNGBb