### PR TITLE
Add small gap between section headings and first field in recipe form

### DIFF
--- a/src/components/RecipeForm.css
+++ b/src/components/RecipeForm.css
@@ -694,11 +694,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0rem;
-}
-
-.form-section .section-header + .form-list-item {
-  margin-top: -0.35rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-section h3 {

--- a/src/components/RecipeForm.css.test.js
+++ b/src/components/RecipeForm.css.test.js
@@ -86,11 +86,9 @@ describe('RecipeForm toolbar CSS layout', () => {
     expect(addItemButtonDarkRule).toContain('border-color: #555;');
   });
 
-  test('keeps section headings close to the first ingredient and step fields', () => {
+  test('keeps a small gap between section headings and the first ingredient/step field', () => {
     const sectionHeaderRule = getRuleBody(css, '.section-header');
-    const firstListItemRule = getRuleBody(css, '.form-section .section-header + .form-list-item');
 
-    expect(sectionHeaderRule).toContain('margin-bottom: 0rem;');
-    expect(firstListItemRule).toContain('margin-top: -0.35rem;');
+    expect(sectionHeaderRule).toContain('margin-bottom: 0.5rem;');
   });
 });


### PR DESCRIPTION
Zutaten/Zubereitungsschritte headings previously overlapped their first
row via a negative top margin. Replace with a modest bottom margin on
.section-header for breathing room without a large gap.