### PR TITLE
fix: Kochbuch-Nav öffnet nur bei tatsächlich review-fertigen Importen das Formular

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,6 @@ import { hasHauptsaisonIngredient } from './utils/recipeSortIndex';
 import { getAllCookDatesForUser } from './utils/recipeCookDates';
 import {
   subscribeToRecipes,
-  subscribeToTempRecipes,
   addRecipe as addRecipeToFirestore,
   updateRecipe as updateRecipeInFirestore,
   deleteRecipe as deleteRecipeFromFirestore,
@@ -366,7 +365,6 @@ function App() {
   const [publicGroupId, setPublicGroupId] = useState(null);
   const [categoryFilter, setCategoryFilter] = useState('');
   const [recipesLoaded, setRecipesLoaded] = useState(false);
-  const [hasPendingTempImports, setHasPendingTempImports] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
   const [authView, setAuthView] = useState('login'); // 'login' or 'register'
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
@@ -840,21 +838,6 @@ function App() {
     return () => unsubscribe();
   }, [currentUser, userGroupIds]);
 
-  // Track whether the current user has background imports (isTemp recipes)
-  // awaiting review, so navigating to the Kochbuch overview via the bottom
-  // nav / hamburger menu can jump straight to the review form instead of
-  // the plain recipe list — see handleNavigateToRecipesOverview.
-  useEffect(() => {
-    if (!currentUser) {
-      setHasPendingTempImports(false);
-      return undefined;
-    }
-    const unsubscribe = subscribeToTempRecipes(currentUser.id, (tempRecipes) => {
-      setHasPendingTempImports(tempRecipes.length > 0);
-    });
-    return () => unsubscribe();
-  }, [currentUser]);
-
   // Migrate old global favorites to user-specific favorites (one-time migration)
   useEffect(() => {
     if (currentUser && recipesLoaded && recipes.length > 0) {
@@ -1253,14 +1236,18 @@ function App() {
   };
 
   // Used specifically by the bottom nav "Kochbuch" tab and the hamburger
-  // menu's "Kochbuch" item: if the user has background imports waiting for
-  // review, jump straight into the add-recipe form (which surfaces that
-  // pending-imports list) instead of the plain recipe list. Other paths
-  // that navigate to the recipe view (private-list links, "back" buttons)
-  // keep calling handleViewChange directly and are unaffected.
+  // menu's "Kochbuch" item: if the user has finished background imports
+  // waiting for review, jump straight into the add-recipe form (which
+  // surfaces that pending-imports list) instead of the plain recipe list.
+  // pendingReviewRecipes only contains imports that have finished
+  // processing (see AppReviewRecipesSync / RecipeImportQueueContext's
+  // reviewRecipes) — imports still queued/processing/erroring don't count,
+  // since there's nothing to review yet. Other paths that navigate to the
+  // recipe view (private-list links, "back" buttons) keep calling
+  // handleViewChange directly and are unaffected.
   const handleNavigateToRecipesOverview = () => {
     handleViewChange('recipes');
-    if (hasPendingTempImports) {
+    if (pendingReviewRecipes.length > 0) {
       handleAddRecipe();
     }
   };


### PR DESCRIPTION
Die Sprungentscheidung basierte auf allen isTemp-Rezepten inkl. noch
laufender Importjobs (queued/processing/error), statt nur auf fertig
verarbeiteten Importen. Dadurch öffnete der Kochbuch-Tab das leere
"Neues Rezept hinzufügen"-Formular, obwohl keine Importe zur Freigabe
bereitstanden. Nutzt jetzt pendingReviewRecipes (bereits korrekt auf
abgeschlossene Importe gefiltert) statt einer eigenen, ungefilterten
Firestore-Abfrage.