### PR TITLE
Add cancel/restart actions to the running import job

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -48,7 +48,7 @@ const Header = forwardRef(function Header({
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const menuRef = useRef(null);
   const searchRef = useRef(null);
-  const { jobs: importJobs, dismissJob: dismissImportJob, restartJob: restartImportJob } = useRecipeImportQueue();
+  const { jobs: importJobs, dismissJob: dismissImportJob, restartJob: restartImportJob, cancelJob: cancelImportJob } = useRecipeImportQueue();
 
   useImperativeHandle(ref, () => ({
     openSearch() {
@@ -437,6 +437,7 @@ const Header = forwardRef(function Header({
           onClose={() => setImportDialogOpen(false)}
           onDismissJob={dismissImportJob}
           onRestartJob={restartImportJob}
+          onCancelJob={cancelImportJob}
         />
       )}
     </>

--- a/src/components/ImportProgressDialog.css
+++ b/src/components/ImportProgressDialog.css
@@ -117,6 +117,7 @@
   margin-top: 8px;
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
 }
 
 .import-progress-item-error {

--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -18,7 +18,7 @@ function statusLabel(status) {
 // every queued/running/failed background import job; finished imports leave
 // this list immediately and show up as pending reviews on "Neues Rezept
 // hinzufügen" instead.
-function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob }) {
+function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCancelJob }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="import-progress-dialog" onClick={(e) => e.stopPropagation()}>
@@ -56,6 +56,30 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob }) {
                         aria-label={`${job.label || 'Import'} neu starten`}
                       >
                         Neu starten
+                      </button>
+                    </div>
+                  )}
+                  {job.status === 'processing' && (
+                    <div className="import-progress-item-actions">
+                      {job.canRestart && (
+                        <button
+                          type="button"
+                          className="import-progress-item-restart"
+                          onClick={() => onRestartJob(job.id)}
+                          title="Import neu starten"
+                          aria-label={`${job.label || 'Import'} neu starten`}
+                        >
+                          Neu starten
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="import-progress-item-dismiss"
+                        onClick={() => onCancelJob(job.id)}
+                        title="Import abbrechen"
+                        aria-label={`${job.label || 'Import'} abbrechen`}
+                      >
+                        Abbrechen
                       </button>
                     </div>
                   )}

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -17,6 +17,7 @@ const noopQueue = {
   enqueueImportJob: () => undefined,
   dismissJob: () => {},
   restartJob: () => {},
+  cancelJob: () => {},
 };
 
 // Images are compressed before being persisted as importSource (for
@@ -84,6 +85,13 @@ export function RecipeImportQueueProvider({ userId, children }) {
   const queueRef = useRef([]);
   const processingRef = useRef(false);
   const lastProgressWriteRef = useRef({});
+  // Ids whose in-flight/queued run() result should be discarded instead of
+  // written to Firestore once it settles — set by cancelJob() and by
+  // restartJob() when it supersedes an attempt that's already running.
+  // There is no AbortController threaded through the import runners (OCR /
+  // screenshot / AI calls), so a "cancel" can't actually stop the network
+  // work in flight; it only makes sure the stale result is never persisted.
+  const cancelledJobsRef = useRef(new Set());
 
   useEffect(() => {
     const unsubscribe = subscribeToTempRecipes(userId, setTempRecipes);
@@ -129,25 +137,41 @@ export function RecipeImportQueueProvider({ userId, children }) {
     try {
       while (queueRef.current.length > 0) {
         const job = queueRef.current[0];
+        if (cancelledJobsRef.current.has(job.id)) {
+          cancelledJobsRef.current.delete(job.id);
+          queueRef.current.shift();
+          continue;
+        }
         patchJob(job.id, { importStatus: 'processing' });
         try {
           const recipe = await job.run((progress, label) => patchProgress(job.id, progress, label));
-          await updateRecipe(job.id, {
-            ...recipe,
-            ...job.context,
-            // Matches the previous addRecipe(..., job.userId) behavior: the
-            // doc's owner is always whoever queued the job, regardless of
-            // any authorId the parsed recipe itself may carry (e.g. an
-            // Instagram caption's author).
-            authorId: job.userId,
-            isTemp: true,
-            importStatus: deleteField(),
-            importProgress: deleteField(),
-          });
+          if (cancelledJobsRef.current.has(job.id)) {
+            // Cancelled (or superseded by a restart) while running — the
+            // recognition finished, but nobody is waiting on this result
+            // anymore, so don't persist it.
+            cancelledJobsRef.current.delete(job.id);
+          } else {
+            await updateRecipe(job.id, {
+              ...recipe,
+              ...job.context,
+              // Matches the previous addRecipe(..., job.userId) behavior: the
+              // doc's owner is always whoever queued the job, regardless of
+              // any authorId the parsed recipe itself may carry (e.g. an
+              // Instagram caption's author).
+              authorId: job.userId,
+              isTemp: true,
+              importStatus: deleteField(),
+              importProgress: deleteField(),
+            });
+          }
           delete lastProgressWriteRef.current[job.id];
         } catch (error) {
-          console.error('Hintergrund-Import fehlgeschlagen:', error);
-          patchJob(job.id, { importStatus: 'error', importError: error?.message || 'Import fehlgeschlagen' });
+          if (cancelledJobsRef.current.has(job.id)) {
+            cancelledJobsRef.current.delete(job.id);
+          } else {
+            console.error('Hintergrund-Import fehlgeschlagen:', error);
+            patchJob(job.id, { importStatus: 'error', importError: error?.message || 'Import fehlgeschlagen' });
+          }
         } finally {
           queueRef.current.shift();
         }
@@ -184,23 +208,44 @@ export function RecipeImportQueueProvider({ userId, children }) {
     });
   }, []);
 
-  // Restarts a waiting/failed job from its persisted importSource — this is
-  // what makes a job stuck in 'queued'/'error' (e.g. because the tab that
-  // queued it was closed or reloaded, dropping the in-memory queue) worth
-  // recovering from, instead of only being dismissable.
+  // Cancels a queued or actively running job: the temp-recipe doc is
+  // removed right away, and if the job is mid-run its eventual result is
+  // discarded by processQueue instead of being written back (see
+  // cancelledJobsRef above — there's no way to actually abort the
+  // in-flight OCR/screenshot call itself).
+  const cancelJob = useCallback((id) => {
+    cancelledJobsRef.current.add(id);
+    deleteRecipe(id).catch((error) => {
+      console.error('Fehler beim Abbrechen des Import-Jobs:', error);
+    });
+  }, []);
+
+  // Restarts a waiting/failed/running job from its persisted importSource —
+  // this is what makes a job stuck in 'queued'/'error' (e.g. because the tab
+  // that queued it was closed or reloaded, dropping the in-memory queue)
+  // worth recovering from, instead of only being dismissable. Restarting a
+  // 'processing' job supersedes its current attempt (cancelledJobsRef makes
+  // sure the stale result is discarded) and queues a fresh one behind it.
   const restartJob = useCallback((id) => {
     const tempRecipe = tempRecipes.find((r) => r.id === id);
     if (!tempRecipe || !tempRecipe.importSource) return;
     const run = buildRunFromSource(tempRecipe.importSource);
     if (!run) return;
 
+    // Only mark the old attempt cancelled if one is actually still
+    // queued/in-flight (queueRef) — e.g. restarting an 'error' job has
+    // nothing left in the queue to supersede, and flagging its id here
+    // would wrongly cause the freshly-queued attempt below to be discarded
+    // by the very first "is this cancelled?" check in processQueue.
+    if (queueRef.current.some((job) => job.id === id)) {
+      cancelledJobsRef.current.add(id);
+    }
     patchJob(id, { importStatus: 'queued', importProgress: 0, importError: deleteField() });
-    queueRef.current = queueRef.current.filter((job) => job.id !== id);
     queueRef.current.push({ id, run, context: {}, userId: tempRecipe.authorId });
     processQueue();
   }, [tempRecipes, patchJob, processQueue]);
 
-  const value = { jobs, reviewRecipes, enqueueImportJob, dismissJob, restartJob };
+  const value = { jobs, reviewRecipes, enqueueImportJob, dismissJob, restartJob, cancelJob };
 
   return (
     <RecipeImportQueueContext.Provider value={value}>


### PR DESCRIPTION
The import progress dialog only offered "Neu starten"/"Verwerfen" for
queued and failed jobs; a job actively being analyzed had no action
at all. Add "Abbrechen" and (where importSource allows it) "Neu
starten" to the processing state too.

There's no AbortController threaded through the import runners, so
these don't interrupt the in-flight OCR/screenshot call itself -
cancelJob/restartJob mark the job's id so processQueue discards its
result instead of persisting it once the call settles.