### PR TITLE
Restart wartende/fehlgeschlagene Importe im Import-Dialog

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -48,7 +48,7 @@ const Header = forwardRef(function Header({
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const menuRef = useRef(null);
   const searchRef = useRef(null);
-  const { jobs: importJobs, dismissJob: dismissImportJob } = useRecipeImportQueue();
+  const { jobs: importJobs, dismissJob: dismissImportJob, restartJob: restartImportJob } = useRecipeImportQueue();
 
   useImperativeHandle(ref, () => ({
     openSearch() {
@@ -436,6 +436,7 @@ const Header = forwardRef(function Header({
           jobs={importJobs}
           onClose={() => setImportDialogOpen(false)}
           onDismissJob={dismissImportJob}
+          onRestartJob={restartImportJob}
         />
       )}
     </>

--- a/src/components/ImportProgressDialog.css
+++ b/src/components/ImportProgressDialog.css
@@ -113,6 +113,12 @@
   transition: width 0.2s ease;
 }
 
+.import-progress-item-actions {
+  margin-top: 8px;
+  display: flex;
+  justify-content: flex-end;
+}
+
 .import-progress-item-error {
   margin-top: 8px;
   display: flex;
@@ -123,15 +129,35 @@
   color: #a33a26;
 }
 
-.import-progress-item-dismiss {
-  background: transparent;
-  border: 1px solid #a33a26;
-  color: #a33a26;
+.import-progress-item-error span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.import-progress-item-error-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.import-progress-item-dismiss,
+.import-progress-item-restart {
   border-radius: 999px;
   padding: 2px 10px;
   font-size: 0.75rem;
   cursor: pointer;
   flex-shrink: 0;
+  background: transparent;
+}
+
+.import-progress-item-dismiss {
+  border: 1px solid #a33a26;
+  color: #a33a26;
+}
+
+.import-progress-item-restart {
+  border: 1px solid #2196f3;
+  color: #2196f3;
 }
 
 .import-progress-hint {

--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -18,7 +18,7 @@ function statusLabel(status) {
 // every queued/running/failed background import job; finished imports leave
 // this list immediately and show up as pending reviews on "Neues Rezept
 // hinzufügen" instead.
-function ImportProgressDialog({ jobs, onClose, onDismissJob }) {
+function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="import-progress-dialog" onClick={(e) => e.stopPropagation()}>
@@ -46,16 +46,42 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob }) {
                       />
                     </div>
                   )}
+                  {job.status === 'queued' && job.canRestart && (
+                    <div className="import-progress-item-actions">
+                      <button
+                        type="button"
+                        className="import-progress-item-restart"
+                        onClick={() => onRestartJob(job.id)}
+                        title="Import neu starten"
+                        aria-label={`${job.label || 'Import'} neu starten`}
+                      >
+                        Neu starten
+                      </button>
+                    </div>
+                  )}
                   {job.status === 'error' && (
                     <div className="import-progress-item-error">
                       <span>{job.error}</span>
-                      <button
-                        type="button"
-                        className="import-progress-item-dismiss"
-                        onClick={() => onDismissJob(job.id)}
-                      >
-                        Verwerfen
-                      </button>
+                      <div className="import-progress-item-error-actions">
+                        {job.canRestart && (
+                          <button
+                            type="button"
+                            className="import-progress-item-restart"
+                            onClick={() => onRestartJob(job.id)}
+                            title="Import neu starten"
+                            aria-label={`${job.label || 'Import'} neu starten`}
+                          >
+                            Neu starten
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="import-progress-item-dismiss"
+                          onClick={() => onDismissJob(job.id)}
+                        >
+                          Verwerfen
+                        </button>
+                      </div>
                     </div>
                   )}
                 </li>

--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -1,137 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import './OcrScanModal.css';
-import { buildRecipeFromAiResult } from '../utils/ocrParser';
 import { fileToBase64 } from '../utils/imageUtils';
-import { recognizeRecipeWithAI } from '../utils/aiOcrService';
+import { runPhotoScanImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 const MAX_CAMERA_PHOTOS = 10;
-// Max number of images processed at the same time during a batch scan.
-// Keeps the OCR calls independent (each image is unrelated to the others)
-// while staying well under the Cloud Function's per-user rate limit.
-const BATCH_CONCURRENCY = 3;
-
-// Remove duplicate strings using Levenshtein similarity
-function stringSimilarity(s1, s2) {
-  const longer = s1.length > s2.length ? s1 : s2;
-  const shorter = s1.length > s2.length ? s2 : s1;
-  if (longer.length === 0) return 1.0;
-  const editDistance = levenshteinDistance(longer, shorter);
-  return (longer.length - editDistance) / longer.length;
-}
-
-function levenshteinDistance(s1, s2) {
-  const costs = [];
-  for (let i = 0; i <= s1.length; i++) {
-    let lastValue = i;
-    for (let j = 0; j <= s2.length; j++) {
-      if (i === 0) {
-        costs[j] = j;
-      } else if (j > 0) {
-        let newValue = costs[j - 1];
-        if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
-          newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
-        }
-        costs[j - 1] = lastValue;
-        lastValue = newValue;
-      }
-    }
-    if (i > 0) costs[s2.length] = lastValue;
-  }
-  return costs[s2.length];
-}
-
-function removeDuplicates(items) {
-  if (!items || items.length === 0) return [];
-  const unique = [];
-  for (const item of items) {
-    const normalized = item.toLowerCase().trim();
-    const isDuplicate = unique.some(existing =>
-      stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8
-    );
-    if (!isDuplicate) {
-      unique.push(item);
-    }
-  }
-  return unique;
-}
-
-// Combine multiple per-image AI OCR results into one recipe
-function mergeAiResults(results) {
-  const validResults = results.filter(r => !r.error);
-  if (validResults.length === 0) {
-    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
-  }
-
-  const merged = { ...validResults[0] };
-
-  const allIngredients = validResults.flatMap(r => r.ingredients || []);
-  merged.ingredients = removeDuplicates(allIngredients);
-
-  const allSteps = validResults.flatMap(r => r.steps || []);
-  merged.steps = removeDuplicates(allSteps);
-
-  const allTags = validResults.flatMap(r => r.tags || []);
-  merged.tags = [...new Set(allTags)];
-
-  const allNotes = validResults
-    .map(r => r.notes)
-    .filter(n => n && n.trim())
-    .join('\n\n');
-  merged.notes = allNotes || merged.notes;
-
-  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
-  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
-  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
-  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
-  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
-  merged.category = merged.category || validResults.find(r => r.category)?.category;
-
-  return merged;
-}
-
-// Runs AI OCR on a batch of images (concurrently, up to BATCH_CONCURRENCY at
-// once) and returns the merged recipe. Passed as the `run` function to
-// enqueueImportJob() so it executes in the background, after the modal has
-// already closed.
-async function runPhotoScanImport(images, language, onProgress) {
-  const total = images.length;
-  const results = new Array(total);
-  const progressPerImage = new Array(total).fill(0);
-
-  const updateOverall = () => {
-    const sum = progressPerImage.reduce((a, b) => a + b, 0);
-    onProgress(Math.round(sum / total));
-  };
-
-  let nextIndex = 0;
-  const worker = async () => {
-    while (nextIndex < total) {
-      const i = nextIndex++;
-      try {
-        const result = await recognizeRecipeWithAI(images[i], {
-          language,
-          provider: 'gemini',
-          onProgress: (progress) => {
-            progressPerImage[i] = progress;
-            updateOverall();
-          },
-        });
-        results[i] = result;
-      } catch (err) {
-        results[i] = { error: err.message };
-      }
-      progressPerImage[i] = 100;
-      updateOverall();
-    }
-  };
-
-  const workerCount = Math.min(BATCH_CONCURRENCY, total);
-  await Promise.all(Array.from({ length: workerCount }, worker));
-
-  const merged = mergeAiResults(results);
-  return buildRecipeFromAiResult(merged);
-}
 
 // initialImage: single image that triggers an immediate background scan (takes precedence over initialImages)
 // initialImages: array of base64 images to pre-fill the image-preview step
@@ -161,6 +34,7 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
       userId,
       context: importContext,
       run: (onProgress) => runPhotoScanImport(images, language, onProgress),
+      source: { type: 'photo', images, language },
     });
     stopCamera();
     onCancel();

--- a/src/components/UniversalImportModal.js
+++ b/src/components/UniversalImportModal.js
@@ -1,165 +1,11 @@
 import React, { useState, useRef } from 'react';
 import './UniversalImportModal.css';
 import { fileToBase64 } from '../utils/imageUtils';
-import { recognizeRecipeWithAI } from '../utils/aiOcrService';
-import { captureWebsiteScreenshot } from '../utils/webImportService';
-import { buildRecipeFromAiResult } from '../utils/ocrParser';
+import { runUniversalImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 function buildInitialText(title, text) {
   return [title, text].filter(Boolean).join('\n\n');
-}
-
-// Max number of images processed at the same time during a multi-image import.
-// Images are independent OCR calls, so processing several in parallel cuts
-// total wait time roughly to (image count / concurrency) instead of the sum
-// of every individual call, while staying under the per-user rate limit.
-const BATCH_CONCURRENCY = 3;
-
-function mergeAiResults(results) {
-  const validResults = results.filter(r => !r.error);
-  if (validResults.length === 0) {
-    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
-  }
-
-  const merged = { ...validResults[0] };
-
-  const allIngredients = validResults.flatMap(r => r.ingredients || []);
-  const seenIngredients = new Set();
-  merged.ingredients = allIngredients.filter(ing => {
-    const key = ing.toLowerCase().trim();
-    if (seenIngredients.has(key)) return false;
-    seenIngredients.add(key);
-    return true;
-  });
-
-  merged.steps = validResults.flatMap(r => r.steps || []);
-
-  const allTags = validResults.flatMap(r => r.tags || []);
-  merged.tags = [...new Set(allTags)];
-
-  const allNotes = validResults
-    .map(r => r.notes)
-    .filter(n => n && n.trim())
-    .join('\n\n');
-  merged.notes = allNotes || merged.notes;
-
-  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
-  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
-  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
-  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
-  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
-  merged.category = merged.category || validResults.find(r => r.category)?.category;
-
-  return merged;
-}
-
-// Runs recognition for a combination of images/text/url and returns the
-// merged recipe. Passed as the `run` function to enqueueImportJob() so it
-// executes in the background, after the modal has already closed.
-async function runUniversalImport({ images, text, url }, onProgress) {
-  const results = [];
-
-  if (url.trim()) {
-    const screenshotBase64 = await captureWebsiteScreenshot(url.trim(), (prog) => {
-      onProgress(Math.round(prog * 0.5), 'Lade Website...');
-    });
-    onProgress(50, 'Analysiere Website...');
-    try {
-      const result = await recognizeRecipeWithAI(screenshotBase64, {
-        language: 'de',
-        provider: 'gemini',
-        onProgress: (prog) => onProgress(50 + Math.round(prog * 0.5)),
-      });
-      results.push(result);
-    } catch (err) {
-      results.push({ error: err.message });
-    }
-  }
-
-  if (text.trim()) {
-    onProgress(0, 'Analysiere Text...');
-    // Create a simple canvas image with the text for Gemini to extract from
-    const canvas = document.createElement('canvas');
-    canvas.width = 800;
-    canvas.height = Math.min(4000, Math.max(600, text.split('\n').length * 24 + 80));
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = '#000000';
-    ctx.font = '18px Arial, sans-serif';
-    const lines = text.split('\n');
-    let y = 40;
-    for (const line of lines) {
-      const words = line.split(' ');
-      let currentLine = '';
-      for (const word of words) {
-        const testLine = currentLine + (currentLine ? ' ' : '') + word;
-        if (ctx.measureText(testLine).width > 760 && currentLine) {
-          ctx.fillText(currentLine, 20, y);
-          y += 26;
-          currentLine = word;
-        } else {
-          currentLine = testLine;
-        }
-      }
-      if (currentLine) {
-        ctx.fillText(currentLine, 20, y);
-        y += 26;
-      }
-    }
-    const textImageBase64 = canvas.toDataURL('image/png');
-    try {
-      const result = await recognizeRecipeWithAI(textImageBase64, {
-        language: 'de',
-        provider: 'gemini',
-        onProgress: (prog) => onProgress(prog),
-      });
-      results.push(result);
-    } catch (err) {
-      results.push({ error: err.message });
-    }
-  }
-
-  if (images.length > 0) {
-    const imageResults = new Array(images.length);
-    const progressPerImage = new Array(images.length).fill(0);
-
-    const updateOverallProgress = () => {
-      const sum = progressPerImage.reduce((a, b) => a + b, 0);
-      onProgress(Math.round(sum / images.length), images.length === 1 ? 'Analysiere Bild...' : `Analysiere ${images.length} Bilder...`);
-    };
-
-    let nextIndex = 0;
-    const processNext = async () => {
-      while (nextIndex < images.length) {
-        const i = nextIndex++;
-        try {
-          const result = await recognizeRecipeWithAI(images[i], {
-            language: 'de',
-            provider: 'gemini',
-            onProgress: (progress) => {
-              progressPerImage[i] = progress;
-              updateOverallProgress();
-            }
-          });
-          imageResults[i] = result;
-        } catch (err) {
-          imageResults[i] = { error: err.message };
-        }
-        progressPerImage[i] = 100;
-        updateOverallProgress();
-      }
-    };
-
-    const workerCount = Math.min(BATCH_CONCURRENCY, images.length);
-    await Promise.all(Array.from({ length: workerCount }, processNext));
-
-    results.push(...imageResults);
-  }
-
-  const merged = mergeAiResults(results);
-  return buildRecipeFromAiResult(merged);
 }
 
 function UniversalImportModal({ onCancel, initialImages = [], initialText = '', initialUrl = '', initialTitle = '', userId = '', importContext = {} }) {
@@ -202,6 +48,7 @@ function UniversalImportModal({ onCancel, initialImages = [], initialText = '', 
       userId,
       context: importContext,
       run: (onProgress) => runUniversalImport(snapshot, onProgress),
+      source: { type: 'universal', images: snapshot.images, text: snapshot.text, url: snapshot.url },
     });
 
     // The import now runs in the background (see the header's progress

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -1,32 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './WebImportModal.css';
-import {
-  normalizeImportedUrl,
-  isRecipeImportPageUrl,
-  parseRecipeImportPage,
-  isInstagramUrl,
-  importInstagramReel,
-  importRecipeFromUrl,
-} from '../utils/webImportService';
-import { buildRecipeFromAiResult } from '../utils/ocrParser';
+import { normalizeImportedUrl } from '../utils/webImportService';
+import { runWebImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
-
-async function runWebImport(normalizedUrl, authorId, onProgress) {
-  let result;
-
-  if (isInstagramUrl(normalizedUrl)) {
-    // Instagram path (post, reel, or IGTV) – extract caption and page text with Puppeteer + Gemini
-    result = await importInstagramReel(normalizedUrl, onProgress);
-  } else if (isRecipeImportPageUrl(normalizedUrl)) {
-    // Direct HTML parsing path – no screenshot or AI needed
-    result = await parseRecipeImportPage(normalizedUrl, onProgress);
-  } else {
-    // Multi-step import: JSON-LD → Text+Gemini → Screenshot+Vision
-    result = await importRecipeFromUrl(normalizedUrl, onProgress);
-  }
-
-  return buildRecipeFromAiResult(result, authorId);
-}
 
 function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '', importContext = {} }) {
   const [url, setUrl] = useState(() => normalizeImportedUrl(initialUrl));
@@ -70,6 +46,7 @@ function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '',
       userId,
       context: importContext,
       run: (onProgress) => runWebImport(normalizedUrl, authorId, onProgress),
+      source: { type: 'web', url: normalizedUrl, authorId },
     });
 
     onCancel();

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -6,6 +6,8 @@ import {
   deleteRecipe,
   subscribeToTempRecipes,
 } from '../utils/recipeFirestore';
+import { compressImage } from '../utils/imageUtils';
+import { runWebImport, runUniversalImport, runPhotoScanImport } from '../utils/importRunners';
 
 const RecipeImportQueueContext = createContext(null);
 
@@ -14,7 +16,41 @@ const noopQueue = {
   reviewRecipes: [],
   enqueueImportJob: () => undefined,
   dismissJob: () => {},
+  restartJob: () => {},
 };
+
+// Images are compressed before being persisted as importSource (for
+// restarting a job later) to stay well clear of Firestore's 1 MiB document
+// size limit — uploaded photos can be up to 5MB uncompressed (see
+// fileToBase64). The live run for the current attempt still uses the
+// original, uncompressed images; only the restart snapshot is compressed.
+async function buildImportSourceSnapshot(source) {
+  if (!source) return null;
+  if ((source.type === 'universal' || source.type === 'photo') && Array.isArray(source.images) && source.images.length > 0) {
+    const compressedImages = await Promise.all(
+      source.images.map((img) => compressImage(img, 1000, 1400, 0.5).catch(() => img))
+    );
+    return { ...source, images: compressedImages };
+  }
+  return source;
+}
+
+// Reconstructs the `run` function an import job was originally queued with,
+// from its persisted importSource — used to restart a job that is stuck
+// waiting (e.g. its owning tab was closed/reloaded before it could finish).
+function buildRunFromSource(source) {
+  if (!source) return null;
+  switch (source.type) {
+    case 'web':
+      return (onProgress) => runWebImport(source.url, source.authorId, onProgress);
+    case 'universal':
+      return (onProgress) => runUniversalImport({ images: source.images, text: source.text, url: source.url }, onProgress);
+    case 'photo':
+      return (onProgress) => runPhotoScanImport(source.images, source.language, onProgress);
+    default:
+      return null;
+  }
+}
 
 // Progress-only Firestore writes are throttled to this interval so a fast
 // OCR/screenshot progress callback (which can fire many times per second)
@@ -62,6 +98,7 @@ export function RecipeImportQueueProvider({ userId, children }) {
       status: r.importStatus,
       progress: r.importProgress || 0,
       error: r.importError,
+      canRestart: Boolean(r.importSource),
     })), [tempRecipes]);
 
   const reviewRecipes = useMemo(
@@ -120,11 +157,20 @@ export function RecipeImportQueueProvider({ userId, children }) {
     }
   }, [patchJob, patchProgress]);
 
-  const enqueueImportJob = useCallback(({ label, run, context = {}, userId: jobUserId }) => {
-    addRecipe(
-      { title: label || 'Rezept-Import', isTemp: true, importStatus: 'queued', importProgress: 0, ...context },
-      jobUserId
-    ).then((created) => {
+  const enqueueImportJob = useCallback(({ label, run, context = {}, userId: jobUserId, source = null }) => {
+    buildImportSourceSnapshot(source).catch(() => null).then((importSource) => (
+      addRecipe(
+        {
+          title: label || 'Rezept-Import',
+          isTemp: true,
+          importStatus: 'queued',
+          importProgress: 0,
+          ...context,
+          ...(importSource ? { importSource } : {}),
+        },
+        jobUserId
+      )
+    )).then((created) => {
       queueRef.current.push({ id: created.id, run, context, userId: jobUserId });
       processQueue();
     }).catch((error) => {
@@ -138,7 +184,23 @@ export function RecipeImportQueueProvider({ userId, children }) {
     });
   }, []);
 
-  const value = { jobs, reviewRecipes, enqueueImportJob, dismissJob };
+  // Restarts a waiting/failed job from its persisted importSource — this is
+  // what makes a job stuck in 'queued'/'error' (e.g. because the tab that
+  // queued it was closed or reloaded, dropping the in-memory queue) worth
+  // recovering from, instead of only being dismissable.
+  const restartJob = useCallback((id) => {
+    const tempRecipe = tempRecipes.find((r) => r.id === id);
+    if (!tempRecipe || !tempRecipe.importSource) return;
+    const run = buildRunFromSource(tempRecipe.importSource);
+    if (!run) return;
+
+    patchJob(id, { importStatus: 'queued', importProgress: 0, importError: deleteField() });
+    queueRef.current = queueRef.current.filter((job) => job.id !== id);
+    queueRef.current.push({ id, run, context: {}, userId: tempRecipe.authorId });
+    processQueue();
+  }, [tempRecipes, patchJob, processQueue]);
+
+  const value = { jobs, reviewRecipes, enqueueImportJob, dismissJob, restartJob };
 
   return (
     <RecipeImportQueueContext.Provider value={value}>

--- a/src/utils/importRunners.js
+++ b/src/utils/importRunners.js
@@ -1,0 +1,307 @@
+import {
+  isRecipeImportPageUrl,
+  parseRecipeImportPage,
+  isInstagramUrl,
+  importInstagramReel,
+  importRecipeFromUrl,
+  captureWebsiteScreenshot,
+} from './webImportService';
+import { buildRecipeFromAiResult } from './ocrParser';
+import { recognizeRecipeWithAI } from './aiOcrService';
+
+// Max number of images processed at the same time during a multi-image
+// import/scan. Images are independent OCR calls, so processing several in
+// parallel cuts total wait time roughly to (image count / concurrency)
+// instead of the sum of every individual call, while staying under the
+// per-user rate limit.
+const BATCH_CONCURRENCY = 3;
+
+// Runs recipe-import recognition for a single URL (web page or Instagram
+// post/reel/IGTV) and returns the resulting recipe (no id yet). Passed as
+// the `run` function to enqueueImportJob() from WebImportModal, and
+// reconstructed identically by RecipeImportQueueContext when restarting a
+// job whose importSource was persisted to Firestore.
+export async function runWebImport(normalizedUrl, authorId, onProgress) {
+  let result;
+
+  if (isInstagramUrl(normalizedUrl)) {
+    // Instagram path (post, reel, or IGTV) – extract caption and page text with Puppeteer + Gemini
+    result = await importInstagramReel(normalizedUrl, onProgress);
+  } else if (isRecipeImportPageUrl(normalizedUrl)) {
+    // Direct HTML parsing path – no screenshot or AI needed
+    result = await parseRecipeImportPage(normalizedUrl, onProgress);
+  } else {
+    // Multi-step import: JSON-LD → Text+Gemini → Screenshot+Vision
+    result = await importRecipeFromUrl(normalizedUrl, onProgress);
+  }
+
+  return buildRecipeFromAiResult(result, authorId);
+}
+
+function mergeUniversalAiResults(results) {
+  const validResults = results.filter(r => !r.error);
+  if (validResults.length === 0) {
+    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
+  }
+
+  const merged = { ...validResults[0] };
+
+  const allIngredients = validResults.flatMap(r => r.ingredients || []);
+  const seenIngredients = new Set();
+  merged.ingredients = allIngredients.filter(ing => {
+    const key = ing.toLowerCase().trim();
+    if (seenIngredients.has(key)) return false;
+    seenIngredients.add(key);
+    return true;
+  });
+
+  merged.steps = validResults.flatMap(r => r.steps || []);
+
+  const allTags = validResults.flatMap(r => r.tags || []);
+  merged.tags = [...new Set(allTags)];
+
+  const allNotes = validResults
+    .map(r => r.notes)
+    .filter(n => n && n.trim())
+    .join('\n\n');
+  merged.notes = allNotes || merged.notes;
+
+  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
+  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
+  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
+  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
+  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
+  merged.category = merged.category || validResults.find(r => r.category)?.category;
+
+  return merged;
+}
+
+// Runs recognition for a combination of images/text/url and returns the
+// merged recipe. Passed as the `run` function to enqueueImportJob() from
+// UniversalImportModal, and reconstructed identically on restart.
+export async function runUniversalImport({ images, text, url }, onProgress) {
+  const results = [];
+
+  if (url.trim()) {
+    const screenshotBase64 = await captureWebsiteScreenshot(url.trim(), (prog) => {
+      onProgress(Math.round(prog * 0.5), 'Lade Website...');
+    });
+    onProgress(50, 'Analysiere Website...');
+    try {
+      const result = await recognizeRecipeWithAI(screenshotBase64, {
+        language: 'de',
+        provider: 'gemini',
+        onProgress: (prog) => onProgress(50 + Math.round(prog * 0.5)),
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  }
+
+  if (text.trim()) {
+    onProgress(0, 'Analysiere Text...');
+    // Create a simple canvas image with the text for Gemini to extract from
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = Math.min(4000, Math.max(600, text.split('\n').length * 24 + 80));
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#000000';
+    ctx.font = '18px Arial, sans-serif';
+    const lines = text.split('\n');
+    let y = 40;
+    for (const line of lines) {
+      const words = line.split(' ');
+      let currentLine = '';
+      for (const word of words) {
+        const testLine = currentLine + (currentLine ? ' ' : '') + word;
+        if (ctx.measureText(testLine).width > 760 && currentLine) {
+          ctx.fillText(currentLine, 20, y);
+          y += 26;
+          currentLine = word;
+        } else {
+          currentLine = testLine;
+        }
+      }
+      if (currentLine) {
+        ctx.fillText(currentLine, 20, y);
+        y += 26;
+      }
+    }
+    const textImageBase64 = canvas.toDataURL('image/png');
+    try {
+      const result = await recognizeRecipeWithAI(textImageBase64, {
+        language: 'de',
+        provider: 'gemini',
+        onProgress: (prog) => onProgress(prog),
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  }
+
+  if (images.length > 0) {
+    const imageResults = new Array(images.length);
+    const progressPerImage = new Array(images.length).fill(0);
+
+    const updateOverallProgress = () => {
+      const sum = progressPerImage.reduce((a, b) => a + b, 0);
+      onProgress(Math.round(sum / images.length), images.length === 1 ? 'Analysiere Bild...' : `Analysiere ${images.length} Bilder...`);
+    };
+
+    let nextIndex = 0;
+    const processNext = async () => {
+      while (nextIndex < images.length) {
+        const i = nextIndex++;
+        try {
+          const result = await recognizeRecipeWithAI(images[i], {
+            language: 'de',
+            provider: 'gemini',
+            onProgress: (progress) => {
+              progressPerImage[i] = progress;
+              updateOverallProgress();
+            }
+          });
+          imageResults[i] = result;
+        } catch (err) {
+          imageResults[i] = { error: err.message };
+        }
+        progressPerImage[i] = 100;
+        updateOverallProgress();
+      }
+    };
+
+    const workerCount = Math.min(BATCH_CONCURRENCY, images.length);
+    await Promise.all(Array.from({ length: workerCount }, processNext));
+
+    results.push(...imageResults);
+  }
+
+  const merged = mergeUniversalAiResults(results);
+  return buildRecipeFromAiResult(merged);
+}
+
+// Remove duplicate strings using Levenshtein similarity
+function stringSimilarity(s1, s2) {
+  const longer = s1.length > s2.length ? s1 : s2;
+  const shorter = s1.length > s2.length ? s2 : s1;
+  if (longer.length === 0) return 1.0;
+  const editDistance = levenshteinDistance(longer, shorter);
+  return (longer.length - editDistance) / longer.length;
+}
+
+function levenshteinDistance(s1, s2) {
+  const costs = [];
+  for (let i = 0; i <= s1.length; i++) {
+    let lastValue = i;
+    for (let j = 0; j <= s2.length; j++) {
+      if (i === 0) {
+        costs[j] = j;
+      } else if (j > 0) {
+        let newValue = costs[j - 1];
+        if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
+          newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+        }
+        costs[j - 1] = lastValue;
+        lastValue = newValue;
+      }
+    }
+    if (i > 0) costs[s2.length] = lastValue;
+  }
+  return costs[s2.length];
+}
+
+function removeDuplicates(items) {
+  if (!items || items.length === 0) return [];
+  const unique = [];
+  for (const item of items) {
+    const normalized = item.toLowerCase().trim();
+    const isDuplicate = unique.some(existing =>
+      stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8
+    );
+    if (!isDuplicate) {
+      unique.push(item);
+    }
+  }
+  return unique;
+}
+
+// Combine multiple per-image AI OCR results into one recipe
+function mergePhotoAiResults(results) {
+  const validResults = results.filter(r => !r.error);
+  if (validResults.length === 0) {
+    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
+  }
+
+  const merged = { ...validResults[0] };
+
+  const allIngredients = validResults.flatMap(r => r.ingredients || []);
+  merged.ingredients = removeDuplicates(allIngredients);
+
+  const allSteps = validResults.flatMap(r => r.steps || []);
+  merged.steps = removeDuplicates(allSteps);
+
+  const allTags = validResults.flatMap(r => r.tags || []);
+  merged.tags = [...new Set(allTags)];
+
+  const allNotes = validResults
+    .map(r => r.notes)
+    .filter(n => n && n.trim())
+    .join('\n\n');
+  merged.notes = allNotes || merged.notes;
+
+  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
+  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
+  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
+  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
+  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
+  merged.category = merged.category || validResults.find(r => r.category)?.category;
+
+  return merged;
+}
+
+// Runs AI OCR on a batch of images (concurrently, up to BATCH_CONCURRENCY at
+// once) and returns the merged recipe. Passed as the `run` function to
+// enqueueImportJob() from OcrScanModal, and reconstructed identically on
+// restart.
+export async function runPhotoScanImport(images, language, onProgress) {
+  const total = images.length;
+  const results = new Array(total);
+  const progressPerImage = new Array(total).fill(0);
+
+  const updateOverall = () => {
+    const sum = progressPerImage.reduce((a, b) => a + b, 0);
+    onProgress(Math.round(sum / total));
+  };
+
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < total) {
+      const i = nextIndex++;
+      try {
+        const result = await recognizeRecipeWithAI(images[i], {
+          language,
+          provider: 'gemini',
+          onProgress: (progress) => {
+            progressPerImage[i] = progress;
+            updateOverall();
+          },
+        });
+        results[i] = result;
+      } catch (err) {
+        results[i] = { error: err.message };
+      }
+      progressPerImage[i] = 100;
+      updateOverall();
+    }
+  };
+
+  const workerCount = Math.min(BATCH_CONCURRENCY, total);
+  await Promise.all(Array.from({ length: workerCount }, worker));
+
+  const merged = mergePhotoAiResults(results);
+  return buildRecipeFromAiResult(merged);
+}


### PR DESCRIPTION
Bislang blieb ein Import, dessen Tab geschlossen oder neu geladen wurde,
während er noch "Wartet…" war, für immer in diesem Status hängen: die
Verarbeitungs-Queue lebt nur im Arbeitsspeicher des Tabs und wurde nie
aus Firestore wiederhergestellt.

Jetzt wird pro Job eine restartfähige Quelle (URL bzw. komprimierte
Bilder/Text) in Firestore mitgespeichert, sodass "Neu starten" den Import
jederzeit erneut anstoßen kann – auch nach einem Reload. Die Run-Funktionen
der drei Import-Wege (Web, Universal, Foto-Scan) wurden dafür aus den
Modals in ein gemeinsames src/utils/importRunners.js verschoben.