### PR TITLE
Zeige Import-Donut auch auf Share-Link-Seiten an

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1937,16 +1937,18 @@ function App() {
     };
     return (
       <NutritionReferenceProvider>
-        <div className="App" style={appBottomNavStyle}>
-          <Header />
-          <Suspense fallback={<ViewLoadingFallback />}>
-            <SharePage
-              shareId={sharePageId}
-              currentUser={currentUser}
-              onClose={handleSharePageClose}
-            />
-          </Suspense>
-        </div>
+        <RecipeImportQueueProvider userId={currentUser?.id}>
+          <div className="App" style={appBottomNavStyle}>
+            <Header />
+            <Suspense fallback={<ViewLoadingFallback />}>
+              <SharePage
+                shareId={sharePageId}
+                currentUser={currentUser}
+                onClose={handleSharePageClose}
+              />
+            </Suspense>
+          </div>
+        </RecipeImportQueueProvider>
       </NutritionReferenceProvider>
     );
   }
@@ -1964,16 +1966,18 @@ function App() {
     };
     return (
       <NutritionReferenceProvider>
-        <div className="App" style={appBottomNavStyle}>
-          <Header />
-          <Suspense fallback={<ViewLoadingFallback />}>
-            <MenuSharePage
-              shareId={menuSharePageId}
-              currentUser={currentUser}
-              onClose={handleMenuSharePageClose}
-            />
-          </Suspense>
-        </div>
+        <RecipeImportQueueProvider userId={currentUser?.id}>
+          <div className="App" style={appBottomNavStyle}>
+            <Header />
+            <Suspense fallback={<ViewLoadingFallback />}>
+              <MenuSharePage
+                shareId={menuSharePageId}
+                currentUser={currentUser}
+                onClose={handleMenuSharePageClose}
+              />
+            </Suspense>
+          </div>
+        </RecipeImportQueueProvider>
       </NutritionReferenceProvider>
     );
   }


### PR DESCRIPTION
Header wurde auf den /share- und /menu-share-Routen außerhalb des
RecipeImportQueueProvider gerendert. War man dort eingeloggt, fiel
useRecipeImportQueue() auf die inerte noopQueue (jobs: []) zurück,
sodass der Import-Fortschritts-Donut auf diesen Seiten nie angezeigt
wurde, auch wenn im Hintergrund ein Import lief.