### PR TITLE
Redesign event status badges as progress indicators

### DIFF
--- a/src/components/EventsPage.css
+++ b/src/components/EventsPage.css
@@ -166,10 +166,12 @@
   font-size: 18px;
 }
 
+/* Statuspille sitzt unter Titel und Datumszeile (linksbuendig), damit lange
+   Labels wie "Verbrauch erfasst" den Text nicht mehr umbrechen. */
 .events-card-meta-row {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 12px;
 }
 
@@ -189,35 +191,44 @@
   margin: 4px 0 0;
 }
 
+/* Ein Pillenstil fuer alle Status: die Farbe bleibt das Markengruen, den
+   Status traegt der Fortschrittsbalken. */
 .events-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
   flex-shrink: 0;
-  padding: 4px 10px;
+  padding: 5px 11px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
-  background: #eee;
-  color: #555;
+  background: #f7f8f7;
+  border: 1px solid #dbdfdd;
+  color: #3f4a45;
 }
 
-.events-status-geplant {
-  background: #fff3cd;
-  color: #8a6d1a;
+.events-status-progress {
+  display: flex;
+  gap: 2px;
 }
 
-.events-status-berechnet {
-  background: #dbeafe;
-  color: #1d4f8c;
+.events-status-progress-seg {
+  width: 8px;
+  height: 3px;
+  border-radius: 2px;
+  background: #cfd5d2;
 }
 
-.events-status-eingekauft {
-  background: #ede9fe;
-  color: #5b3fa8;
+.events-status-progress-seg.is-done {
+  background: #2F5D50;
 }
 
-.events-status-verbrauchErfasst {
-  background: #d7f0e3;
-  color: #1c6b46;
+/* Abgeschlossen ("Verbrauch erfasst"): gefuellte Pille ohne Segmente. */
+.events-status-complete {
+  background: #2F5D50;
+  border-color: #2F5D50;
+  color: #f2f6f4;
 }
 
 .events-add-fab-button {
@@ -1462,6 +1473,11 @@
 
   .events-card-meta {
     font-size: 16px;
+  }
+
+  .events-status-badge {
+    font-size: 13px;
+    padding: 6px 12px;
   }
 
   .events-card-drink-summary {

--- a/src/components/EventsPage.js
+++ b/src/components/EventsPage.js
@@ -21,6 +21,39 @@ const STATUS_LABELS = {
   verbrauchErfasst: 'Verbrauch erfasst',
 };
 
+const STATUS_STEPS = {
+  geplant: 1,
+  berechnet: 2,
+  eingekauft: 3,
+  verbrauchErfasst: 4,
+};
+
+const TOTAL_STATUS_STEPS = 4;
+
+// Statuspille als Fortschrittsanzeige: vier Segmente zeigen, wie weit ein Event
+// ist; der Endzustand ("Verbrauch erfasst") wird stattdessen gefuellt gesetzt.
+function StatusBadge({ status }) {
+  const step = STATUS_STEPS[status] || 0;
+  const isComplete = step === TOTAL_STATUS_STEPS;
+  return (
+    <span
+      className={`events-status-badge events-status-${status}${isComplete ? ' events-status-complete' : ''}`}
+    >
+      {!isComplete && step > 0 && (
+        <span className="events-status-progress" aria-hidden="true">
+          {Array.from({ length: TOTAL_STATUS_STEPS }, (_, idx) => (
+            <span
+              key={idx}
+              className={`events-status-progress-seg${idx < step ? ' is-done' : ''}`}
+            />
+          ))}
+        </span>
+      )}
+      {STATUS_LABELS[status] || status}
+    </span>
+  );
+}
+
 const formatDate = (dateStr) => {
   if (!dateStr) return '';
   try {
@@ -124,9 +157,7 @@ function EventCard({ event, ownerName, canManage, onSelect, onDelete, swipeDelet
             {formatDate(event.date)} · {EVENT_TYPE_LABELS[event.eventType] || event.eventType}
             {ownerName ? ` · von ${ownerName}` : ''}
           </p>
-          <span className={`events-status-badge events-status-${event.status}`}>
-            {STATUS_LABELS[event.status] || event.status}
-          </span>
+          <StatusBadge status={event.status} />
         </div>
       </div>
     </div>
@@ -431,9 +462,7 @@ function EventsPage({ onBack, currentUser, recipes, pendingEventReminderId, onPe
 
         <div className="events-result-card">
           <div className="events-detail-meta">
-            <span className={`events-status-badge events-status-${selectedEvent.status}`}>
-              {STATUS_LABELS[selectedEvent.status] || selectedEvent.status}
-            </span>
+            <StatusBadge status={selectedEvent.status} />
             <span>{formatDate(selectedEvent.date)}</span>
             <span>{selectedEvent.durationHours} Std.</span>
             <span>{EVENT_TYPE_LABELS[selectedEvent.eventType] || selectedEvent.eventType}</span>

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -4063,28 +4063,23 @@
 }
 
 [data-theme="dark"] .events-status-badge {
-  background: #333;
-  color: #ccc;
+  background: #222524;
+  border-color: #333835;
+  color: #c9cfcc;
 }
 
-[data-theme="dark"] .events-status-geplant {
-  background: #4a3f1a;
-  color: #e8c766;
+[data-theme="dark"] .events-status-progress-seg {
+  background: #3b403d;
 }
 
-[data-theme="dark"] .events-status-berechnet {
-  background: #1a3350;
-  color: #8fb8e8;
+[data-theme="dark"] .events-status-progress-seg.is-done {
+  background: #8FC9AE;
 }
 
-[data-theme="dark"] .events-status-eingekauft {
-  background: #362a52;
-  color: #c4a8f0;
-}
-
-[data-theme="dark"] .events-status-verbrauchErfasst {
-  background: #1a3a2a;
-  color: #7fd9a8;
+[data-theme="dark"] .events-status-complete {
+  background: #8FC9AE;
+  border-color: #8FC9AE;
+  color: #101613;
 }
 
 [data-theme="dark"] .events-warnings {


### PR DESCRIPTION
## Summary
Refactored the event status badge component to display progress through a 4-step workflow using visual progress segments instead of color-coded labels. The final state ("Verbrauch erfasst") is now shown as a filled pill, while intermediate states display a segmented progress bar.

## Key Changes

- **New `StatusBadge` component** in `EventsPage.js`: Replaces inline status rendering with a reusable component that displays progress segments for steps 1–3 and a filled state for step 4 (completion)
- **Progress visualization**: Four segments indicate workflow progression (geplant → berechnet → eingekauft → verbrauchErfasst), with completed segments filled in brand green (#2F5D50)
- **Unified styling**: Removed individual status-specific color classes (`.events-status-geplant`, `.events-status-berechnet`, etc.) in favor of a single `.events-status-badge` style with optional `.events-status-complete` modifier
- **Layout adjustment**: Changed `.events-card-meta-row` from horizontal (space-between) to vertical (flex-column, flex-start) to prevent long status labels from wrapping text
- **Updated badge appearance**: 
  - Light mode: Subtle gray background (#f7f8f7) with border, brand green for progress segments and completed state
  - Dark mode: Adjusted colors for contrast (#222524 background, #8FC9AE for progress/complete)
- **Responsive refinement**: Added tablet breakpoint styling for badge padding and font size

## Implementation Details

- Status steps are mapped via `STATUS_STEPS` constant (1–4) with `TOTAL_STATUS_STEPS = 4`
- Progress segments are rendered as decorative elements (`aria-hidden="true"`) to avoid redundant screen reader announcements
- The component gracefully handles unknown status values by displaying the raw status string
- Dark mode colors maintain sufficient contrast while preserving the visual hierarchy

https://claude.ai/code/session_014HVUxYRTWts41Ad4ZepNnc