### PR TITLE
Run recipe imports (Web + OCR) in the background with a review queue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -89,6 +89,8 @@ import {
   removeRecipeFromGroup as removeRecipeFromGroupInFirestore
 } from './utils/groupFirestore';
 import { NutritionReferenceProvider, useNutritionReference } from './contexts/NutritionReferenceContext';
+import { RecipeImportQueueProvider } from './contexts/RecipeImportQueueContext';
+import { resolveRecipeGroupContext, resolveImportGroupContext } from './utils/recipeGroupContext';
 
 const PENDING_WEBIMPORT_URL_STORAGE_KEY = 'pendingWebimportUrl';
 const PENDING_WEBIMPORT_AUTHOR_STORAGE_KEY = 'pendingWebimportAuthor';
@@ -925,6 +927,14 @@ function App() {
     window.scrollTo(0, 0);
   };
 
+  const handleReviewTempRecipe = (tempRecipe) => {
+    // Load a pending background import into the form for full review;
+    // handleSaveRecipe/handleCancelForm branch on editingRecipe.isTemp to
+    // confirm (clear the flag) or discard (delete the document) it.
+    setEditingRecipe(tempRecipe);
+    setIsCreatingVersion(false);
+  };
+
   const handleCreateVersion = (recipe) => {
     setEditingRecipe(recipe);
     setIsCreatingVersion(true);
@@ -939,7 +949,8 @@ function App() {
 
     try {
       if (editingRecipe && editingRecipe.id !== undefined && !isCreatingVersion) {
-        // Update existing recipe (direct edit)
+        // Update existing recipe (direct edit) — also covers confirming a
+        // pending background import (isTemp), which just clears the flag.
         const { id, ...updates } = recipe;
 
         // Automatically clear WhatsApp thumbnail when the default image changes,
@@ -951,37 +962,29 @@ function App() {
 
         await updateRecipeInFirestore(
           id,
-          shouldClearThumbnail ? { ...updates, imageThumbnail: deleteField() } : updates,
+          {
+            ...updates,
+            ...(shouldClearThumbnail ? { imageThumbnail: deleteField() } : {}),
+            ...(editingRecipe.isTemp ? { isTemp: deleteField() } : {}),
+          },
           editingRecipe.authorId
         );
 
-        // Build local state: exclude Firestore sentinel so it doesn't end up in React state
+        // Build local state: exclude Firestore sentinels so they don't end up in React state
         const nextSelectedRecipe = { ...editingRecipe, ...updates };
         if (shouldClearThumbnail) {
           delete nextSelectedRecipe.imageThumbnail;
         }
+        delete nextSelectedRecipe.isTemp;
         // Navigate back to the recipe detail view after a successful update
         setSelectedRecipe(nextSelectedRecipe);
       } else {
         // Add new recipe or new version; attach groupId if created from within a group,
         // otherwise fall back to the public group (from state or from the groups subscription)
-        const resolvedPublicGroupId = publicGroupId || groups.find(g => g.type === 'public')?.id;
-        let safeGroupId;
-        let autoPublish;
         const { selectedGroupId, ...recipeWithoutMeta } = recipe;
-        if (selectedGroupId) {
-          // User explicitly chose a private list from the form dropdown
-          safeGroupId = selectedGroupId;
-          autoPublish = false;
-        } else {
-          safeGroupId = activeGroupId
-            ? (typeof activeGroupId === 'string' ? activeGroupId : activeGroupId.id ?? String(activeGroupId))
-            : resolvedPublicGroupId;
-          // Auto-publish when creating via "Rezept hinzufügen" (no active private group)
-          autoPublish = !activeGroupId && !isCreatingVersion;
-        }
-        const activeGroup = groups.find(g => g.id === safeGroupId);
-        const groupType = activeGroup?.type ?? 'public';
+        const { groupId: safeGroupId, groupType, autoPublish } = resolveRecipeGroupContext({
+          selectedGroupId, activeGroupId, groups, publicGroupId, isCreatingVersion,
+        });
         const recipeWithGroup = safeGroupId
           ? { ...recipeWithoutMeta, groupId: safeGroupId, groupType, ...(autoPublish ? { publishedToPublic: true } : {}) }
           : recipeWithoutMeta;
@@ -1081,8 +1084,19 @@ function App() {
   };
 
   const handleCancelForm = () => {
+    if (editingRecipe?.isTemp) {
+      // Discarding a pending background import deletes the recipe document
+      // entirely (it only ever existed as a TEMP draft), so confirm first —
+      // same rule as deleting any other recipe with content.
+      if (!window.confirm(`Möchten Sie den Import "${editingRecipe.title || 'Unbenanntes Rezept'}" wirklich verwerfen?`)) {
+        return;
+      }
+      deleteRecipeFromFirestore(editingRecipe.id).catch((error) => {
+        console.error('Error discarding temp recipe:', error);
+      });
+    }
     setIsFormOpen(false);
-    if (editingRecipe && editingRecipe.id !== undefined && !isCreatingVersion) {
+    if (!editingRecipe?.isTemp && editingRecipe && editingRecipe.id !== undefined && !isCreatingVersion) {
       // Return to recipe detail view when canceling an edit of an existing recipe
       const recipe = recipes.find(r => r.id === editingRecipe.id) || editingRecipe;
       setSelectedRecipe(recipe);
@@ -1848,17 +1862,6 @@ function App() {
     );
   }, [atelierCategoryOptions]);
 
-  const handleUniversalImport = (recipe) => {
-    setShowUniversalImport(false);
-    setSharedData({ images: [], title: '', text: '', url: '' });
-    clearSharedDataFromDB();
-    // Open RecipeForm pre-populated with the imported recipe
-    setEditingRecipe(recipe);
-    setIsCreatingVersion(false);
-    setActiveGroupId(null);
-    setIsFormOpen(true);
-  };
-
   const handleUniversalImportCancel = () => {
     setShowUniversalImport(false);
     setSharedData({ images: [], title: '', text: '', url: '' });
@@ -1964,9 +1967,10 @@ function App() {
 
   return (
     <NutritionReferenceProvider enabled={!!currentUser}>
+    <RecipeImportQueueProvider>
       <AppNutritionRowsSync onRows={setNutritionReferenceRows} />
       <div className="App" style={appBottomNavStyle}>
-        <Header 
+        <Header
           ref={headerRef}
           onSettingsClick={handleOpenSettings}
           currentView={currentView}
@@ -2013,9 +2017,11 @@ function App() {
           allRecipes={recipes}
           activeGroupId={activeGroupId}
           groups={groups}
+          publicGroupId={publicGroupId}
           privateLists={groups.filter(g => g.type === 'private' && (g.ownerId === currentUser?.id || (Array.isArray(g.memberIds) && g.memberIds.includes(currentUser?.id))))}
           initialWebImportUrl={webimportDeeplink}
           initialWebImportAuthorId={webimportAuthorId}
+          onSelectTempRecipe={handleReviewTempRecipe}
         />
         ) : selectedMenu ? (
         // Menu detail view - shown regardless of currentView
@@ -2239,8 +2245,9 @@ function App() {
             initialTitle={sharedData.title}
             initialText={sharedData.text}
             initialUrl={sharedData.url}
-            onImport={handleUniversalImport}
             onCancel={handleUniversalImportCancel}
+            userId={currentUser?.id}
+            importContext={resolveImportGroupContext({ activeGroupId, groups, publicGroupId })}
           />
         )}
         <MobileSearchOverlay
@@ -2293,6 +2300,7 @@ function App() {
           <AtelierTasteIntroOverlay onContinue={handleAtelierTasteIntroContinue} />
         )}
       </div>
+    </RecipeImportQueueProvider>
     </NutritionReferenceProvider>
   );
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,9 @@ import './Header.css';
 import { getHeaderSlogan, getAppLogoImage } from '../utils/customLists';
 import { subscribeToFaqs } from '../utils/faqFirestore';
 import SearchIcon from './icons/SearchIcon';
+import ImportProgressIndicator from './ImportProgressIndicator';
+import ImportProgressDialog from './ImportProgressDialog';
+import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 /**
  * Renders text with **bold** markdown syntax as <strong> elements.
@@ -42,8 +45,10 @@ const Header = forwardRef(function Header({
   const [faqModalOpen, setFaqModalOpen] = useState(false);
   const [expandedFaqId, setExpandedFaqId] = useState(null);
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
   const menuRef = useRef(null);
   const searchRef = useRef(null);
+  const { jobs: importJobs, dismissJob: dismissImportJob } = useRecipeImportQueue();
 
   useImperativeHandle(ref, () => ({
     openSearch() {
@@ -240,6 +245,12 @@ const Header = forwardRef(function Header({
               </div>
           )}
           {currentUser && (
+            <ImportProgressIndicator
+              jobs={importJobs}
+              onClick={() => setImportDialogOpen(true)}
+            />
+          )}
+          {currentUser && (
               <div className="hamburger-menu-container" ref={menuRef}>
               <button 
                 className="hamburger-btn" 
@@ -418,6 +429,14 @@ const Header = forwardRef(function Header({
             </div>
           </div>
         </div>
+      )}
+
+      {importDialogOpen && (
+        <ImportProgressDialog
+          jobs={importJobs}
+          onClose={() => setImportDialogOpen(false)}
+          onDismissJob={dismissImportJob}
+        />
       )}
     </>
   );

--- a/src/components/ImportProgressDialog.css
+++ b/src/components/ImportProgressDialog.css
@@ -1,0 +1,180 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.import-progress-dialog {
+  background: white;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 420px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.import-progress-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.import-progress-dialog-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #333;
+}
+
+.import-progress-dialog-header .close-button {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #666;
+  padding: 4px 8px;
+}
+
+.import-progress-dialog-content {
+  padding: 16px 20px;
+  overflow-y: auto;
+}
+
+.import-progress-empty {
+  color: #666;
+  text-align: center;
+  margin: 12px 0;
+}
+
+.import-progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.import-progress-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.import-progress-item.status-error {
+  border-color: rgba(163, 58, 38, 0.4);
+  background: rgba(163, 58, 38, 0.05);
+}
+
+.import-progress-item-main {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.import-progress-item-label {
+  color: #1a1a1a;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-progress-item-status {
+  color: #666;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+}
+
+.import-progress-item-bar {
+  margin-top: 8px;
+  height: 6px;
+  border-radius: 999px;
+  background: #eee;
+  overflow: hidden;
+}
+
+.import-progress-item-bar-fill {
+  height: 100%;
+  background: #1a1a1a;
+  transition: width 0.2s ease;
+}
+
+.import-progress-item-error {
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: #a33a26;
+}
+
+.import-progress-item-dismiss {
+  background: transparent;
+  border: 1px solid #a33a26;
+  color: #a33a26;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.import-progress-hint {
+  margin: 16px 0 4px;
+  color: #666;
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+[data-theme="dark"] .import-progress-dialog {
+  background: #1e1e1e;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] .import-progress-dialog-header {
+  border-color: #3d3d3d;
+}
+
+[data-theme="dark"] .import-progress-dialog-header h2 {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .import-progress-item {
+  border-color: #3d3d3d;
+}
+
+[data-theme="dark"] .import-progress-item.status-error {
+  background: rgba(163, 58, 38, 0.12);
+}
+
+[data-theme="dark"] .import-progress-item-label {
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .import-progress-item-bar {
+  background: #3d3d3d;
+}
+
+[data-theme="dark"] .import-progress-item-bar-fill {
+  background: #e8e8e8;
+}
+
+[data-theme="dark"] .import-progress-empty,
+[data-theme="dark"] .import-progress-hint {
+  color: #aaa;
+}

--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import './ImportProgressDialog.css';
+
+function statusLabel(status) {
+  switch (status) {
+    case 'queued':
+      return 'Wartet…';
+    case 'processing':
+      return 'Wird analysiert…';
+    case 'error':
+      return 'Fehlgeschlagen';
+    default:
+      return '';
+  }
+}
+
+// Detail view opened by clicking the header's import progress donut. Shows
+// every queued/running/failed background import job; finished imports leave
+// this list immediately and show up as pending reviews on "Neues Rezept
+// hinzufügen" instead.
+function ImportProgressDialog({ jobs, onClose, onDismissJob }) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="import-progress-dialog" onClick={(e) => e.stopPropagation()}>
+        <div className="import-progress-dialog-header">
+          <h2>Rezept-Import</h2>
+          <button className="close-button" onClick={onClose} aria-label="Schließen">×</button>
+        </div>
+
+        <div className="import-progress-dialog-content">
+          {jobs.length === 0 ? (
+            <p className="import-progress-empty">Kein Import aktiv.</p>
+          ) : (
+            <ul className="import-progress-list">
+              {jobs.map((job) => (
+                <li key={job.id} className={`import-progress-item status-${job.status}`}>
+                  <div className="import-progress-item-main">
+                    <span className="import-progress-item-label">{job.label || 'Rezept-Import'}</span>
+                    <span className="import-progress-item-status">{statusLabel(job.status)}</span>
+                  </div>
+                  {(job.status === 'processing' || job.status === 'queued') && (
+                    <div className="import-progress-item-bar">
+                      <div
+                        className="import-progress-item-bar-fill"
+                        style={{ width: `${job.progress || 0}%` }}
+                      />
+                    </div>
+                  )}
+                  {job.status === 'error' && (
+                    <div className="import-progress-item-error">
+                      <span>{job.error}</span>
+                      <button
+                        type="button"
+                        className="import-progress-item-dismiss"
+                        onClick={() => onDismissJob(job.id)}
+                      >
+                        Verwerfen
+                      </button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="import-progress-hint">
+            Fertige Importe findest du unter „Neues Rezept hinzufügen" zur Überprüfung.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ImportProgressDialog;

--- a/src/components/ImportProgressIndicator.css
+++ b/src/components/ImportProgressIndicator.css
@@ -1,0 +1,64 @@
+.import-progress-indicator {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.import-progress-track {
+  stroke: rgba(26, 26, 26, 0.15);
+}
+
+.import-progress-fill {
+  stroke: #1a1a1a;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.2s ease;
+}
+
+.import-progress-indicator.has-error .import-progress-track {
+  stroke: rgba(163, 58, 38, 0.25);
+}
+
+.import-progress-error-dot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #a33a26;
+}
+
+.import-progress-badge {
+  position: absolute;
+  bottom: -4px;
+  right: -4px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  border-radius: 999px;
+  background: #1a1a1a;
+  color: #fff;
+  font-size: 0.6rem;
+  font-weight: 700;
+  line-height: 14px;
+  text-align: center;
+}
+
+[data-theme="dark"] .import-progress-track {
+  stroke: rgba(232, 232, 232, 0.2);
+}
+
+[data-theme="dark"] .import-progress-fill {
+  stroke: #e8e8e8;
+}
+
+[data-theme="dark"] .import-progress-badge {
+  background: #e8e8e8;
+  color: #1a1a1a;
+}

--- a/src/components/ImportProgressIndicator.js
+++ b/src/components/ImportProgressIndicator.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import './ImportProgressIndicator.css';
+
+const SIZE = 28;
+const STROKE = 3;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+// Small circular progress "donut" shown next to the hamburger menu while
+// background recipe imports (Web-Import / Foto-OCR) are running. Clicking
+// it opens the ImportProgressDialog with the full job list.
+function ImportProgressIndicator({ jobs, onClick }) {
+  if (!jobs || jobs.length === 0) return null;
+
+  const activeJob = jobs.find((job) => job.status === 'processing') || jobs[0];
+  const hasError = jobs.some((job) => job.status === 'error');
+  const progress = Math.max(0, Math.min(100, activeJob?.progress || 0));
+  const offset = CIRCUMFERENCE * (1 - progress / 100);
+  const extraCount = jobs.length - 1;
+
+  return (
+    <button
+      type="button"
+      className={`import-progress-indicator${hasError ? ' has-error' : ''}`}
+      onClick={onClick}
+      title={hasError ? 'Import fehlgeschlagen – Details anzeigen' : `Rezept-Import läuft (${progress}%)`}
+      aria-label="Import-Fortschritt anzeigen"
+    >
+      <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
+        <circle
+          className="import-progress-track"
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RADIUS}
+          strokeWidth={STROKE}
+          fill="none"
+        />
+        {!hasError && (
+          <circle
+            className="import-progress-fill"
+            cx={SIZE / 2}
+            cy={SIZE / 2}
+            r={RADIUS}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={offset}
+            transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+          />
+        )}
+      </svg>
+      {hasError && <span className="import-progress-error-dot" aria-hidden="true" />}
+      {extraCount > 0 && (
+        <span className="import-progress-badge">{extraCount}</span>
+      )}
+    </button>
+  );
+}
+
+export default ImportProgressIndicator;

--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -1,10 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './OcrScanModal.css';
-import { recognizeText } from '../utils/ocrService';
-import { parseOcrTextSmart, buildRecipeFromAiResult } from '../utils/ocrParser';
-import { getValidationSummary } from '../utils/ocrValidation';
+import { buildRecipeFromAiResult } from '../utils/ocrParser';
 import { fileToBase64 } from '../utils/imageUtils';
 import { recognizeRecipeWithAI } from '../utils/aiOcrService';
+import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 const MAX_CAMERA_PHOTOS = 10;
 // Max number of images processed at the same time during a batch scan.
@@ -12,47 +11,166 @@ const MAX_CAMERA_PHOTOS = 10;
 // while staying well under the Cloud Function's per-user rate limit.
 const BATCH_CONCURRENCY = 3;
 
-// initialImage: single image that triggers immediate OCR (takes precedence over initialImages)
+// Remove duplicate strings using Levenshtein similarity
+function stringSimilarity(s1, s2) {
+  const longer = s1.length > s2.length ? s1 : s2;
+  const shorter = s1.length > s2.length ? s2 : s1;
+  if (longer.length === 0) return 1.0;
+  const editDistance = levenshteinDistance(longer, shorter);
+  return (longer.length - editDistance) / longer.length;
+}
+
+function levenshteinDistance(s1, s2) {
+  const costs = [];
+  for (let i = 0; i <= s1.length; i++) {
+    let lastValue = i;
+    for (let j = 0; j <= s2.length; j++) {
+      if (i === 0) {
+        costs[j] = j;
+      } else if (j > 0) {
+        let newValue = costs[j - 1];
+        if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
+          newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+        }
+        costs[j - 1] = lastValue;
+        lastValue = newValue;
+      }
+    }
+    if (i > 0) costs[s2.length] = lastValue;
+  }
+  return costs[s2.length];
+}
+
+function removeDuplicates(items) {
+  if (!items || items.length === 0) return [];
+  const unique = [];
+  for (const item of items) {
+    const normalized = item.toLowerCase().trim();
+    const isDuplicate = unique.some(existing =>
+      stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8
+    );
+    if (!isDuplicate) {
+      unique.push(item);
+    }
+  }
+  return unique;
+}
+
+// Combine multiple per-image AI OCR results into one recipe
+function mergeAiResults(results) {
+  const validResults = results.filter(r => !r.error);
+  if (validResults.length === 0) {
+    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
+  }
+
+  const merged = { ...validResults[0] };
+
+  const allIngredients = validResults.flatMap(r => r.ingredients || []);
+  merged.ingredients = removeDuplicates(allIngredients);
+
+  const allSteps = validResults.flatMap(r => r.steps || []);
+  merged.steps = removeDuplicates(allSteps);
+
+  const allTags = validResults.flatMap(r => r.tags || []);
+  merged.tags = [...new Set(allTags)];
+
+  const allNotes = validResults
+    .map(r => r.notes)
+    .filter(n => n && n.trim())
+    .join('\n\n');
+  merged.notes = allNotes || merged.notes;
+
+  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
+  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
+  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
+  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
+  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
+  merged.category = merged.category || validResults.find(r => r.category)?.category;
+
+  return merged;
+}
+
+// Runs AI OCR on a batch of images (concurrently, up to BATCH_CONCURRENCY at
+// once) and returns the merged recipe. Passed as the `run` function to
+// enqueueImportJob() so it executes in the background, after the modal has
+// already closed.
+async function runPhotoScanImport(images, language, onProgress) {
+  const total = images.length;
+  const results = new Array(total);
+  const progressPerImage = new Array(total).fill(0);
+
+  const updateOverall = () => {
+    const sum = progressPerImage.reduce((a, b) => a + b, 0);
+    onProgress(Math.round(sum / total));
+  };
+
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < total) {
+      const i = nextIndex++;
+      try {
+        const result = await recognizeRecipeWithAI(images[i], {
+          language,
+          provider: 'gemini',
+          onProgress: (progress) => {
+            progressPerImage[i] = progress;
+            updateOverall();
+          },
+        });
+        results[i] = result;
+      } catch (err) {
+        results[i] = { error: err.message };
+      }
+      progressPerImage[i] = 100;
+      updateOverall();
+    }
+  };
+
+  const workerCount = Math.min(BATCH_CONCURRENCY, total);
+  await Promise.all(Array.from({ length: workerCount }, worker));
+
+  const merged = mergeAiResults(results);
+  return buildRecipeFromAiResult(merged);
+}
+
+// initialImage: single image that triggers an immediate background scan (takes precedence over initialImages)
 // initialImages: array of base64 images to pre-fill the image-preview step
-function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [] }) {
-  // initialImage starts OCR immediately; initialImages shows the preview step; neither → upload step
-  const [step, setStep] = useState(initialImage ? 'scan' : (initialImages.length > 0 ? 'image-preview' : 'upload')); // 'upload', 'scan', 'edit', 'batch-processing', 'image-preview'
-  // imageBase64 tracks the current image but OCR functions receive it directly as parameter
-  // This state is maintained for potential future features (e.g., image preview, retry)
-  // eslint-disable-next-line no-unused-vars
-  const [imageBase64, setImageBase64] = useState(initialImage);
+function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId = '', importContext = {} }) {
+  // initialImage queues immediately (no step UI shown); initialImages shows the
+  // image-preview step; neither → upload step
+  const [step, setStep] = useState(initialImage ? 'queuing' : (initialImages.length > 0 ? 'image-preview' : 'upload'));
   const [language, setLanguage] = useState('de'); // 'de' or 'en'
-  const [scanning, setScanning] = useState(false);
-  const [scanProgress, setScanProgress] = useState(0);
-  const [ocrText, setOcrText] = useState('');
   const [error, setError] = useState('');
   const [cameraActive, setCameraActive] = useState(false);
-  const [ocrMode, setOcrMode] = useState('ai'); // 'standard' or 'ai'
-  const [validationResult, setValidationResult] = useState(null);
-  const [remainingScans, setRemainingScans] = useState(null);
-  const [aiFailed, setAiFailed] = useState(false);
-  const [lastImageForRetry, setLastImageForRetry] = useState(null);
   const [uploadedImages, setUploadedImages] = useState(initialImages.length > 0 ? [...initialImages] : []);
-  const [currentImageIndex, setCurrentImageIndex] = useState(0);
-  // Which batch images are currently being processed / already done (batch images
-  // are processed concurrently, so several can be "processing" at once, and they
-  // don't necessarily finish in order).
-  const [activeImageIndices, setActiveImageIndices] = useState(() => new Set());
-  const [doneImageIndices, setDoneImageIndices] = useState(() => new Set());
   const [capturedPhotos, setCapturedPhotos] = useState([]);
-  
+
+  const { enqueueImportJob } = useRecipeImportQueue();
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
   const streamRef = useRef(null);
   const initialScanTriggered = useRef(false);
   const addMoreInputRef = useRef(null);
 
-  // When initialImage is provided, start OCR automatically
-  // We only want this to run once on mount, not when performOcr changes
+  // Queue a background scan for the given images and close the modal
+  // immediately; the recipe is saved with a TEMP flag once analysis
+  // finishes and shows up for review on "Neues Rezept hinzufügen".
+  const queuePhotoScan = (images) => {
+    enqueueImportJob({
+      label: images.length === 1 ? 'Foto-Scan' : `Foto-Scan (${images.length} Bilder)`,
+      userId,
+      context: importContext,
+      run: (onProgress) => runPhotoScanImport(images, language, onProgress),
+    });
+    stopCamera();
+    onCancel();
+  };
+
+  // When initialImage is provided, queue the scan automatically on mount
   useEffect(() => {
     if (initialImage && !initialScanTriggered.current) {
       initialScanTriggered.current = true;
-      performOcr(initialImage);
+      queuePhotoScan([initialImage]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialImage]);
@@ -63,6 +181,7 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
       videoRef.current.srcObject = streamRef.current;
     }
   }, [cameraActive]);
+
   // Handle file upload (single or multiple) – shows preview before analysis
   const handleMultiFileUpload = async (e) => {
     const files = Array.from(e.target.files);
@@ -105,121 +224,10 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     });
   };
 
-  // Start analysis on all selected uploaded images
-  const startUploadedAnalysis = async () => {
+  // Queue analysis on all selected uploaded images
+  const startUploadedAnalysis = () => {
     if (uploadedImages.length === 0) return;
-    const images = [...uploadedImages];
-    setCurrentImageIndex(0);
-    setStep('batch-processing');
-    await processBase64Batch(images);
-  };
-
-  // Combine multiple OCR results into one recipe
-  const mergeOcrResults = (results, mode) => {
-    if (mode === 'ai') {
-      return mergeAiResults(results);
-    } else {
-      return mergeTextResults(results);
-    }
-  };
-
-  const mergeAiResults = (results) => {
-    const validResults = results.filter(r => !r.error);
-
-    if (validResults.length === 0) {
-      throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
-    }
-
-    const merged = { ...validResults[0] };
-
-    const allIngredients = validResults.flatMap(r => r.ingredients || []);
-    merged.ingredients = removeDuplicates(allIngredients);
-
-    const allSteps = validResults.flatMap(r => r.steps || []);
-    merged.steps = removeDuplicates(allSteps);
-
-    const allTags = validResults.flatMap(r => r.tags || []);
-    merged.tags = [...new Set(allTags)];
-
-    const allNotes = validResults
-      .map(r => r.notes)
-      .filter(n => n && n.trim())
-      .join('\n\n');
-    merged.notes = allNotes || merged.notes;
-
-    merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
-    merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
-    merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
-    merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
-    merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
-    merged.category = merged.category || validResults.find(r => r.category)?.category;
-
-    return merged;
-  };
-
-  const mergeTextResults = (results) => {
-    const validResults = results.filter(r => !r.error && r.text);
-
-    if (validResults.length === 0) {
-      throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
-    }
-
-    const combinedText = validResults
-      .map((r, i) => `--- Bild ${i + 1} ---\n${r.text}`)
-      .join('\n\n');
-
-    return { text: combinedText };
-  };
-
-  // Remove duplicate strings using Levenshtein similarity
-  const removeDuplicates = (items) => {
-    if (!items || items.length === 0) return [];
-
-    const unique = [];
-
-    for (const item of items) {
-      const normalized = item.toLowerCase().trim();
-      const isDuplicate = unique.some(existing =>
-        stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8
-      );
-
-      if (!isDuplicate) {
-        unique.push(item);
-      }
-    }
-
-    return unique;
-  };
-
-  const stringSimilarity = (s1, s2) => {
-    const longer = s1.length > s2.length ? s1 : s2;
-    const shorter = s1.length > s2.length ? s2 : s1;
-
-    if (longer.length === 0) return 1.0;
-
-    const editDistance = levenshteinDistance(longer, shorter);
-    return (longer.length - editDistance) / longer.length;
-  };
-
-  const levenshteinDistance = (s1, s2) => {
-    const costs = [];
-    for (let i = 0; i <= s1.length; i++) {
-      let lastValue = i;
-      for (let j = 0; j <= s2.length; j++) {
-        if (i === 0) {
-          costs[j] = j;
-        } else if (j > 0) {
-          let newValue = costs[j - 1];
-          if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
-            newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
-          }
-          costs[j - 1] = lastValue;
-          lastValue = newValue;
-        }
-      }
-      if (i > 0) costs[s2.length] = lastValue;
-    }
-    return costs[s2.length];
+    queuePhotoScan([...uploadedImages]);
   };
 
   // Start camera
@@ -264,289 +272,20 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
     setCapturedPhotos([]);
   };
 
-  // Process an array of base64 images concurrently (up to BATCH_CONCURRENCY at
-  // once). Similar to processBatchImages(), but accepts base64 strings directly
-  // instead of File objects, avoiding an extra fileToBase64 conversion step.
-  // Images are independent of each other, so processing several in parallel
-  // cuts total wait time roughly to (batch size / concurrency) instead of the
-  // sum of every individual OCR call.
-  const processBase64Batch = async (base64Images) => {
-    const results = new Array(base64Images.length);
-    const total = base64Images.length;
-    // Per-image progress (0-100), combined below into one overall percentage
-    // so several images updating concurrently don't make the bar jump around.
-    const progressPerImage = new Array(total).fill(0);
-    let doneCount = 0;
-
-    const updateOverallProgress = () => {
-      const sum = progressPerImage.reduce((a, b) => a + b, 0);
-      setScanProgress(Math.round(sum / total));
-    };
-
-    setCurrentImageIndex(0);
-    setScanProgress(0);
-    setActiveImageIndices(new Set());
-    setDoneImageIndices(new Set());
-
-    let nextIndex = 0;
-    const processNext = async () => {
-      while (nextIndex < total) {
-        const i = nextIndex++;
-        setActiveImageIndices(prev => new Set(prev).add(i));
-
-        try {
-          const base64 = base64Images[i];
-
-          if (ocrMode === 'ai') {
-            const result = await recognizeRecipeWithAI(base64, {
-              language,
-              provider: 'gemini',
-              onProgress: (progress) => {
-                progressPerImage[i] = progress;
-                updateOverallProgress();
-              }
-            });
-
-            // Update remaining scans if provided by the Cloud Function
-            if (result.remainingScans !== undefined) {
-              setRemainingScans(result.remainingScans);
-            }
-
-            results[i] = result;
-          } else {
-            const langCode = language === 'de' ? 'deu' : 'eng';
-            const result = await recognizeText(base64, langCode,
-              (progress) => {
-                progressPerImage[i] = progress;
-                updateOverallProgress();
-              }
-            );
-            results[i] = { text: result.text };
-          }
-        } catch (err) {
-          console.error(`Error processing photo ${i + 1}:`, err);
-          results[i] = { error: err.message };
-        }
-
-        doneCount += 1;
-        progressPerImage[i] = 100;
-        setActiveImageIndices(prev => {
-          const next = new Set(prev);
-          next.delete(i);
-          return next;
-        });
-        setDoneImageIndices(prev => new Set(prev).add(i));
-        setCurrentImageIndex(doneCount);
-        updateOverallProgress();
-      }
-    };
-
-    const workerCount = Math.min(BATCH_CONCURRENCY, total);
-    await Promise.all(Array.from({ length: workerCount }, processNext));
-
-    const allFailed = results.every(r => r.error);
-    if (allFailed) {
-      // Use the first individual error message (consistent with single-image performOcr)
-      const firstError = results[0]?.error || 'Unbekannter Fehler';
-      const isQuotaError = firstError.includes('Tageslimit') ||
-        firstError.includes('resource-exhausted') ||
-        firstError.includes('quota');
-      setError('OCR fehlgeschlagen: ' + firstError);
-      if (ocrMode === 'ai') {
-        setAiFailed(true);
-        setLastImageForRetry(base64Images[0]);
-      }
-      if (!isQuotaError) {
-        setStep('upload');
-      }
-      return;
-    }
-
-    try {
-      const merged = mergeOcrResults(results, ocrMode);
-
-      if (ocrMode === 'ai') {
-        onImport(buildRecipeFromAiResult(merged));
-      } else {
-        setOcrText(merged.text);
-        setStep('edit');
-      }
-    } catch (err) {
-      setError(err.message);
-      setStep('upload');
-    }
-  };
-
-  // Start batch OCR analysis on all captured camera photos
-  const startBatchAnalysis = async () => {
+  // Queue analysis on all captured camera photos
+  const startBatchAnalysis = () => {
     if (capturedPhotos.length === 0) return;
-
-    const photos = [...capturedPhotos];
-    stopCamera();
-    setCurrentImageIndex(0);
-    setUploadedImages(photos);
-    setStep('batch-processing');
-    await processBase64Batch(photos);
+    queuePhotoScan([...capturedPhotos]);
   };
 
   // Stop camera
-  const stopCamera = () => {
+  function stopCamera() {
     if (streamRef.current) {
       streamRef.current.getTracks().forEach(track => track.stop());
       streamRef.current = null;
     }
     setCameraActive(false);
-  };
-
-  // Perform OCR
-  const performOcr = async (imageToProcess) => {
-    // Validate input
-    if (!imageToProcess) {
-      setError('Kein Bild zum Scannen verfügbar. Bitte laden Sie ein Bild hoch.');
-      setStep('upload');
-      return;
-    }
-
-    setScanning(true);
-    setScanProgress(0);
-    setError('');
-    setAiFailed(false);
-
-    try {
-
-    console.log('DEBUG performOcr called, ocrMode:', ocrMode);
-    console.log('DEBUG performOcr called, imageToProcess length:', imageToProcess?.length);
-	
-      if (ocrMode === 'ai') {
-        // AI OCR using Gemini Vision
-        const result = await recognizeRecipeWithAI(imageToProcess, {
-          language,
-          provider: 'gemini',
-          onProgress: (progress) => setScanProgress(progress)
-        });
-
-        // Update remaining scans if provided by the Cloud Function
-        if (result.remainingScans !== undefined) {
-          setRemainingScans(result.remainingScans);
-        }
-
-        onImport(buildRecipeFromAiResult(result));
-      } else {
-        // Standard OCR using Tesseract
-        const langCode = language === 'de' ? 'deu' : 'eng';
-        const result = await recognizeText(
-          imageToProcess,
-          langCode,
-          (progress) => setScanProgress(progress)
-        );
-
-        setOcrText(result.text);
-        setStep('edit');
-      }
-    } catch (err) {
-      const isQuotaError = err.message && (
-        err.message.includes('Tageslimit') ||
-        err.message.includes('resource-exhausted') ||
-        err.message.includes('quota')
-      );
-      setError('OCR fehlgeschlagen: ' + err.message);
-      if (ocrMode === 'ai') {
-        setAiFailed(true);
-        setLastImageForRetry(imageToProcess);
-      }
-      if (!isQuotaError) {
-        setStep('upload');
-      }
-    } finally {
-      setScanning(false);
-      setScanProgress(0);
-    }
-  };
-
-  // Fall back to standard OCR after AI failure
-  const fallbackToStandardOcr = async () => {
-    if (!lastImageForRetry) return;
-    setOcrMode('standard');
-    setError('');
-    setAiFailed(false);
-    setScanning(true);
-    setScanProgress(0);
-    setStep('scan');
-    try {
-      const langCode = language === 'de' ? 'deu' : 'eng';
-      const result = await recognizeText(
-        lastImageForRetry,
-        langCode,
-        (progress) => setScanProgress(progress)
-      );
-      setOcrText(result.text);
-      setStep('edit');
-    } catch (err) {
-      setError('OCR fehlgeschlagen: ' + err.message);
-      setStep('upload');
-    } finally {
-      setScanning(false);
-      setScanProgress(0);
-    }
-  };
-
-  // Handle import of OCR text (standard/text mode; AI results import immediately after analysis)
-  const handleImport = () => {
-    setError('');
-
-    // Standard text import with validation
-    if (!ocrText.trim()) {
-      setError('Kein Text erkannt. Bitte versuchen Sie es erneut.');
-      return;
-    }
-
-    try {
-      // Use smart parsing with classification and validation
-      const result = parseOcrTextSmart(ocrText, language);
-      
-      // Store validation result for display
-      setValidationResult(result.validation);
-      
-      // Show warnings if quality is low
-      if (result.validation.score < 50) {
-        const summary = getValidationSummary(result.validation, language);
-        setError(`Erkennungsqualität ist niedrig (${result.validation.score}%):\n${summary}\n\nKlicken Sie auf "Trotzdem übernehmen" um das Rezept dennoch zu importieren.`);
-        // Don't import automatically - wait for user confirmation
-        return;
-      }
-      
-      onImport(result.recipe);
-    } catch (err) {
-      setError(err.message);
-    }
-  };
-  
-  // Force import despite low quality
-  const forceImport = () => {
-    setError('');
-    try {
-      const result = parseOcrTextSmart(ocrText, language);
-      onImport(result.recipe);
-    } catch (err) {
-      setError(err.message);
-    }
-  };
-
-  // Reset to start
-  const handleReset = () => {
-    stopCamera();
-    setStep('upload');
-    setImageBase64('');
-    setOcrText('');
-    setError('');
-    setOcrMode('ai');
-    setValidationResult(null);
-    setAiFailed(false);
-    setLastImageForRetry(null);
-    setUploadedImages([]);
-    setCurrentImageIndex(0);
-    setCapturedPhotos([]);
-  };
+  }
 
   // Handle cancel
   const handleCancel = () => {
@@ -587,15 +326,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
                   </button>
                 </div>
               </div>
-
-              {remainingScans !== null && ocrMode === 'ai' && (
-                <div className={`scan-quota-info ${remainingScans < 5 ? 'scan-quota-warning' : ''}`}>
-                  {remainingScans < 5
-                    ? `Noch ${remainingScans} KI-Scans heute verfügbar. Danach Standard-OCR verwenden.`
-                    : `${remainingScans} KI-Scans heute noch verfügbar`
-                  }
-                </div>
-              )}
 
               {!cameraActive && (
                 <div className="upload-buttons">
@@ -748,129 +478,9 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
             </div>
           )}
 
-          {/* Scan Step */}
-          {step === 'scan' && scanning && (
-            <div className="scan-section">
-              <p className="ocr-instructions">
-                {ocrMode === 'ai' ? 'Analysiere Rezept...' : 'Scanne Text...'}
-              </p>
-              <div className="progress-container">
-                <div className="progress-bar">
-                  <div
-                    className="progress-fill"
-                    style={{ width: `${scanProgress}%` }}
-                  />
-                </div>
-                <p className="progress-text">{scanProgress}%</p>
-              </div>
-            </div>
-          )}
-
-          {/* Batch Processing Step */}
-          {step === 'batch-processing' && (
-            <div className="batch-processing-section">
-              <p className="ocr-instructions">
-                Verarbeite {uploadedImages.length} Bilder...
-              </p>
-
-              <div className="batch-progress">
-                <div className="batch-image-progress">
-                  {currentImageIndex} von {uploadedImages.length} Bildern verarbeitet
-                </div>
-
-                <div className="progress-container">
-                  <div className="progress-bar">
-                    <div
-                      className="progress-fill"
-                      style={{ width: `${scanProgress}%` }}
-                    />
-                  </div>
-                  <p className="progress-text">{scanProgress}%</p>
-                </div>
-
-                <div className="processed-images">
-                  {uploadedImages.map((_, index) => {
-                    const isDone = doneImageIndices.has(index);
-                    const isActive = activeImageIndices.has(index);
-                    return (
-                      <div
-                        key={index}
-                        className={`image-indicator ${
-                          isDone ? 'completed' :
-                          isActive ? 'processing' :
-                          'pending'
-                        }`}
-                      >
-                        {isDone ? '✓' : isActive ? '...' : '○'}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Edit Step */}
-          {step === 'edit' && (
-            <div className="edit-section">
-              <p className="ocr-instructions">
-                Überprüfen und bearbeiten Sie den erkannten Text
-              </p>
-
-              {/* Validation Results */}
-              {validationResult && (
-                <div className={`validation-info ${validationResult.score >= 70 ? 'validation-good' : validationResult.score >= 50 ? 'validation-moderate' : 'validation-poor'}`}>
-                  <h4>Erkennungsqualität: {validationResult.score}%</h4>
-                  {validationResult.warnings.length > 0 && (
-                    <div className="validation-warnings">
-                      <strong>Hinweise:</strong>
-                      <ul>
-                        {validationResult.warnings.map((warning, idx) => (
-                          <li key={idx}>{warning}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {validationResult.suggestions.length > 0 && (
-                    <div className="validation-suggestions">
-                      <strong>Verbesserungsvorschläge:</strong>
-                      <ul>
-                        {validationResult.suggestions.slice(0, 3).map((suggestion, idx) => (
-                          <li key={idx}>{suggestion}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              <textarea
-                className="ocr-textarea"
-                value={ocrText}
-                onChange={(e) => setOcrText(e.target.value)}
-                placeholder="Erkannter Text..."
-                rows="15"
-              />
-
-              <button className="new-scan-button" onClick={handleReset}>
-                ↻ Neuer Scan
-              </button>
-            </div>
-          )}
-
           {error && (
             <div className="ocr-error">
               {error}
-              {validationResult && validationResult.score < 50 && (
-                <button className="force-import-button" onClick={forceImport}>
-                  Trotzdem übernehmen
-                </button>
-              )}
-              {aiFailed && (
-                <button className="fallback-ocr-button" onClick={fallbackToStandardOcr}>
-                  Mit Standard-OCR fortfahren
-                </button>
-              )}
             </div>
           )}
         </div>
@@ -879,12 +489,6 @@ function OcrScanModal({ onImport, onCancel, initialImage = '', initialImages = [
           <button className="cancel-button" onClick={handleCancel}>
             Abbrechen
           </button>
-          
-          {step === 'edit' && (
-            <button className="import-button" onClick={handleImport}>
-              Übernehmen
-            </button>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/OcrScanModal.test.js
+++ b/src/components/OcrScanModal.test.js
@@ -6,25 +6,6 @@ import OcrScanModal from './OcrScanModal';
 // Test configuration constants
 const OCR_TIMEOUT = 3000;
 
-// Mock the OCR service
-jest.mock('../utils/ocrService', () => ({
-  recognizeText: jest.fn()
-}));
-
-// Mock the OCR parser
-jest.mock('../utils/ocrParser', () => ({
-  parseOcrText: jest.fn(),
-  parseOcrTextSmart: jest.fn(),
-  extractKulinarikFromTags: jest.requireActual('../utils/ocrParser').extractKulinarikFromTags,
-  buildRecipeFromAiResult: jest.requireActual('../utils/ocrParser').buildRecipeFromAiResult
-}));
-
-// Mock the OCR validation
-jest.mock('../utils/ocrValidation', () => ({
-  validateOcrResult: jest.fn(),
-  getValidationSummary: jest.fn()
-}));
-
 // Mock the image utils
 jest.mock('../utils/imageUtils', () => ({
   fileToBase64: jest.fn()
@@ -32,23 +13,41 @@ jest.mock('../utils/imageUtils', () => ({
 
 // Mock the AI OCR service
 jest.mock('../utils/aiOcrService', () => ({
-  recognizeRecipeWithAI: jest.fn(),
-  isAiOcrAvailable: jest.fn().mockReturnValue(true) // Default to true
+  recognizeRecipeWithAI: jest.fn()
+}));
+
+// Mock ocrParser's buildRecipeFromAiResult with the real implementation so
+// the recipe shape returned from a queued job matches production behavior.
+jest.mock('../utils/ocrParser', () => ({
+  buildRecipeFromAiResult: jest.requireActual('../utils/ocrParser').buildRecipeFromAiResult,
+}));
+
+// Mock the background import queue: enqueueImportJob is captured so tests
+// can manually invoke the queued `run` function and inspect the recipe it
+// resolves to, mirroring what the real RecipeImportQueueProvider would do.
+const mockEnqueueImportJob = jest.fn();
+jest.mock('../contexts/RecipeImportQueueContext', () => ({
+  useRecipeImportQueue: () => ({ enqueueImportJob: mockEnqueueImportJob }),
 }));
 
 describe('OcrScanModal', () => {
-  const mockOnImport = jest.fn();
   const mockOnCancel = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Re-set default return value after clearAllMocks removes it
-    const { isAiOcrAvailable } = require('../utils/aiOcrService');
-    isAiOcrAvailable.mockReturnValue(true);
   });
 
+  // Runs the `run` function captured by the most recent enqueueImportJob
+  // call, with a no-op progress callback — equivalent to what the queue
+  // does when it actually processes the job.
+  const runQueuedJob = async () => {
+    expect(mockEnqueueImportJob).toHaveBeenCalled();
+    const job = mockEnqueueImportJob.mock.calls[mockEnqueueImportJob.mock.calls.length - 1][0];
+    return job.run(jest.fn());
+  };
+
   test('renders modal with initial upload step', () => {
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     expect(screen.getByText('Rezept scannen')).toBeInTheDocument();
     expect(screen.getByText(/Fotografieren Sie ein Rezept/i)).toBeInTheDocument();
@@ -57,7 +56,7 @@ describe('OcrScanModal', () => {
   });
 
   test('cancel button calls onCancel', () => {
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const cancelButton = screen.getByText('Abbrechen');
     fireEvent.click(cancelButton);
@@ -66,7 +65,7 @@ describe('OcrScanModal', () => {
   });
 
   test('close button calls onCancel', () => {
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const closeButton = screen.getByText('×');
     fireEvent.click(closeButton);
@@ -74,19 +73,11 @@ describe('OcrScanModal', () => {
     expect(mockOnCancel).toHaveBeenCalledTimes(1);
   });
 
-  test('file upload shows preview step before scanning', async () => {
+  test('file upload shows preview step before queuing analysis', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Test Recipe',
-      ingredients: ['200g Zutat'],
-      steps: ['Mix'],
-      servings: 4,
-    });
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -98,32 +89,14 @@ describe('OcrScanModal', () => {
       expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
 
-    // Start analysis
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    // OCR should complete and import the recipe directly, without a review step
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Test Recipe' })
-      );
-    }, { timeout: OCR_TIMEOUT });
+    // Queues a background job and closes the modal immediately, without a review step
+    expect(mockEnqueueImportJob).toHaveBeenCalled();
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
   });
 
-  test('language selection works on upload step', async () => {
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    // Language selector should be visible on upload step
-    expect(screen.getByText('Deutsch')).toBeInTheDocument();
-    expect(screen.getByText('English')).toBeInTheDocument();
-
-    const englishButton = screen.getByText('English');
-    fireEvent.click(englishButton);
-
-    // Check that English tab is now active
-    expect(englishButton).toHaveClass('active');
-  });
-
-  test('AI OCR result is imported automatically once analysis completes', async () => {
+  test('queued job resolves to the recognized recipe', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
 
@@ -139,77 +112,37 @@ describe('OcrScanModal', () => {
 
     recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    // Wait for preview step and start analysis
     await waitFor(() => {
       expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    // Verify AI import was called without any review/confirm step
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith({
-        title: 'Test Recipe',
-        ingredients: ['200g Zutat'],
-        steps: ['Mix'],
-        portionen: 4,
-        kochdauer: 30,
-        kulinarik: [],
-        schwierigkeit: 3,
-        speisekategorie: ''
-      });
-    }, { timeout: OCR_TIMEOUT });
-  });
+    const recipe = await runQueuedJob();
 
-  test('displays error when AI OCR returns empty results', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: '',
-      ingredients: [],
-      steps: []
+    expect(recipe).toEqual({
+      title: 'Test Recipe',
+      ingredients: ['200g Zutat'],
+      steps: ['Mix'],
+      portionen: 4,
+      kochdauer: 30,
+      kulinarik: [],
+      schwierigkeit: 3,
+      speisekategorie: ''
     });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    // AI results are imported as-is, even if empty (with defaults) — no review step needed
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith({
-        title: '',
-        ingredients: [],
-        steps: [],
-        portionen: 4,
-        kochdauer: 30,
-        kulinarik: [],
-        schwierigkeit: 3,
-        speisekategorie: ''
-      });
-    }, { timeout: OCR_TIMEOUT });
-  });
+  }, OCR_TIMEOUT);
 
   test('handles file upload error', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
-    
+
     fileToBase64.mockRejectedValue(new Error('Failed to read file'));
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -220,105 +153,31 @@ describe('OcrScanModal', () => {
     });
   });
 
-  test('handles OCR processing error', async () => {
+  test('queued job surfaces the OCR error instead of resolving', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
+
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
     recognizeRecipeWithAI.mockRejectedValue(new Error('OCR processing failed'));
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    // Wait for preview step and start analysis
     await waitFor(() => {
       expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    await waitFor(() => {
-      expect(screen.getByText(/OCR fehlgeschlagen/i)).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-  });
+    await expect(runQueuedJob()).rejects.toThrow('Keine gültigen OCR-Ergebnisse gefunden');
+  }, OCR_TIMEOUT);
 
-  test('handles AI result with valid data', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Test',
-      ingredients: ['Ingredient'],
-      steps: ['Step']
-    });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith({
-        title: 'Test',
-        ingredients: ['Ingredient'],
-        steps: ['Step'],
-        portionen: 4,
-        kochdauer: 30,
-        kulinarik: [],
-        schwierigkeit: 3,
-        speisekategorie: ''
-      });
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('progress callback is passed to recognizeRecipeWithAI', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Test Recipe',
-      ingredients: ['Ingredient'],
-      steps: ['Step']
-    });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(recognizeRecipeWithAI).toHaveBeenCalled();
-    }, { timeout: OCR_TIMEOUT });
-
-    // Verify that recognizeRecipeWithAI was called with a progress callback function
-    const aiCall = recognizeRecipeWithAI.mock.calls[0];
-    expect(aiCall).toHaveLength(2);
-    expect(aiCall[1]).toHaveProperty('onProgress');
-    expect(aiCall[1].onProgress).toBeInstanceOf(Function);
-  });
-
-  test('modal starts scanning immediately when initialImage is provided', async () => {
+  test('modal queues an immediate scan and closes when initialImage is provided', async () => {
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
     const initialImageData = 'data:image/png;base64,test';
-    
+
     recognizeRecipeWithAI.mockResolvedValue({
       title: 'Initial Image Recipe',
       ingredients: ['Test'],
@@ -327,187 +186,61 @@ describe('OcrScanModal', () => {
 
     render(
       <OcrScanModal
-        onImport={mockOnImport}
         onCancel={mockOnCancel}
         initialImage={initialImageData}
       />
     );
 
-    // Should skip upload step and start scanning immediately
+    // Should skip upload step and queue immediately
     expect(screen.queryByText('Bild(er) hochladen')).not.toBeInTheDocument();
-    
-    // Wait for OCR to be called with the initial image
-    await waitFor(() => {
-      expect(recognizeRecipeWithAI).toHaveBeenCalledWith(
-        initialImageData,
-        expect.objectContaining({
-          language: 'de',
-          provider: 'gemini'
-        })
-      );
-    }, { timeout: OCR_TIMEOUT });
+    expect(mockEnqueueImportJob).toHaveBeenCalled();
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+
+    await runQueuedJob();
+    expect(recognizeRecipeWithAI).toHaveBeenCalledWith(
+      initialImageData,
+      expect.objectContaining({ language: 'de', provider: 'gemini' })
+    );
   });
 
-  test('displays error when AI OCR fails', async () => {
+  test('progress callback is passed to recognizeRecipeWithAI', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
     const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockRejectedValue(new Error('API key not configured'));
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    fileToBase64.mockResolvedValue('data:image/png;base64,test');
+    recognizeRecipeWithAI.mockResolvedValue({
+      title: 'Test Recipe',
+      ingredients: ['Ingredient'],
+      steps: ['Step']
+    });
+
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    // Wait for preview step and start analysis
     await waitFor(() => {
       expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    // Should show error when AI OCR fails
-    await waitFor(() => {
-      expect(screen.getByText(/OCR fehlgeschlagen.*API key not configured/i)).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
+    await runQueuedJob();
+
+    expect(recognizeRecipeWithAI).toHaveBeenCalled();
+    const aiCall = recognizeRecipeWithAI.mock.calls[0];
+    expect(aiCall).toHaveLength(2);
+    expect(aiCall[1]).toHaveProperty('onProgress');
+    expect(aiCall[1].onProgress).toBeInstanceOf(Function);
   });
 
-  test('AI mode is default - no mode selector shown', async () => {
+  test('queued job adds vegetarisch and vegan tags to kulinarik', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    await waitFor(() => {
-      // OCR mode selector should not be visible
-      expect(screen.queryByText('📝 Standard-OCR')).not.toBeInTheDocument();
-      expect(screen.queryByText('🤖 KI-Scan (Gemini)')).not.toBeInTheDocument();
-    });
-  });
-
-  test('AI mode is used by default', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(false);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    await waitFor(() => {
-      // No hint should be shown since the mode selector is hidden
-      expect(screen.queryByText(/KI-Scan benötigt einen Gemini API-Key/i)).not.toBeInTheDocument();
-    });
-  });
-
-  test('AI OCR mode processes image with Gemini and imports the result directly', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
+    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
 
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
 
-    const mockAiResult = {
-      title: 'AI-erkanntes Rezept',
-      servings: 4,
-      prepTime: '30 min',
-      difficulty: 3,
-      cuisine: 'Italienisch',
-      category: 'Hauptgericht',
-      ingredients: ['200g Pasta', '100g Tomaten'],
-      steps: ['Pasta kochen', 'Mit Tomaten servieren'],
-      tags: ['vegetarisch']
-    };
-    recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    // Upload file
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    // Should import directly after analysis, without a review step
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith(expect.objectContaining({
-        title: 'AI-erkanntes Rezept',
-        ingredients: ['200g Pasta', '100g Tomaten'],
-        steps: ['Pasta kochen', 'Mit Tomaten servieren']
-      }));
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('AI result can be imported directly', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
-
-    const mockAiResult = {
-      title: 'Testrezept',
-      servings: 2,
-      prepTime: '20 min',
-      difficulty: 2,
-      cuisine: 'Deutsch',
-      category: 'Dessert',
-      ingredients: ['100g Zucker'],
-      steps: ['Zucker schmelzen']
-    };
-    recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith({
-        title: 'Testrezept',
-        ingredients: ['100g Zucker'],
-        steps: ['Zucker schmelzen'],
-        portionen: 2,
-        kochdauer: 20,
-        kulinarik: ['Deutsch'],
-        schwierigkeit: 2,
-        speisekategorie: 'Dessert'
-      });
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('AI result adds vegetarisch and vegan tags to kulinarik', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
-
-    const mockAiResult = {
+    recognizeRecipeWithAI.mockResolvedValue({
       title: 'Veganer Salat',
       servings: 2,
       prepTime: '10 min',
@@ -517,36 +250,30 @@ describe('OcrScanModal', () => {
       ingredients: ['Tomaten', 'Gurken'],
       steps: ['Gemüse hacken'],
       tags: ['vegan', 'vegetarisch']
-    };
-    recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
+    });
 
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
     fireEvent.change(fileInput, { target: { files: [file] } });
 
-    // Wait for preview step and start analysis
     await waitFor(() => {
       expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith(expect.objectContaining({
-        kulinarik: expect.arrayContaining(['Mediterran', 'Vegan', 'Vegetarisch'])
-      }));
-    }, { timeout: OCR_TIMEOUT });
+    const recipe = await runQueuedJob();
+    expect(recipe.kulinarik).toEqual(expect.arrayContaining(['Mediterran', 'Vegan', 'Vegetarisch']));
   });
 
-  test('AI result does not duplicate kulinarik when tag matches cuisine', async () => {
+  test('queued job does not duplicate kulinarik when tag matches cuisine', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
+    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
 
     fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
 
-    const mockAiResult = {
+    recognizeRecipeWithAI.mockResolvedValue({
       title: 'Veggie Burger',
       servings: 4,
       prepTime: '30 min',
@@ -556,88 +283,9 @@ describe('OcrScanModal', () => {
       ingredients: ['Gemüse', 'Brötchen'],
       steps: ['Gemüse braten'],
       tags: ['vegetarisch']
-    };
-    recognizeRecipeWithAI.mockResolvedValue(mockAiResult);
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalled();
-    }, { timeout: OCR_TIMEOUT });
-
-    const calledWith = mockOnImport.mock.calls[0][0];
-    expect(calledWith.kulinarik.filter(k => k === 'Vegetarisch')).toHaveLength(1);
-  });
-
-  test('handles AI OCR error gracefully', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { isAiOcrAvailable, recognizeRecipeWithAI } = require('../utils/aiOcrService');
-    
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    isAiOcrAvailable.mockReturnValue(true);
-    recognizeRecipeWithAI.mockRejectedValue(new Error('API quota exceeded'));
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(screen.getByText(/OCR fehlgeschlagen.*API quota exceeded/i)).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('shows fallback to standard OCR button when AI OCR fails', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockRejectedValue(new Error('Tageslimit erreicht (20/20 Scans)'));
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(screen.getByText(/Mit Standard-OCR fortfahren/i)).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('shows clear callable auth error and keeps standard OCR fallback button', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockRejectedValue(
-      new Error('Die OCR-Funktion ist aktuell nicht korrekt freigeschaltet. Bitte Administrator kontaktieren.')
-    );
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+    render(<OcrScanModal onCancel={mockOnCancel} />);
 
     const fileInput = screen.getByLabelText('Bild(er) hochladen');
     const file = new File(['test'], 'test.png', { type: 'image/png' });
@@ -648,49 +296,13 @@ describe('OcrScanModal', () => {
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    await waitFor(() => {
-      expect(screen.getByText(/nicht korrekt freigeschaltet/i)).toBeInTheDocument();
-      expect(screen.getByText(/Mit Standard-OCR fortfahren/i)).toBeInTheDocument();
-    }, { timeout: OCR_TIMEOUT });
-  });
-
-  test('AI import includes the recipe data even when remainingScans is reported', async () => {
-    const { fileToBase64 } = require('../utils/imageUtils');
-    const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
-
-    fileToBase64.mockResolvedValue('data:image/png;base64,test');
-    recognizeRecipeWithAI.mockResolvedValue({
-      title: 'Test Recipe',
-      ingredients: ['Zutat'],
-      steps: ['Schritt'],
-      servings: 2,
-      remainingScans: 3,
-      dailyLimit: 20,
-    });
-
-    render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
-
-    const fileInput = screen.getByLabelText('Bild(er) hochladen');
-    const file = new File(['test'], 'test.png', { type: 'image/png' });
-    fireEvent.change(fileInput, { target: { files: [file] } });
-
-    // Wait for preview step and start analysis
-    await waitFor(() => {
-      expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
-
-    await waitFor(() => {
-      expect(mockOnImport).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Test Recipe' })
-      );
-    }, { timeout: OCR_TIMEOUT });
+    const recipe = await runQueuedJob();
+    expect(recipe.kulinarik.filter(k => k === 'Vegetarisch')).toHaveLength(1);
   });
 
   // Camera multi-photo tests
   describe('Camera multi-photo capture', () => {
     let mockGetUserMedia;
-    let mockVideoElement;
 
     beforeEach(() => {
       // Mock MediaStream and getUserMedia
@@ -704,10 +316,6 @@ describe('OcrScanModal', () => {
       });
 
       // Mock canvas toDataURL
-      mockVideoElement = {
-        videoWidth: 640,
-        videoHeight: 480,
-      };
       HTMLCanvasElement.prototype.toDataURL = jest.fn().mockReturnValue('data:image/png;base64,photo1');
       HTMLCanvasElement.prototype.getContext = jest.fn().mockReturnValue({
         drawImage: jest.fn(),
@@ -715,7 +323,7 @@ describe('OcrScanModal', () => {
     });
 
     test('camera start button activates camera', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -726,7 +334,7 @@ describe('OcrScanModal', () => {
     });
 
     test('capturing a photo keeps camera active and shows thumbnail', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -748,7 +356,7 @@ describe('OcrScanModal', () => {
     });
 
     test('capturing multiple photos shows correct count and thumbnails', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -757,14 +365,12 @@ describe('OcrScanModal', () => {
         expect(screen.getByText('Foto aufnehmen')).toBeInTheDocument();
       });
 
-      // Take first photo
       fireEvent.click(screen.getByText('Foto aufnehmen'));
 
       await waitFor(() => {
         expect(screen.getByText(/1 Foto aufgenommen/i)).toBeInTheDocument();
       });
 
-      // Take second photo
       fireEvent.click(screen.getByText(/Weiteres Foto aufnehmen/i));
 
       await waitFor(() => {
@@ -775,7 +381,7 @@ describe('OcrScanModal', () => {
     });
 
     test('analyse starten button appears after first photo', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -784,10 +390,8 @@ describe('OcrScanModal', () => {
         expect(screen.getByText('Foto aufnehmen')).toBeInTheDocument();
       });
 
-      // No analyse button before any photo
       expect(screen.queryByText(/Analyse starten/i)).not.toBeInTheDocument();
 
-      // Take first photo
       fireEvent.click(screen.getByText('Foto aufnehmen'));
 
       await waitFor(() => {
@@ -796,7 +400,7 @@ describe('OcrScanModal', () => {
     });
 
     test('letztes löschen button removes last photo', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -805,7 +409,6 @@ describe('OcrScanModal', () => {
         expect(screen.getByText('Foto aufnehmen')).toBeInTheDocument();
       });
 
-      // Take two photos
       fireEvent.click(screen.getByText('Foto aufnehmen'));
       await waitFor(() => {
         expect(screen.getByText(/1 Foto aufgenommen/i)).toBeInTheDocument();
@@ -816,7 +419,6 @@ describe('OcrScanModal', () => {
         expect(screen.getByText(/2 Fotos aufgenommen/i)).toBeInTheDocument();
       });
 
-      // Remove last photo
       fireEvent.click(screen.getByText('Löschen'));
 
       await waitFor(() => {
@@ -826,7 +428,7 @@ describe('OcrScanModal', () => {
     });
 
     test('abbrechen button stops camera and discards photos', async () => {
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -835,24 +437,21 @@ describe('OcrScanModal', () => {
         expect(screen.getByText('Foto aufnehmen')).toBeInTheDocument();
       });
 
-      // Take a photo
       fireEvent.click(screen.getByText('Foto aufnehmen'));
       await waitFor(() => {
         expect(screen.getByText(/1 Foto aufgenommen/i)).toBeInTheDocument();
       });
 
-      // Cancel camera
       const abortButton = screen.getByText('× Abbrechen');
       fireEvent.click(abortButton);
 
       await waitFor(() => {
-        // Should return to upload step with camera inactive
         expect(screen.getByText('Kamera starten')).toBeInTheDocument();
         expect(screen.queryByText(/aufgenommen/i)).not.toBeInTheDocument();
       });
     });
 
-    test('startBatchAnalysis processes captured photos and shows results', async () => {
+    test('startBatchAnalysis queues captured photos and closes the modal', async () => {
       const { recognizeRecipeWithAI } = require('../utils/aiOcrService');
       recognizeRecipeWithAI.mockResolvedValue({
         title: 'Kamera Rezept',
@@ -861,7 +460,7 @@ describe('OcrScanModal', () => {
         servings: 4,
       });
 
-      render(<OcrScanModal onImport={mockOnImport} onCancel={mockOnCancel} />);
+      render(<OcrScanModal onCancel={mockOnCancel} />);
 
       const cameraButton = screen.getByText('Kamera starten');
       fireEvent.click(cameraButton);
@@ -870,21 +469,19 @@ describe('OcrScanModal', () => {
         expect(screen.getByText('Foto aufnehmen')).toBeInTheDocument();
       });
 
-      // Take a photo
       fireEvent.click(screen.getByText('Foto aufnehmen'));
       await waitFor(() => {
         expect(screen.getByText(/Analyse starten \(1\)/i)).toBeInTheDocument();
       });
 
-      // Start analysis
       fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-      // Should import the recipe directly, without a review step
-      await waitFor(() => {
-        expect(mockOnImport).toHaveBeenCalledWith(
-          expect.objectContaining({ title: 'Kamera Rezept' })
-        );
-      }, { timeout: OCR_TIMEOUT });
-    });
+      // Queues the background job and closes the modal, without a review step
+      expect(mockEnqueueImportJob).toHaveBeenCalled();
+      expect(mockOnCancel).toHaveBeenCalledTimes(1);
+
+      const recipe = await runQueuedJob();
+      expect(recipe).toEqual(expect.objectContaining({ title: 'Kamera Rezept' }));
+    }, OCR_TIMEOUT);
   });
 });

--- a/src/components/RecipeForm.css
+++ b/src/components/RecipeForm.css
@@ -222,6 +222,84 @@
   line-height: 1.4;
 }
 
+.temp-import-banner {
+  background: linear-gradient(135deg, #FFF3E0 0%, #FFE0B2 100%);
+  border-left-color: #FB8C00;
+}
+
+.pending-imports-section {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.pending-imports-title {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.pending-imports-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pending-import-item {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.95rem;
+  color: #1a1a1a;
+}
+
+.pending-import-item:hover {
+  background: #ececec;
+}
+
+.pending-import-item-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pending-import-item-arrow {
+  flex-shrink: 0;
+  color: #888;
+  font-size: 1.1rem;
+}
+
+[data-theme="dark"] .pending-imports-section {
+  border-color: #3d3d3d;
+}
+
+[data-theme="dark"] .pending-imports-title {
+  color: #ccc;
+}
+
+[data-theme="dark"] .pending-import-item {
+  background: #2a2a2a;
+  border-color: #3d3d3d;
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .pending-import-item:hover {
+  background: #333;
+}
+
 .group-assignment-banner {
   display: flex;
   align-s: center;

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -11,6 +11,8 @@ import { formatIngredientSpacing, expandSaltAndPepperIngredients } from '../util
 import { encodeRecipeLink, decodeRecipeLink, containsHashForTypeahead } from '../utils/recipeLinks';
 import { getAutoAssignedIngredients } from '../utils/ingredientIdMatching';
 import { useNutritionReference } from '../contexts/NutritionReferenceContext';
+import { resolveImportGroupContext } from '../utils/recipeGroupContext';
+import { subscribeToTempRecipes } from '../utils/recipeFirestore';
 import RecipeImportModal from './RecipeImportModal';
 import OcrScanModal from './OcrScanModal';
 import WebImportModal from './WebImportModal';
@@ -391,7 +393,7 @@ function SortableStep({ id, item, index, stepNumber, onChange, onRemove, canRemo
   );
 }
 
-function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCreatingVersion = false, allRecipes = [], activeGroupId = null, groups = [], privateLists = [], initialWebImportUrl = '', initialWebImportAuthorId = '' }) {
+function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCreatingVersion = false, allRecipes = [], activeGroupId = null, groups = [], publicGroupId, privateLists = [], initialWebImportUrl = '', initialWebImportAuthorId = '', onSelectTempRecipe }) {
   const [title, setTitle] = useState('');
   const [image, setImage] = useState('');
   // Array of { url: string, isDefault: boolean } for multi-image support
@@ -634,6 +636,25 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   useEffect(() => {
     setImageError(false);
   }, [image]);
+
+  // Group/publish context applied to background-imported recipes (Web-Import,
+  // Foto-Scan), mirroring the same rules App.js uses when saving a new recipe.
+  const importContext = useMemo(
+    () => resolveImportGroupContext({ selectedGroupId: selectedPrivateListId, activeGroupId, groups, publicGroupId }),
+    [selectedPrivateListId, activeGroupId, groups, publicGroupId]
+  );
+
+  // Pending background imports (isTemp recipes) awaiting review — only
+  // relevant on the plain "Neues Rezept hinzufügen" page.
+  const [tempRecipes, setTempRecipes] = useState([]);
+  useEffect(() => {
+    if (recipe || isCreatingVersion || !currentUser?.id) {
+      setTempRecipes([]);
+      return undefined;
+    }
+    const unsubscribe = subscribeToTempRecipes(currentUser.id, setTempRecipes);
+    return () => unsubscribe();
+  }, [recipe, isCreatingVersion, currentUser?.id]);
 
   const handleCuisinePillToggle = (name) => {
     setKulinarik((prev) =>
@@ -1153,24 +1174,9 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     }
   };
 
-  const handleOcrScan = (ocrRecipe) => {
-    // Populate form with OCR scanned data
-    handleImport(ocrRecipe);
-    // Close the OCR modal
-    setShowOcrModal(false);
-    setOcrImagesBase64([]);
-  };
-
   const handleOcrCancel = () => {
     setShowOcrModal(false);
     setOcrImagesBase64([]);
-  };
-
-  const handleWebImport = (webRecipe) => {
-    // Populate form with web imported data
-    handleImport(webRecipe);
-    // Close the web import modal
-    setShowWebImportModal(false);
   };
 
   const handleRecipeSelect = (selectedRecipe) => {
@@ -1210,7 +1216,11 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     <div className="recipe-form-container">
       <div className="recipe-form-header">
         <h2 className="recipe-form-header-title">
-          {isCreatingVersion ? 'Eigene Version erstellen' : (recipe ? 'Rezept bearbeiten' : 'Neues Rezept hinzufügen')}
+          {isCreatingVersion
+            ? 'Eigene Version erstellen'
+            : recipe?.isTemp
+              ? 'Import überprüfen'
+              : (recipe ? 'Rezept bearbeiten' : 'Neues Rezept hinzufügen')}
         </h2>
         <div className="recipe-form-header-actions">
           <button
@@ -1240,6 +1250,38 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
           <div className="version-info-text">
             <p>Du erstellst eine neue Version von "{recipe?.title}".</p>
           </div>
+        </div>
+      )}
+
+      {recipe?.isTemp && (
+        <div className="version-info-banner temp-import-banner">
+          <div className="version-info-text">
+            <p>Dieses Rezept wurde automatisch importiert. Bitte prüfen und speichern oder verwerfen.</p>
+          </div>
+        </div>
+      )}
+
+      {!recipe && !isCreatingVersion && tempRecipes.length > 0 && (
+        <div className="pending-imports-section">
+          <p className="pending-imports-title">
+            {tempRecipes.length === 1
+              ? '1 automatischer Import wartet auf Überprüfung'
+              : `${tempRecipes.length} automatische Importe warten auf Überprüfung`}
+          </p>
+          <ul className="pending-imports-list">
+            {tempRecipes.map((tempRecipe) => (
+              <li key={tempRecipe.id}>
+                <button
+                  type="button"
+                  className="pending-import-item"
+                  onClick={() => onSelectTempRecipe?.(tempRecipe)}
+                >
+                  <span className="pending-import-item-title">{tempRecipe.title || 'Unbenanntes Rezept'}</span>
+                  <span className="pending-import-item-arrow">›</span>
+                </button>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 
@@ -1750,18 +1792,20 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
 
       {showOcrModal && (
         <OcrScanModal
-          onImport={handleOcrScan}
           onCancel={handleOcrCancel}
           initialImages={ocrImagesBase64}
+          userId={currentUser?.id}
+          importContext={importContext}
         />
       )}
 
       {showWebImportModal && (
         <WebImportModal
           initialUrl={initialWebImportUrl}
-          onImport={handleWebImport}
           onCancel={() => setShowWebImportModal(false)}
           authorId={initialWebImportAuthorId}
+          userId={currentUser?.id}
+          importContext={importContext}
         />
       )}
 

--- a/src/components/UniversalImportModal.js
+++ b/src/components/UniversalImportModal.js
@@ -4,6 +4,7 @@ import { fileToBase64 } from '../utils/imageUtils';
 import { recognizeRecipeWithAI } from '../utils/aiOcrService';
 import { captureWebsiteScreenshot } from '../utils/webImportService';
 import { buildRecipeFromAiResult } from '../utils/ocrParser';
+import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 function buildInitialText(title, text) {
   return [title, text].filter(Boolean).join('\n\n');
@@ -15,19 +16,158 @@ function buildInitialText(title, text) {
 // of every individual call, while staying under the per-user rate limit.
 const BATCH_CONCURRENCY = 3;
 
-function UniversalImportModal({ onImport, onCancel, initialImages = [], initialText = '', initialUrl = '', initialTitle = '' }) {
+function mergeAiResults(results) {
+  const validResults = results.filter(r => !r.error);
+  if (validResults.length === 0) {
+    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
+  }
+
+  const merged = { ...validResults[0] };
+
+  const allIngredients = validResults.flatMap(r => r.ingredients || []);
+  const seenIngredients = new Set();
+  merged.ingredients = allIngredients.filter(ing => {
+    const key = ing.toLowerCase().trim();
+    if (seenIngredients.has(key)) return false;
+    seenIngredients.add(key);
+    return true;
+  });
+
+  merged.steps = validResults.flatMap(r => r.steps || []);
+
+  const allTags = validResults.flatMap(r => r.tags || []);
+  merged.tags = [...new Set(allTags)];
+
+  const allNotes = validResults
+    .map(r => r.notes)
+    .filter(n => n && n.trim())
+    .join('\n\n');
+  merged.notes = allNotes || merged.notes;
+
+  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
+  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
+  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
+  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
+  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
+  merged.category = merged.category || validResults.find(r => r.category)?.category;
+
+  return merged;
+}
+
+// Runs recognition for a combination of images/text/url and returns the
+// merged recipe. Passed as the `run` function to enqueueImportJob() so it
+// executes in the background, after the modal has already closed.
+async function runUniversalImport({ images, text, url }, onProgress) {
+  const results = [];
+
+  if (url.trim()) {
+    const screenshotBase64 = await captureWebsiteScreenshot(url.trim(), (prog) => {
+      onProgress(Math.round(prog * 0.5), 'Lade Website...');
+    });
+    onProgress(50, 'Analysiere Website...');
+    try {
+      const result = await recognizeRecipeWithAI(screenshotBase64, {
+        language: 'de',
+        provider: 'gemini',
+        onProgress: (prog) => onProgress(50 + Math.round(prog * 0.5)),
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  }
+
+  if (text.trim()) {
+    onProgress(0, 'Analysiere Text...');
+    // Create a simple canvas image with the text for Gemini to extract from
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = Math.min(4000, Math.max(600, text.split('\n').length * 24 + 80));
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#000000';
+    ctx.font = '18px Arial, sans-serif';
+    const lines = text.split('\n');
+    let y = 40;
+    for (const line of lines) {
+      const words = line.split(' ');
+      let currentLine = '';
+      for (const word of words) {
+        const testLine = currentLine + (currentLine ? ' ' : '') + word;
+        if (ctx.measureText(testLine).width > 760 && currentLine) {
+          ctx.fillText(currentLine, 20, y);
+          y += 26;
+          currentLine = word;
+        } else {
+          currentLine = testLine;
+        }
+      }
+      if (currentLine) {
+        ctx.fillText(currentLine, 20, y);
+        y += 26;
+      }
+    }
+    const textImageBase64 = canvas.toDataURL('image/png');
+    try {
+      const result = await recognizeRecipeWithAI(textImageBase64, {
+        language: 'de',
+        provider: 'gemini',
+        onProgress: (prog) => onProgress(prog),
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  }
+
+  if (images.length > 0) {
+    const imageResults = new Array(images.length);
+    const progressPerImage = new Array(images.length).fill(0);
+
+    const updateOverallProgress = () => {
+      const sum = progressPerImage.reduce((a, b) => a + b, 0);
+      onProgress(Math.round(sum / images.length), images.length === 1 ? 'Analysiere Bild...' : `Analysiere ${images.length} Bilder...`);
+    };
+
+    let nextIndex = 0;
+    const processNext = async () => {
+      while (nextIndex < images.length) {
+        const i = nextIndex++;
+        try {
+          const result = await recognizeRecipeWithAI(images[i], {
+            language: 'de',
+            provider: 'gemini',
+            onProgress: (progress) => {
+              progressPerImage[i] = progress;
+              updateOverallProgress();
+            }
+          });
+          imageResults[i] = result;
+        } catch (err) {
+          imageResults[i] = { error: err.message };
+        }
+        progressPerImage[i] = 100;
+        updateOverallProgress();
+      }
+    };
+
+    const workerCount = Math.min(BATCH_CONCURRENCY, images.length);
+    await Promise.all(Array.from({ length: workerCount }, processNext));
+
+    results.push(...imageResults);
+  }
+
+  const merged = mergeAiResults(results);
+  return buildRecipeFromAiResult(merged);
+}
+
+function UniversalImportModal({ onCancel, initialImages = [], initialText = '', initialUrl = '', initialTitle = '', userId = '', importContext = {} }) {
   const [images, setImages] = useState(initialImages);
   const [text, setText] = useState(buildInitialText(initialTitle, initialText));
   const [url, setUrl] = useState(initialUrl);
-  const [step, setStep] = useState('preview'); // 'preview' | 'processing'
-  // Which images are currently being processed / already done. Images are
-  // processed concurrently, so several can be "processing" at once and don't
-  // necessarily finish in order.
-  const [activeImageIndices, setActiveImageIndices] = useState(() => new Set());
-  const [doneImageIndices, setDoneImageIndices] = useState(() => new Set());
-  const [scanProgress, setScanProgress] = useState(0);
   const [error, setError] = useState('');
-  const [processingLabel, setProcessingLabel] = useState('');
+  const { enqueueImportJob } = useRecipeImportQueue();
 
   const fileInputRef = useRef(null);
 
@@ -50,189 +190,24 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
     setImages(prev => prev.filter((_, i) => i !== index));
   };
 
-  const mergeAiResults = (results) => {
-    const validResults = results.filter(r => !r.error);
-    if (validResults.length === 0) {
-      throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
-    }
-
-    const merged = { ...validResults[0] };
-
-    const allIngredients = validResults.flatMap(r => r.ingredients || []);
-    const seenIngredients = new Set();
-    merged.ingredients = allIngredients.filter(ing => {
-      const key = ing.toLowerCase().trim();
-      if (seenIngredients.has(key)) return false;
-      seenIngredients.add(key);
-      return true;
-    });
-
-    merged.steps = validResults.flatMap(r => r.steps || []);
-
-    const allTags = validResults.flatMap(r => r.tags || []);
-    merged.tags = [...new Set(allTags)];
-
-    const allNotes = validResults
-      .map(r => r.notes)
-      .filter(n => n && n.trim())
-      .join('\n\n');
-    merged.notes = allNotes || merged.notes;
-
-    merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
-    merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
-    merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
-    merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
-    merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
-    merged.category = merged.category || validResults.find(r => r.category)?.category;
-
-    return merged;
-  };
-
-  const handleStartAnalysis = async () => {
+  const handleQueueImport = () => {
     if (!hasContent) {
       setError('Bitte fügen Sie mindestens einen Inhalt hinzu.');
       return;
     }
 
-    setError('');
-    setStep('processing');
-    setScanProgress(0);
+    const snapshot = { images: [...images], text, url };
+    enqueueImportJob({
+      label: snapshot.url.trim() || 'Rezept-Import',
+      userId,
+      context: importContext,
+      run: (onProgress) => runUniversalImport(snapshot, onProgress),
+    });
 
-    const results = [];
-
-    // Process URL: capture screenshot and run AI OCR
-    if (url.trim()) {
-      try {
-        setProcessingLabel('Lade Website...');
-        setScanProgress(0);
-        const screenshotBase64 = await captureWebsiteScreenshot(url.trim(), (prog) => {
-          setScanProgress(Math.round(prog * 0.5));
-        });
-        setProcessingLabel('Analysiere Website...');
-        const result = await recognizeRecipeWithAI(screenshotBase64, {
-          language: 'de',
-          provider: 'gemini',
-          onProgress: (prog) => setScanProgress(50 + Math.round(prog * 0.5))
-        });
-        results.push(result);
-      } catch (err) {
-        console.error('URL processing error:', err);
-        results.push({ error: err.message });
-      }
-    }
-
-    // Process plain text: build an image with the text for Gemini to extract from
-    if (text.trim()) {
-      try {
-        setProcessingLabel('Analysiere Text...');
-        setScanProgress(0);
-        // Create a simple canvas image with the text for OCR
-        const canvas = document.createElement('canvas');
-        canvas.width = 800;
-        canvas.height = Math.min(4000, Math.max(600, text.split('\n').length * 24 + 80));
-        const ctx = canvas.getContext('2d');
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#000000';
-        ctx.font = '18px Arial, sans-serif';
-        const lines = text.split('\n');
-        let y = 40;
-        for (const line of lines) {
-          // Word-wrap long lines
-          const words = line.split(' ');
-          let currentLine = '';
-          for (const word of words) {
-            const testLine = currentLine + (currentLine ? ' ' : '') + word;
-            if (ctx.measureText(testLine).width > 760 && currentLine) {
-              ctx.fillText(currentLine, 20, y);
-              y += 26;
-              currentLine = word;
-            } else {
-              currentLine = testLine;
-            }
-          }
-          if (currentLine) {
-            ctx.fillText(currentLine, 20, y);
-            y += 26;
-          }
-        }
-        const textImageBase64 = canvas.toDataURL('image/png');
-        const result = await recognizeRecipeWithAI(textImageBase64, {
-          language: 'de',
-          provider: 'gemini',
-          onProgress: (prog) => setScanProgress(prog)
-        });
-        results.push(result);
-      } catch (err) {
-        console.error('Text processing error:', err);
-        results.push({ error: err.message });
-      }
-    }
-
-    // Process images concurrently (up to BATCH_CONCURRENCY at once). Results
-    // are written back at their original index so step/ingredient order in
-    // the merged recipe stays independent of which image finishes first.
-    if (images.length > 0) {
-      const imageResults = new Array(images.length);
-      const progressPerImage = new Array(images.length).fill(0);
-
-      const updateOverallProgress = () => {
-        const sum = progressPerImage.reduce((a, b) => a + b, 0);
-        setScanProgress(Math.round(sum / images.length));
-      };
-
-      setScanProgress(0);
-      setActiveImageIndices(new Set());
-      setDoneImageIndices(new Set());
-      setProcessingLabel(
-        images.length === 1 ? 'Analysiere Bild...' : `Analysiere ${images.length} Bilder...`
-      );
-
-      let nextIndex = 0;
-      const processNext = async () => {
-        while (nextIndex < images.length) {
-          const i = nextIndex++;
-          setActiveImageIndices(prev => new Set(prev).add(i));
-
-          try {
-            const result = await recognizeRecipeWithAI(images[i], {
-              language: 'de',
-              provider: 'gemini',
-              onProgress: (progress) => {
-                progressPerImage[i] = progress;
-                updateOverallProgress();
-              }
-            });
-            imageResults[i] = result;
-          } catch (err) {
-            console.error(`Error processing image ${i + 1}:`, err);
-            imageResults[i] = { error: err.message };
-          }
-
-          progressPerImage[i] = 100;
-          setActiveImageIndices(prev => {
-            const next = new Set(prev);
-            next.delete(i);
-            return next;
-          });
-          setDoneImageIndices(prev => new Set(prev).add(i));
-          updateOverallProgress();
-        }
-      };
-
-      const workerCount = Math.min(BATCH_CONCURRENCY, images.length);
-      await Promise.all(Array.from({ length: workerCount }, processNext));
-
-      results.push(...imageResults);
-    }
-
-    try {
-      const merged = mergeAiResults(results);
-      onImport(buildRecipeFromAiResult(merged));
-    } catch (err) {
-      setError(err.message);
-      setStep('preview');
-    }
+    // The import now runs in the background (see the header's progress
+    // indicator); the recipe is saved with a TEMP flag once analysis
+    // finishes and shows up for review on "Neues Rezept hinzufügen".
+    onCancel();
   };
 
   const totalItems = images.length + (text.trim() ? 1 : 0) + (url.trim() ? 1 : 0);
@@ -246,129 +221,88 @@ function UniversalImportModal({ onImport, onCancel, initialImages = [], initialT
         </div>
 
         <div className="universal-import-content">
-          {/* Preview Step */}
-          {step === 'preview' && (
-            <>
-              {!hasContent ? (
-                <p className="universal-import-instructions">
-                  Keine geteilten Inhalte gefunden. Fügen Sie Bilder, Text oder eine URL hinzu.
-                </p>
-              ) : (
-                <p className="universal-import-instructions">
-                  {totalItems === 1
-                    ? '1 Inhalt bereit für die Analyse.'
-                    : `${totalItems} Inhalte bereit für die Analyse.`}{' '}
-                  Sie können weitere Bilder hinzufügen oder Inhalte bearbeiten.
-                </p>
-              )}
+          {!hasContent ? (
+            <p className="universal-import-instructions">
+              Keine geteilten Inhalte gefunden. Fügen Sie Bilder, Text oder eine URL hinzu.
+            </p>
+          ) : (
+            <p className="universal-import-instructions">
+              {totalItems === 1
+                ? '1 Inhalt bereit für die Analyse.'
+                : `${totalItems} Inhalte bereit für die Analyse.`}{' '}
+              Sie können weitere Bilder hinzufügen oder Inhalte bearbeiten.
+            </p>
+          )}
 
-              {/* URL field */}
-              <div className="universal-import-field">
-                <label className="universal-import-label">URL</label>
+          {/* URL field */}
+          <div className="universal-import-field">
+            <label className="universal-import-label">URL</label>
+            <input
+              type="url"
+              className="universal-import-url-input"
+              placeholder="https://beispiel.de/rezept"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+          </div>
+
+          {/* Text field */}
+          <div className="universal-import-field">
+            <label className="universal-import-label">Text</label>
+            <textarea
+              className="universal-import-textarea"
+              placeholder="Rezepttext hier einfügen..."
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={4}
+            />
+          </div>
+
+          {/* Image grid */}
+          <div className="universal-import-field">
+            <label className="universal-import-label">Bilder ({images.length})</label>
+            <div className="universal-image-grid">
+              {images.map((src, index) => (
+                <div key={index} className="universal-image-item">
+                  <img src={src} alt={`Bild ${index + 1}`} className="universal-image-thumb" />
+                  <button
+                    className="universal-image-remove"
+                    onClick={() => handleRemoveImage(index)}
+                    title="Bild entfernen"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+
+              <label className="universal-add-image" title="Weitere Bilder hinzufügen">
+                <span>+</span>
                 <input
-                  type="url"
-                  className="universal-import-url-input"
-                  placeholder="https://beispiel.de/rezept"
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/jpg,image/png,image/webp"
+                  multiple
+                  onChange={handleAddImages}
+                  style={{ display: 'none' }}
                 />
-              </div>
-
-              {/* Text field */}
-              <div className="universal-import-field">
-                <label className="universal-import-label">Text</label>
-                <textarea
-                  className="universal-import-textarea"
-                  placeholder="Rezepttext hier einfügen..."
-                  value={text}
-                  onChange={(e) => setText(e.target.value)}
-                  rows={4}
-                />
-              </div>
-
-              {/* Image grid */}
-              <div className="universal-import-field">
-                <label className="universal-import-label">Bilder ({images.length})</label>
-                <div className="universal-image-grid">
-                  {images.map((src, index) => (
-                    <div key={index} className="universal-image-item">
-                      <img src={src} alt={`Bild ${index + 1}`} className="universal-image-thumb" />
-                      <button
-                        className="universal-image-remove"
-                        onClick={() => handleRemoveImage(index)}
-                        title="Bild entfernen"
-                      >
-                        ×
-                      </button>
-                    </div>
-                  ))}
-
-                  <label className="universal-add-image" title="Weitere Bilder hinzufügen">
-                    <span>+</span>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/jpeg,image/jpg,image/png,image/webp"
-                      multiple
-                      onChange={handleAddImages}
-                      style={{ display: 'none' }}
-                    />
-                  </label>
-                </div>
-              </div>
-
-              {error && <div className="universal-error">{error}</div>}
-            </>
-          )}
-
-          {/* Processing Step */}
-          {step === 'processing' && (
-            <div className="universal-processing">
-              <p className="universal-processing-title">Analyse läuft...</p>
-              <p className="universal-processing-subtitle">{processingLabel}</p>
-              <div className="universal-progress-bar">
-                <div
-                  className="universal-progress-fill"
-                  style={{ width: `${scanProgress}%` }}
-                />
-              </div>
-              <p className="universal-progress-text">{scanProgress}%</p>
-              {images.length > 1 && (
-                <div className="universal-image-indicators">
-                  {images.map((_, index) => {
-                    const isDone = doneImageIndices.has(index);
-                    const isActive = activeImageIndices.has(index);
-                    return (
-                      <div
-                        key={index}
-                        className={`universal-image-indicator ${
-                          isDone ? 'completed' : isActive ? 'processing' : 'pending'
-                        }`}
-                      >
-                        {isDone ? '✓' : index + 1}
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
+              </label>
             </div>
-          )}
+          </div>
 
+          {error && <div className="universal-error">{error}</div>}
         </div>
 
         <div className="universal-import-actions">
           <button className="universal-cancel-button" onClick={onCancel}>
             Abbrechen
           </button>
-          {step === 'preview' && (
-            <button
-              className="universal-analyse-button"
-              onClick={handleStartAnalysis}
-              disabled={!hasContent}
-            >
-              Analyse starten
-            </button>
-          )}
+          <button
+            className="universal-analyse-button"
+            onClick={handleQueueImport}
+            disabled={!hasContent}
+          >
+            Import starten
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -5,17 +5,33 @@ import {
   isRecipeImportPageUrl,
   parseRecipeImportPage,
   isInstagramUrl,
-  isInstagramReelUrl,
   importInstagramReel,
   importRecipeFromUrl,
 } from '../utils/webImportService';
 import { buildRecipeFromAiResult } from '../utils/ocrParser';
+import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
-function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) {
-  const [step, setStep] = useState('url'); // 'url', 'loading'
+async function runWebImport(normalizedUrl, authorId, onProgress) {
+  let result;
+
+  if (isInstagramUrl(normalizedUrl)) {
+    // Instagram path (post, reel, or IGTV) – extract caption and page text with Puppeteer + Gemini
+    result = await importInstagramReel(normalizedUrl, onProgress);
+  } else if (isRecipeImportPageUrl(normalizedUrl)) {
+    // Direct HTML parsing path – no screenshot or AI needed
+    result = await parseRecipeImportPage(normalizedUrl, onProgress);
+  } else {
+    // Multi-step import: JSON-LD → Text+Gemini → Screenshot+Vision
+    result = await importRecipeFromUrl(normalizedUrl, onProgress);
+  }
+
+  return buildRecipeFromAiResult(result, authorId);
+}
+
+function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '', importContext = {} }) {
   const [url, setUrl] = useState(() => normalizeImportedUrl(initialUrl));
   const [error, setError] = useState('');
-  const [progress, setProgress] = useState(0);
+  const { enqueueImportJob } = useRecipeImportQueue();
 
   useEffect(() => {
     setUrl(normalizeImportedUrl(initialUrl));
@@ -31,8 +47,11 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
     }
   };
 
-  // Core submission logic – works with an explicit URL argument
-  const submitUrl = async (urlToSubmit) => {
+  // Core submission logic – works with an explicit URL argument. Queues the
+  // actual recognition as a background job and closes immediately; the
+  // recipe is saved with a TEMP flag once analysis finishes and shows up
+  // for review on "Neues Rezept hinzufügen".
+  const submitUrl = (urlToSubmit) => {
     const normalizedUrl = normalizeImportedUrl(urlToSubmit);
     setError('');
 
@@ -46,31 +65,14 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
       return;
     }
 
-    setStep('loading');
-    setProgress(10);
+    enqueueImportJob({
+      label: normalizedUrl,
+      userId,
+      context: importContext,
+      run: (onProgress) => runWebImport(normalizedUrl, authorId, onProgress),
+    });
 
-    try {
-      let result;
-
-      if (isInstagramUrl(normalizedUrl)) {
-        // Instagram path (post, reel, or IGTV) – extract caption and page text with Puppeteer + Gemini
-        result = await importInstagramReel(normalizedUrl, setProgress);
-      } else if (isRecipeImportPageUrl(normalizedUrl)) {
-        // Direct HTML parsing path – no screenshot or AI needed
-        result = await parseRecipeImportPage(normalizedUrl, setProgress);
-      } else {
-        // Multi-step import: JSON-LD → Text+Gemini → Screenshot+Vision
-        result = await importRecipeFromUrl(normalizedUrl, setProgress);
-      }
-
-      setProgress(100);
-      onImport(buildRecipeFromAiResult(result, authorId));
-    } catch (err) {
-      console.error('Web import error:', err);
-      setError(err.message || 'Fehler beim Importieren der Website');
-      setStep('url');
-      setProgress(0);
-    }
+    onCancel();
   };
 
   // Handle URL submission from the form
@@ -94,62 +96,34 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
         </div>
 
         <div className="web-import-modal-content">
-          {/* URL Input Step */}
-          {step === 'url' && (
-            <div className="url-input-section">
-              <p className="web-import-instructions">
-                Gebe die URL deines Rezepts ein
-              </p>
+          <div className="url-input-section">
+            <p className="web-import-instructions">
+              Gebe die URL deines Rezepts ein
+            </p>
 
-              <div className="url-input-container">
-                <label htmlFor="urlInput">Website-URL:</label>
-                <input
-                  type="text"
-                  id="urlInput"
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                  placeholder="z.B. https://www.chefkoch.de/rezepte/..."
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      handleSubmit();
-                    }
-                  }}
-                  autoFocus
-                />
-              </div>
-
-              <div className="url-input-hint">
-                <p>Tipp: Die Website wird automatisch erfasst und das Rezept extrahiert.</p>
-                <p>Instagram Reels werden direkt unterstützt – die Caption wird automatisch ausgelesen.</p>
-              </div>
+            <div className="url-input-container">
+              <label htmlFor="urlInput">Website-URL:</label>
+              <input
+                type="text"
+                id="urlInput"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="z.B. https://www.chefkoch.de/rezepte/..."
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSubmit();
+                  }
+                }}
+                autoFocus
+              />
             </div>
-          )}
 
-          {/* Loading Step */}
-          {step === 'loading' && (
-            <div className="loading-section">
-              <p className="web-import-instructions">
-                {isInstagramReelUrl(url)
-                  ? (progress < 70
-                      ? 'Extrahiere Caption und Kommentare...'
-                      : 'Analysiere Rezept...')
-                  : (progress < 30
-                      ? 'Analysiere Website-Struktur...'
-                      : progress < 40
-                        ? 'Extrahiere Rezeptdaten...'
-                        : 'Analysiere Rezept...')}
-              </p>
-              <div className="progress-container">
-                <div className="progress-bar">
-                  <div
-                    className="progress-fill"
-                    style={{ width: `${progress}%` }}
-                  />
-                </div>
-                <p className="progress-text">{Math.round(progress)}%</p>
-              </div>
+            <div className="url-input-hint">
+              <p>Tipp: Die Website wird automatisch erfasst und das Rezept extrahiert.</p>
+              <p>Instagram Reels werden direkt unterstützt – die Caption wird automatisch ausgelesen.</p>
+              <p>Der Import läuft im Hintergrund – du kannst währenddessen weiterarbeiten.</p>
             </div>
-          )}
+          </div>
 
           {error && (
             <div className="web-import-error">
@@ -162,12 +136,9 @@ function WebImportModal({ onImport, onCancel, initialUrl = '', authorId = '' }) 
           <button className="cancel-button" onClick={onCancel}>
             Abbrechen
           </button>
-          
-          {step === 'url' && (
-            <button className="submit-button" onClick={handleSubmit}>
-              Weiter
-            </button>
-          )}
+          <button className="submit-button" onClick={handleSubmit}>
+            Import starten
+          </button>
         </div>
       </div>
     </div>

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -1,0 +1,95 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react';
+import { addRecipe as addRecipeToFirestore } from '../utils/recipeFirestore';
+
+const RecipeImportQueueContext = createContext(null);
+
+let jobIdCounter = 0;
+function nextJobId() {
+  jobIdCounter += 1;
+  return `import-${Date.now()}-${jobIdCounter}`;
+}
+
+const noopQueue = {
+  jobs: [],
+  enqueueImportJob: () => undefined,
+  dismissJob: () => {},
+};
+
+/**
+ * Runs recipe-import recognition (web import, AI photo OCR, ...) as a
+ * sequential background queue: enqueueImportJob() takes an async `run`
+ * function that resolves to a recipe object (no id yet), and once it
+ * resolves, the recipe is saved directly to Firestore with isTemp:true.
+ * Jobs are processed one at a time (FIFO) so multiple queued imports don't
+ * race each other or blow through OCR rate limits.
+ *
+ * Pending temp recipes are later surfaced on the "Neues Rezept hinzufügen"
+ * page (see subscribeToTempRecipes) for the user to confirm or discard.
+ */
+export function RecipeImportQueueProvider({ children }) {
+  const [jobs, setJobs] = useState([]);
+  const queueRef = useRef([]);
+  const processingRef = useRef(false);
+
+  const patchJob = useCallback((id, patch) => {
+    setJobs((prev) => prev.map((job) => (job.id === id ? { ...job, ...patch } : job)));
+  }, []);
+
+  const removeJob = useCallback((id) => {
+    setJobs((prev) => prev.filter((job) => job.id !== id));
+  }, []);
+
+  const processQueue = useCallback(async () => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    try {
+      while (queueRef.current.length > 0) {
+        const job = queueRef.current[0];
+        patchJob(job.id, { status: 'processing' });
+        try {
+          const recipe = await job.run((progress, label) => {
+            patchJob(job.id, {
+              progress: Math.max(0, Math.min(100, Math.round(progress || 0))),
+              ...(label ? { label } : {}),
+            });
+          });
+          await addRecipeToFirestore({ ...recipe, ...job.context, isTemp: true }, job.userId);
+          removeJob(job.id);
+        } catch (error) {
+          console.error('Hintergrund-Import fehlgeschlagen:', error);
+          patchJob(job.id, { status: 'error', error: error?.message || 'Import fehlgeschlagen' });
+        } finally {
+          queueRef.current.shift();
+        }
+      }
+    } finally {
+      processingRef.current = false;
+    }
+  }, [patchJob, removeJob]);
+
+  const enqueueImportJob = useCallback(({ label, run, context = {}, userId }) => {
+    const id = nextJobId();
+    queueRef.current.push({ id, run, context, userId });
+    setJobs((prev) => [...prev, { id, label, status: 'queued', progress: 0 }]);
+    processQueue();
+    return id;
+  }, [processQueue]);
+
+  const value = { jobs, enqueueImportJob, dismissJob: removeJob };
+
+  return (
+    <RecipeImportQueueContext.Provider value={value}>
+      {children}
+    </RecipeImportQueueContext.Provider>
+  );
+}
+
+/**
+ * Reads the shared import queue. Safe to call even when no
+ * RecipeImportQueueProvider is mounted (e.g. pre-login screens that still
+ * render <Header>) — falls back to an inert, always-empty queue.
+ */
+export function useRecipeImportQueue() {
+  const context = useContext(RecipeImportQueueContext);
+  return context || noopQueue;
+}

--- a/src/utils/recipeFirestore.js
+++ b/src/utils/recipeFirestore.js
@@ -35,7 +35,7 @@ import { deleteRecipeImage } from './storageUtils';
  */
 export const subscribeToRecipes = (userId, isAdmin, callback, userGroupIds = [], publicGroupIds = []) => {
   const recipesRef = collection(db, 'recipes');
-  
+
   return onSnapshot(recipesRef, (snapshot) => {
     const recipes = [];
     snapshot.forEach((doc) => {
@@ -43,7 +43,14 @@ export const subscribeToRecipes = (userId, isAdmin, callback, userGroupIds = [],
         id: doc.id,
         ...doc.data()
       };
-      
+
+      // Pending background imports (isTemp) are not real recipes yet — they
+      // only surface in the "Neues Rezept hinzufügen" pending-imports review
+      // list (see subscribeToTempRecipes), never in the main recipe list.
+      if (recipe.isTemp) {
+        return;
+      }
+
       // Group recipes are only visible to group members (and admins),
       // unless the recipe has been published to the public list.
       if (recipe.groupId && !recipe.publishedToPublic) {
@@ -81,7 +88,12 @@ export const getRecipes = async (userId, isAdmin) => {
         id: doc.id,
         ...doc.data()
       };
-      
+
+      // Pending background imports (isTemp) are not real recipes yet.
+      if (recipe.isTemp) {
+        return;
+      }
+
       // Include recipe if it's public OR if it's private and (user is admin OR recipe author)
       if (!recipe.isPrivate || isAdmin || recipe.authorId === userId) {
         recipes.push(recipe);
@@ -92,6 +104,35 @@ export const getRecipes = async (userId, isAdmin) => {
     console.error('Error getting recipes:', error);
     return [];
   }
+};
+
+/**
+ * Set up a real-time listener for the current user's pending background
+ * imports (recipes saved with isTemp:true, awaiting review on the "Neues
+ * Rezept hinzufügen" page).
+ * @param {string} userId - Current user ID (only their own temp imports are returned)
+ * @param {Function} callback - Callback function that receives the temp recipes array
+ * @returns {Function} Unsubscribe function
+ */
+export const subscribeToTempRecipes = (userId, callback) => {
+  if (!userId) {
+    callback([]);
+    return () => {};
+  }
+
+  const recipesRef = collection(db, 'recipes');
+  const q = query(recipesRef, where('authorId', '==', userId), where('isTemp', '==', true));
+
+  return onSnapshot(q, (snapshot) => {
+    const recipes = [];
+    snapshot.forEach((doc) => {
+      recipes.push({ id: doc.id, ...doc.data() });
+    });
+    callback(recipes);
+  }, (error) => {
+    console.error('Error subscribing to temp recipes:', error);
+    callback([]);
+  });
 };
 
 /**

--- a/src/utils/recipeGroupContext.js
+++ b/src/utils/recipeGroupContext.js
@@ -1,0 +1,48 @@
+/**
+ * Resolves which group/private list a newly created recipe should be
+ * attached to, and whether it should be auto-published to the public list,
+ * given the context "Rezept hinzufügen" was invoked in (an explicit private
+ * list dropdown selection vs. an active group vs. a plain public add).
+ *
+ * Shared between the normal save path (App.js handleSaveRecipe) and
+ * background-import call sites, so both apply identical group/publish rules.
+ */
+export function resolveRecipeGroupContext({
+  selectedGroupId,
+  activeGroupId = null,
+  groups = [],
+  publicGroupId,
+  isCreatingVersion = false,
+} = {}) {
+  const resolvedPublicGroupId = publicGroupId || groups.find(g => g.type === 'public')?.id;
+  let groupId;
+  let autoPublish;
+
+  if (selectedGroupId) {
+    // User explicitly chose a private list from the form dropdown
+    groupId = selectedGroupId;
+    autoPublish = false;
+  } else {
+    groupId = activeGroupId
+      ? (typeof activeGroupId === 'string' ? activeGroupId : activeGroupId.id ?? String(activeGroupId))
+      : resolvedPublicGroupId;
+    autoPublish = !activeGroupId && !isCreatingVersion;
+  }
+
+  const activeGroup = groups.find(g => g.id === groupId);
+  const groupType = activeGroup?.type ?? 'public';
+
+  return { groupId: groupId || null, groupType, autoPublish };
+}
+
+/**
+ * Same resolution as resolveRecipeGroupContext(), but returns only the
+ * fields that should be merged onto a recipe object before saving it
+ * (empty object when no group applies).
+ */
+export function resolveImportGroupContext(params) {
+  const { groupId, groupType, autoPublish } = resolveRecipeGroupContext(params);
+  return groupId
+    ? { groupId, groupType, ...(autoPublish ? { publishedToPublic: true } : {}) }
+    : {};
+}


### PR DESCRIPTION
Web-Import, Foto-Scan and the Teilen-Ziel-Import (Universal Import) now
queue recognition as a background job instead of blocking the UI: the
modal closes immediately, and a small progress donut next to the
hamburger menu (click to open the job list) shows what's running.
Multiple imports queue and process sequentially.

Finished imports are saved straight to the recipes collection with an
isTemp flag and stay hidden from the normal recipe list. They surface on
"Neues Rezept hinzufügen" as a pending-imports list; opening one loads
it into the form for full review — "Speichern" clears the isTemp flag,
"Abbrechen" deletes the draft (with the same confirm-before-delete rule
used for any recipe with content).

The camera-scan AI-OCR fallback UI (aiFailed / "Mit Standard-OCR
fortfahren") is removed since it becomes unreachable once analysis runs
in the background; OcrScanModal.test.js is rewritten to match the new
enqueue-and-close contract.