### PR TITLE
Fix: KI-OCR-Tageslimit im Frontend war hart auf 20 kodiert

### DIFF
--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -434,6 +434,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   const [selectedPrivateListId, setSelectedPrivateListId] = useState('');
   // AI OCR daily limit state
   const [aiOcrLimitReached, setAiOcrLimitReached] = useState(false);
+  const [aiOcrDailyLimit, setAiOcrDailyLimit] = useState(20);
   // Tracks whether the web import default list pre-selection has been applied
   const webImportListPreselected = useRef(false);
   // FAB button pressed state for animation
@@ -626,12 +627,15 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   useEffect(() => {
     const checkAiOcrLimit = async () => {
       if (currentUser?.id) {
+        // Mirrors the server-side RATE_LIMITS tiers in functions/index.js
+        const limit = currentUser.isAdmin ? 1000 : currentUser.role === 'moderator' ? 50 : 20;
         const count = await getUserAiOcrScanCount(currentUser.id);
-        setAiOcrLimitReached(count >= 20);
+        setAiOcrDailyLimit(limit);
+        setAiOcrLimitReached(count >= limit);
       }
     };
     checkAiOcrLimit();
-  }, [currentUser?.id]);
+  }, [currentUser?.id, currentUser?.isAdmin, currentUser?.role]);
 
   useEffect(() => {
     setImageError(false);
@@ -1305,7 +1309,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
                 type="button"
                 className="webimport-button-header"
                 onClick={() => !aiOcrLimitReached && setShowWebImportModal(true)}
-                title={aiOcrLimitReached ? 'KI-OCR Tageslimit erreicht (20/Tag). Import nicht verfügbar.' : 'Rezept von Website importieren'}
+                title={aiOcrLimitReached ? `KI-OCR Tageslimit erreicht (${aiOcrDailyLimit}/Tag). Import nicht verfügbar.` : 'Rezept von Website importieren'}
                 aria-label="Webimport"
                 disabled={aiOcrLimitReached}
               >
@@ -1321,7 +1325,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
                 <label
                   htmlFor={aiOcrLimitReached ? undefined : 'ocrImageUpload'}
                   className={`ocr-scan-button-header${aiOcrLimitReached ? ' disabled' : ''}`}
-                  title={aiOcrLimitReached ? 'KI-OCR Tageslimit erreicht (20/Tag). Scan nicht verfügbar.' : 'Rezept mit Kamera scannen'}
+                  title={aiOcrLimitReached ? `KI-OCR Tageslimit erreicht (${aiOcrDailyLimit}/Tag). Scan nicht verfügbar.` : 'Rezept mit Kamera scannen'}
                   aria-label="Rezept mit Kamera scannen"
                   aria-disabled={aiOcrLimitReached}
                   style={{ cursor: aiOcrLimitReached ? 'not-allowed' : 'pointer' }}

--- a/src/components/RecipeForm.test.js
+++ b/src/components/RecipeForm.test.js
@@ -3233,6 +3233,51 @@ describe('RecipeForm - AI OCR Limit', () => {
       expect(scanLabel).toHaveAttribute('aria-disabled', 'true');
     });
   });
+
+  const moderatorWithPermissions = {
+    ...userWithPermissions,
+    id: 'moderator-1',
+    role: 'moderator',
+  };
+
+  test('webimport button stays enabled for moderator at count 20 (raised to 50/day)', async () => {
+    getUserAiOcrScanCount.mockResolvedValue(20);
+
+    render(
+      <RecipeForm
+        recipe={null}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+        currentUser={moderatorWithPermissions}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getUserAiOcrScanCount).toHaveBeenCalled();
+    });
+
+    const webimportBtn = screen.getByLabelText('Webimport');
+    expect(webimportBtn).not.toBeDisabled();
+  });
+
+  test('webimport button is disabled for moderator once count reaches 50', async () => {
+    getUserAiOcrScanCount.mockResolvedValue(50);
+
+    render(
+      <RecipeForm
+        recipe={null}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+        currentUser={moderatorWithPermissions}
+      />
+    );
+
+    await waitFor(() => {
+      const webimportBtn = screen.getByLabelText('Webimport');
+      expect(webimportBtn).toBeDisabled();
+      expect(webimportBtn).toHaveAttribute('title', expect.stringContaining('(50/Tag)'));
+    });
+  });
 });
 
 describe('RecipeForm - Signature Sentence', () => {


### PR DESCRIPTION
## Summary
- Die Fotoscan-/Webimport-Buttons in `RecipeForm.js` wurden client-seitig unabhängig vom Server-Limit fest nach 20 Scans/Tag ausgegraut, sodass die kürzlich erhöhte Moderator-Grenze (50/Tag, siehe #3055) nie zum Tragen kam
- Das Frontend-Limit spiegelt jetzt dieselben Stufen wie `RATE_LIMITS` in `functions/index.js` wider (admin: 1000, moderator: 50, sonst: 20); Tooltip-Texte zeigen das jeweils korrekte Limit statt hart „20/Tag"
- Zwei neue Tests für die Moderator-Rolle in `RecipeForm.test.js` ergänzt

## Test plan
- [x] `AI OCR Limit` Testsuite (8 Tests, inkl. 2 neue Moderator-Fälle) läuft grün
- [x] Bestehende Tests in der Suite unverändert (Vergleich vor/nach Änderung zeigt keine neuen Fehlschläge; verbleibende Fehlschläge sind vorbestehende Testisolations-Flakiness im Gesamtlauf der Datei)
- [ ] Nach Merge: Deploy-Workflow (`workflow_dispatch`) manuell auslösen, damit der Fix live geht

---
_Generated by [Claude Code](https://claude.ai/code/session_01G923Miqhzkt2pR9PUztVpb)_