### PR TITLE
Adjust bottom navigation pill horizontal positioning

### DIFF
--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -118,8 +118,8 @@
  */
 .bottom-navigation-pill {
   position: fixed;
-  left: 86px;
-  right: 86px;
+  left: 81px;
+  right: 81px;
   bottom: calc(8px + env(safe-area-inset-bottom, 0px));
   z-index: 1200;
   display: none;


### PR DESCRIPTION
## Summary
Fine-tunes the horizontal positioning of the bottom navigation pill component by reducing the left and right margins from 86px to 81px.

## Changes
- **BottomNavigation.css**: Updated `.bottom-navigation-pill` left and right properties from `86px` to `81px`

## Details
This adjustment improves the visual alignment and spacing of the bottom navigation pill on the screen. The 5px reduction on each side brings the component slightly closer to the viewport edges, likely to better match the current design specifications or improve visual balance with other UI elements.

https://claude.ai/code/session_01KYmHM5Fp7yEBR3rJoN5XCH