### PR TITLE
perf: code-split secondary views to speed up initial app load

### DIFF
--- a/src/App.auth.test.js
+++ b/src/App.auth.test.js
@@ -484,14 +484,14 @@ describe('App authentication view handling', () => {
     expect(screen.getByTestId('recipe-list-view')).toBeInTheDocument();
 
     fireEvent.click(navQueries.getByRole('button', { name: 'Festtafel' }));
-    expect(screen.getByTestId('menu-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('menu-list-view')).toBeInTheDocument();
 
     localStorage.setItem('atelierOnboardingSeen', 'true');
     fireEvent.click(navQueries.getByRole('button', { name: 'Atelier' }));
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
 
     fireEvent.click(navQueries.getByRole('button', { name: 'Chefkoch' }));
-    expect(screen.getByTestId('kueche-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('kueche-view')).toBeInTheDocument();
   });
 
   test('clicking the active bottom navigation tab scrolls back to the top', async () => {
@@ -552,7 +552,7 @@ describe('App authentication view handling', () => {
 
     localStorage.setItem('atelierOnboardingSeen', 'true');
     fireEvent.click(navQueries.getByRole('button', { name: 'Atelier' }));
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
     // Kochatelier keeps the compact pill visible instead of hiding the bottom nav.
     expect(nav).toHaveAttribute('data-visible', 'true');
   });
@@ -579,7 +579,7 @@ describe('App authentication view handling', () => {
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Atelier Onboarding' })).not.toBeInTheDocument();
   });
 
@@ -627,7 +627,7 @@ describe('App authentication view handling', () => {
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
-    expect(screen.getByRole('dialog', { name: 'Atelier Onboarding' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Atelier Onboarding' })).toBeInTheDocument();
     expect(screen.queryByTestId('tagesmenu-view')).not.toBeInTheDocument();
   });
 
@@ -655,7 +655,7 @@ describe('App authentication view handling', () => {
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
-    expect(screen.getByRole('dialog', { name: 'Atelier Onboarding' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Atelier Onboarding' })).toBeInTheDocument();
     expect(screen.queryByTestId('tagesmenu-view')).not.toBeInTheDocument();
   });
 
@@ -683,7 +683,7 @@ describe('App authentication view handling', () => {
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Atelier Onboarding' })).not.toBeInTheDocument();
   });
 
@@ -730,20 +730,20 @@ describe('App authentication view handling', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Weiter' }));
 
-    expect(screen.getByTestId('atelier-category-selection-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('atelier-category-selection-view')).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Swipe-Training' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Dessert' }));
     fireEvent.click(screen.getByRole('button', { name: 'Kochatelier öffnen' }));
 
-    expect(screen.getByRole('dialog', { name: 'Swipe-Training' })).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Swipe-Training' })).toBeInTheDocument();
 
     swipeTrainerRight();
     swipeTrainerLeft();
     swipeTrainerUp();
     swipeTrainerLeft();
 
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
     expect(mockTagesmenuProps.mock.lastCall[0].selectedCategories).toEqual(['Dessert']);
   });
 
@@ -784,7 +784,7 @@ describe('App authentication view handling', () => {
     localStorage.setItem('atelierOnboardingSeen', 'true');
     fireEvent.click(within(nav).getByRole('button', { name: 'Atelier' }));
 
-    expect(screen.getByTestId('tagesmenu-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('tagesmenu-view')).toBeInTheDocument();
     // Kochatelier keeps the compact pill visible instead of hiding the bottom nav.
     expect(nav).toHaveAttribute('data-visible', 'true');
     expect(app.style.getPropertyValue('--bottom-nav-offset')).toBe('var(--bottom-nav-height)');
@@ -837,10 +837,10 @@ describe('App authentication view handling', () => {
     expect(await screen.findByTestId('startseite-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'startseite-go-groups' }));
-    expect(screen.getByTestId('group-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-list-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'close-groups' }));
-    expect(screen.getByTestId('startseite-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('startseite-view')).toBeInTheDocument();
   });
 
   test('closing groups still returns to kueche when groups were not opened from startseite', async () => {
@@ -864,11 +864,11 @@ describe('App authentication view handling', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'go-recipes' }));
     fireEvent.click(screen.getByRole('button', { name: 'go-groups' }));
-    expect(screen.getByTestId('group-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-list-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'close-groups' }));
 
-    expect(screen.getByTestId('kueche-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('kueche-view')).toBeInTheDocument();
     expect(screen.queryByTestId('startseite-view')).not.toBeInTheDocument();
   });
 
@@ -892,16 +892,16 @@ describe('App authentication view handling', () => {
     expect(await screen.findByTestId('startseite-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'startseite-go-groups' }));
-    expect(screen.getByTestId('group-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-list-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'open-group' }));
-    expect(screen.getByTestId('group-detail-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-detail-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'back-to-groups' }));
-    expect(screen.getByTestId('group-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-list-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'close-groups' }));
-    expect(screen.getByTestId('startseite-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('startseite-view')).toBeInTheDocument();
   });
 
   test('updates selected private list data immediately after editing group properties', async () => {
@@ -1047,7 +1047,7 @@ describe('App authentication view handling', () => {
     expect(await screen.findByTestId('app-calls-view')).toHaveAttribute('data-visible-tabs', '["kulinariktypen"]');
 
     fireEvent.click(screen.getByRole('button', { name: 'appcalls-back' }));
-    expect(screen.getByTestId('kueche-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('kueche-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'go-appcalls' }));
 
@@ -1078,7 +1078,7 @@ describe('App authentication view handling', () => {
     fireEvent.click(screen.getByRole('button', { name: 'go-recipes' }));
     fireEvent.click(screen.getByRole('button', { name: 'add-recipe' }));
 
-    expect(screen.getByTestId('recipe-form-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('recipe-form-view')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Hauptnavigation' })).not.toBeInTheDocument();
   });
 
@@ -1104,7 +1104,7 @@ describe('App authentication view handling', () => {
     fireEvent.click(screen.getByRole('button', { name: 'go-recipes' }));
     fireEvent.click(screen.getByRole('button', { name: 'open-recipe' }));
 
-    expect(screen.getByTestId('recipe-detail-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('recipe-detail-view')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Hauptnavigation' })).not.toBeInTheDocument();
   });
 
@@ -1127,9 +1127,9 @@ describe('App authentication view handling', () => {
 
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Festtafel' }));
-    fireEvent.click(screen.getByRole('button', { name: 'add-menu' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'add-menu' }));
 
-    expect(screen.getByTestId('menu-form-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('menu-form-view')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Hauptnavigation' })).not.toBeInTheDocument();
   });
 
@@ -1152,9 +1152,9 @@ describe('App authentication view handling', () => {
 
     const nav = await screen.findByRole('navigation', { name: 'Hauptnavigation' });
     fireEvent.click(within(nav).getByRole('button', { name: 'Festtafel' }));
-    fireEvent.click(screen.getByRole('button', { name: 'open-menu' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'open-menu' }));
 
-    expect(screen.getByTestId('menu-detail-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('menu-detail-view')).toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: 'Hauptnavigation' })).not.toBeInTheDocument();
   });
 
@@ -1178,7 +1178,7 @@ describe('App authentication view handling', () => {
     expect(await screen.findByRole('navigation', { name: 'Hauptnavigation' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'go-kueche' }));
-    expect(screen.getByTestId('kueche-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('kueche-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'open-personal-data' }));
     expect(screen.queryByRole('navigation', { name: 'Hauptnavigation' })).not.toBeInTheDocument();
@@ -1207,10 +1207,10 @@ describe('App authentication view handling', () => {
     await screen.findByRole('navigation', { name: 'Hauptnavigation' });
 
     fireEvent.click(screen.getByRole('button', { name: 'go-groups' }));
-    expect(screen.getByTestId('group-list-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-list-view')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'open-group' }));
-    expect(screen.getByTestId('group-detail-view')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-detail-view')).toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: 'Hauptnavigation' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'open-settings-tab' }));

--- a/src/App.js
+++ b/src/App.js
@@ -1,35 +1,12 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, Suspense, lazy } from 'react';
 import './App.css';
 import RecipeList from './components/RecipeList';
 import RecipeFilterSidebar from './components/RecipeFilterSidebar';
-import RecipeDetail from './components/RecipeDetail';
-import RecipeForm from './components/RecipeForm';
 import Header from './components/Header';
-import Settings from './components/Settings';
-import MenuList from './components/MenuList';
-import MenuDetail from './components/MenuDetail';
-import MenuForm from './components/MenuForm';
 import Login from './components/Login';
-import Register from './components/Register';
-import PasswordChangeModal from './components/PasswordChangeModal';
-import Kueche from './components/Kueche';
-import SharePage from './components/SharePage';
-import MenuSharePage from './components/MenuSharePage';
-import GroupList from './components/GroupList';
-import GroupDetail from './components/GroupDetail';
-import AppCallsPage from './components/AppCallsPage';
-import MeineKuechenstarsPage from './components/MeineKuechenstarsPage';
-import EventsPage from './components/EventsPage';
-import Tagesmenu from './components/Tagesmenu';
-import UniversalImportModal from './components/UniversalImportModal';
-import Startseite from './components/Startseite';
 import MobileSearchOverlay from './components/MobileSearchOverlay';
 import BottomNavigation from './components/BottomNavigation';
-import AtelierOnboardingOverlay from './components/AtelierOnboardingOverlay';
-import AtelierSwipeTrainerOverlay from './components/AtelierSwipeTrainerOverlay';
-import AtelierTasteIntroOverlay from './components/AtelierTasteIntroOverlay';
-import AtelierCategorySelectionPage from './components/AtelierCategorySelectionPage';
-import { 
+import {
   loginUser, 
   logoutUser, 
   registerUser,
@@ -91,6 +68,39 @@ import {
 import { NutritionReferenceProvider, useNutritionReference } from './contexts/NutritionReferenceContext';
 import { RecipeImportQueueProvider } from './contexts/RecipeImportQueueContext';
 import { resolveRecipeGroupContext, resolveImportGroupContext } from './utils/recipeGroupContext';
+
+// Lazily loaded: everything below is a secondary view/overlay that isn't
+// needed for the initial "recipes" screen. Splitting these out of the main
+// bundle (which included tesseract.js via RecipeForm -> OcrScanModal) cuts
+// the initial JS payload substantially, which matters most on slower mobile
+// CPUs/networks (e.g. iPhone on cellular).
+const RecipeDetail = lazy(() => import('./components/RecipeDetail'));
+const RecipeForm = lazy(() => import('./components/RecipeForm'));
+const Settings = lazy(() => import('./components/Settings'));
+const MenuList = lazy(() => import('./components/MenuList'));
+const MenuDetail = lazy(() => import('./components/MenuDetail'));
+const MenuForm = lazy(() => import('./components/MenuForm'));
+const Register = lazy(() => import('./components/Register'));
+const PasswordChangeModal = lazy(() => import('./components/PasswordChangeModal'));
+const Kueche = lazy(() => import('./components/Kueche'));
+const SharePage = lazy(() => import('./components/SharePage'));
+const MenuSharePage = lazy(() => import('./components/MenuSharePage'));
+const GroupList = lazy(() => import('./components/GroupList'));
+const GroupDetail = lazy(() => import('./components/GroupDetail'));
+const AppCallsPage = lazy(() => import('./components/AppCallsPage'));
+const MeineKuechenstarsPage = lazy(() => import('./components/MeineKuechenstarsPage'));
+const EventsPage = lazy(() => import('./components/EventsPage'));
+const Tagesmenu = lazy(() => import('./components/Tagesmenu'));
+const UniversalImportModal = lazy(() => import('./components/UniversalImportModal'));
+const Startseite = lazy(() => import('./components/Startseite'));
+const AtelierOnboardingOverlay = lazy(() => import('./components/AtelierOnboardingOverlay'));
+const AtelierSwipeTrainerOverlay = lazy(() => import('./components/AtelierSwipeTrainerOverlay'));
+const AtelierTasteIntroOverlay = lazy(() => import('./components/AtelierTasteIntroOverlay'));
+const AtelierCategorySelectionPage = lazy(() => import('./components/AtelierCategorySelectionPage'));
+
+const ViewLoadingFallback = () => (
+  <div style={{ padding: '2rem', textAlign: 'center' }}>Laden...</div>
+);
 
 const PENDING_WEBIMPORT_URL_STORAGE_KEY = 'pendingWebimportUrl';
 const PENDING_WEBIMPORT_AUTHOR_STORAGE_KEY = 'pendingWebimportAuthor';
@@ -1895,11 +1905,13 @@ function App() {
       <NutritionReferenceProvider>
         <div className="App" style={appBottomNavStyle}>
           <Header />
-          <SharePage
-            shareId={sharePageId}
-            currentUser={currentUser}
-            onClose={handleSharePageClose}
-          />
+          <Suspense fallback={<ViewLoadingFallback />}>
+            <SharePage
+              shareId={sharePageId}
+              currentUser={currentUser}
+              onClose={handleSharePageClose}
+            />
+          </Suspense>
         </div>
       </NutritionReferenceProvider>
     );
@@ -1920,11 +1932,13 @@ function App() {
       <NutritionReferenceProvider>
         <div className="App" style={appBottomNavStyle}>
           <Header />
-          <MenuSharePage
-            shareId={menuSharePageId}
-            currentUser={currentUser}
-            onClose={handleMenuSharePageClose}
-          />
+          <Suspense fallback={<ViewLoadingFallback />}>
+            <MenuSharePage
+              shareId={menuSharePageId}
+              currentUser={currentUser}
+              onClose={handleMenuSharePageClose}
+            />
+          </Suspense>
         </div>
       </NutritionReferenceProvider>
     );
@@ -1949,17 +1963,19 @@ function App() {
           </div>
         )}
         {authView === 'login' ? (
-          <Login 
+          <Login
             onLogin={handleLogin}
             onSwitchToRegister={handleSwitchToRegister}
             onGuestLogin={handleGuestLogin}
             onResetPassword={handleResetPassword}
           />
         ) : (
-          <Register 
-            onRegister={handleRegister}
-            onSwitchToLogin={handleSwitchToLogin}
-          />
+          <Suspense fallback={<ViewLoadingFallback />}>
+            <Register
+              onRegister={handleRegister}
+              onSwitchToLogin={handleSwitchToLogin}
+            />
+          </Suspense>
         )}
       </div>
     );
@@ -1985,6 +2001,7 @@ function App() {
           startseiteEnabled={!!currentUser?.startseite}
           onChefkochClick={currentUser ? handleChefkochClick : undefined}
         />
+        <Suspense fallback={<ViewLoadingFallback />}>
         {isSettingsOpen ? (
           <Settings onBack={handleCloseSettings} currentUser={currentUser} allUsers={allUsers} allRecipes={recipes} onUpdateRecipe={(id, updates) => updateRecipeInFirestore(id, updates)} />
         ) : selectedRecipe ? (
@@ -2233,22 +2250,27 @@ function App() {
           </div>
         </div>
         )}
+        </Suspense>
         {requiresPasswordChange && currentUser && (
-          <PasswordChangeModal 
-            user={currentUser}
-            onPasswordChanged={handlePasswordChanged}
-          />
+          <Suspense fallback={null}>
+            <PasswordChangeModal
+              user={currentUser}
+              onPasswordChanged={handlePasswordChanged}
+            />
+          </Suspense>
         )}
         {showUniversalImport && (
-          <UniversalImportModal
-            initialImages={sharedData.images}
-            initialTitle={sharedData.title}
-            initialText={sharedData.text}
-            initialUrl={sharedData.url}
-            onCancel={handleUniversalImportCancel}
-            userId={currentUser?.id}
-            importContext={resolveImportGroupContext({ activeGroupId, groups, publicGroupId })}
-          />
+          <Suspense fallback={null}>
+            <UniversalImportModal
+              initialImages={sharedData.images}
+              initialTitle={sharedData.title}
+              initialText={sharedData.text}
+              initialUrl={sharedData.url}
+              onCancel={handleUniversalImportCancel}
+              userId={currentUser?.id}
+              importContext={resolveImportGroupContext({ activeGroupId, groups, publicGroupId })}
+            />
+          </Suspense>
         )}
         <MobileSearchOverlay
           isOpen={isMobileSearchOpen}
@@ -2291,13 +2313,19 @@ function App() {
           />
         )}
         {showAtelierOnboarding && (
-          <AtelierOnboardingOverlay onConfirm={handleAtelierOnboardingConfirm} />
+          <Suspense fallback={null}>
+            <AtelierOnboardingOverlay onConfirm={handleAtelierOnboardingConfirm} />
+          </Suspense>
         )}
         {showAtelierSwipeTrainer && (
-          <AtelierSwipeTrainerOverlay onComplete={handleAtelierSwipeTrainerComplete} />
+          <Suspense fallback={null}>
+            <AtelierSwipeTrainerOverlay onComplete={handleAtelierSwipeTrainerComplete} />
+          </Suspense>
         )}
         {showAtelierTasteIntro && (
-          <AtelierTasteIntroOverlay onContinue={handleAtelierTasteIntroContinue} />
+          <Suspense fallback={null}>
+            <AtelierTasteIntroOverlay onContinue={handleAtelierTasteIntroContinue} />
+          </Suspense>
         )}
       </div>
     </RecipeImportQueueProvider>

--- a/src/App.share.test.js
+++ b/src/App.share.test.js
@@ -102,17 +102,17 @@ describe('Share URL hash routing', () => {
     jest.clearAllMocks();
   });
 
-  test('shows SharePage when initial URL hash is #share/:shareId', () => {
+  test('shows SharePage when initial URL hash is #share/:shareId', async () => {
     window.location.hash = '#share/abc-123';
     render(<App />);
-    expect(screen.getByTestId('share-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('share-page')).toBeInTheDocument();
     expect(screen.getByTestId('share-page')).toHaveAttribute('data-share-id', 'abc-123');
   });
 
-  test('shows MenuSharePage when initial URL hash is #menu-share/:shareId', () => {
+  test('shows MenuSharePage when initial URL hash is #menu-share/:shareId', async () => {
     window.location.hash = '#menu-share/xyz-456';
     render(<App />);
-    expect(screen.getByTestId('menu-share-page')).toBeInTheDocument();
+    expect(await screen.findByTestId('menu-share-page')).toBeInTheDocument();
     expect(screen.getByTestId('menu-share-page')).toHaveAttribute('data-share-id', 'xyz-456');
   });
 


### PR DESCRIPTION
App.js statically imported every view/overlay (RecipeForm, Settings,
MenuList, Kueche, GroupList, the Atelier overlays, etc.) into one
bundle, plus tesseract.js transitively via RecipeForm -> OcrScanModal,
even though only the "recipes" screen is needed on first paint. That
pushed the initial JS payload to 462 kB gzipped, which is slow to
download and parse on a phone, especially on iPhone/cellular.

Switch all of these to React.lazy + Suspense, keeping only the views
needed for first paint (RecipeList, RecipeFilterSidebar, Header, Login,
MobileSearchOverlay, BottomNavigation) eager. This cuts the initial
bundle to 270 kB gzipped and moves tesseract.js out of the main chunk
entirely, loading it only when the OCR scanner is actually opened.

Updated App.auth.test.js/App.share.test.js assertions that immediately
checked for now-lazily-mounted view content to await it (findBy*
instead of getBy*), matching how the UI actually resolves under
Suspense.