### PR TITLE
docs: correct outdated webimport and shortcut documentation

### DIFF
--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -203,7 +203,9 @@ Die Cloud Function gibt zurück:
 
 ### App-URL aufbauen
 
-Nach dem API-Call öffnest du die `importUrl` direkt mit der Aktion „URL öffnen". Die App erkennt automatisch den Import und startet den Import-Workflow.
+Nach dem API-Call öffnest du die `importUrl` mit der Aktion „URL öffnen".
+
+**Hinweis:** `recipeImportPage` ist aktuell eine eigenständige, statische Antwortseite der Cloud Function (Titel + Rezepttext + JSON-LD) ohne Verbindung zur React-App-Shell — es gibt keinen automatischen Redirect in den Import-Workflow der App. Zusätzlich öffnet iOS eine per Shortcuts-Aktion „URL öffnen" aufgerufene Adresse grundsätzlich in Safari, auch wenn die PWA installiert ist und dieselbe Domain/denselben Scope hat; das ist eine iOS-Plattformeinschränkung und lässt sich nicht per Manifest/Scope-Konfiguration umgehen. Für einen tatsächlichen In-App-Import muss der Nutzer nach dem Öffnen manuell zur installierten App wechseln.
 
 ---
 

--- a/WEBIMPORT_FEATURE.md
+++ b/WEBIMPORT_FEATURE.md
@@ -44,41 +44,25 @@ Das Webimport-Button-Icon kann in den Einstellungen unter "Allgemein" > "Button-
 - Standard: 🌐 (Globus-Emoji)
 - Kann durch Emoji, Text oder eigenes Bild ersetzt werden
 
-### Puppeteer-Installation (Erforderlich)
+### Puppeteer-Installation
 
-**WICHTIG**: Die Screenshot-Funktion benötigt Puppeteer, das aktuell noch nicht installiert ist.
+Puppeteer (`puppeteer@^21.0.0`) und `@sparticuz/chromium` sind in `functions/package.json` als Dependencies eingetragen und in `captureWebsiteScreenshot` (`functions/index.js`) aktiv implementiert (kein Platzhalter, kein auskommentierter Code). Die Function nutzt `chromium.executablePath()`, `memory: '2GiB'` und `timeoutSeconds: 120`.
 
-#### Schritte zur Aktivierung:
+Falls die Cloud Functions noch nicht mit dieser Version deployed wurden:
 
-1. Puppeteer zu Cloud Functions hinzufügen:
-   ```bash
-   cd functions
-   npm install puppeteer@^21.0.0
-   ```
-
-2. Cloud Functions neu deployen:
-   ```bash
-   firebase deploy --only functions
-   ```
-
-3. Memory und Timeout in `functions/index.js` ggf. anpassen:
-   ```javascript
-   exports.captureWebsiteScreenshot = onCall({
-     maxInstances: 10,
-     memory: '2GiB',  // Erhöht für Puppeteer
-     timeoutSeconds: 60,
-   }, ...)
-   ```
+```bash
+cd functions
+npm install
+firebase deploy --only functions:captureWebsiteScreenshot
+```
 
 ### Aktuelle Implementierung
 
-Die Cloud Function ist bereits vorbereitet und enthält:
-- ✅ URL-Validierung
+Die Cloud Function enthält:
+- ✅ URL-Validierung (inkl. SSRF-Schutz via `assertPublicUrl`)
 - ✅ Rate Limiting
 - ✅ Authentifizierung
-- ⏳ Puppeteer-Integration (auskommentiert, bis Puppeteer installiert ist)
-
-Aktuell wird ein hilfreicher Fehler zurückgegeben, der erklärt, dass Puppeteer installiert werden muss.
+- ✅ Puppeteer-Integration (aktiv, inkl. User-Agent-Spoofing und Automation-Fingerprint-Unterdrückung)
 
 ## Nutzung
 


### PR DESCRIPTION
Puppeteer/@sparticuz/chromium are already installed and active in
captureWebsiteScreenshot, not pending setup as previously documented.
Also clarifies that Shortcuts' "URL öffnen" always opens Safari on iOS
(platform limitation) and that recipeImportPage is a standalone page
with no auto-redirect into the app shell.