### PR TITLE
Küche und Chefkoch im Pillenkarussell wieder scrollbar erreichbar machen

### DIFF
--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -162,7 +162,7 @@
 }
 
 .bottom-navigation-pill__item {
-  flex: 0 0 42%;
+  flex: 0 0 33.333%;
   scroll-snap-align: center;
   display: flex;
   flex-direction: column;

--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -160,8 +160,7 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
     if (!isPillMode) return;
     const rail = railRef.current;
     if (!rail) return;
-    const pillTabs = tabs.filter((tab) => PILL_TAB_KEYS.includes(tab.key));
-    const index = pillTabs.findIndex((tab) => tab.key === activeKey);
+    const index = tabs.findIndex((tab) => tab.key === activeKey);
     if (index < 0) return;
     const target = rail.children[index];
     if (!target) return;
@@ -217,7 +216,7 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
           role="navigation"
           aria-label="Hauptnavigation (kompakt)"
         >
-          {tabs.filter((tab) => PILL_TAB_KEYS.includes(tab.key)).map((tab) => {
+          {tabs.map((tab) => {
             const isActive = tab.key === activeKey;
             return (
               <button

--- a/src/components/BottomNavigation.test.js
+++ b/src/components/BottomNavigation.test.js
@@ -76,7 +76,7 @@ describe('BottomNavigation icon rendering', () => {
     expect(fullBar.queryByText('🍳')).not.toBeInTheDocument();
   });
 
-  test('pill navigation only shows Kochbuch, Festtafel and Atelier', async () => {
+  test('pill navigation carousel keeps Küche and Chefkoch reachable by scrolling', async () => {
     const allTabs = [
       { key: 'home', label: 'Küche' },
       { key: 'recipes', label: 'Kochbuch' },
@@ -91,11 +91,15 @@ describe('BottomNavigation icon rendering', () => {
 
     await waitFor(() => expect(getButtonIcons).toHaveBeenCalled());
 
+    // Kochbuch, Festtafel and Atelier are the three tabs visible by default
+    // (activeKey is always one of these while the pill carousel is shown).
+    // Küche and Chefkoch stay in the rail too, just scrolled out of view, so
+    // the carousel can be scrolled to reach them.
     const pill = within(container.querySelector('.bottom-navigation-pill'));
     expect(pill.getByLabelText('Kochbuch')).toBeInTheDocument();
     expect(pill.getByLabelText('Festtafel')).toBeInTheDocument();
     expect(pill.getByLabelText('Atelier')).toBeInTheDocument();
-    expect(pill.queryByLabelText('Küche')).not.toBeInTheDocument();
-    expect(pill.queryByLabelText('Chefkoch')).not.toBeInTheDocument();
+    expect(pill.getByLabelText('Küche')).toBeInTheDocument();
+    expect(pill.getByLabelText('Chefkoch')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Die Pille rendert jetzt wieder alle fünf Tabs im Rail statt nur die drei
kompakten (Kochbuch, Festtafel, Atelier) zu rendern. Standardmäßig
sichtbar bleiben weiterhin nur diese drei, Küche und Chefkoch liegen
außerhalb des sichtbaren Bereichs links/rechts und werden per Scroll
erreicht. Die Flex-Basis der Items ist dafür wieder auf 33.333% gesetzt,
damit exakt drei Items die Rail-Breite füllen.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lne56AgTwoCii91ywiwMp9