### PR TITLE
fix: skip empty add-recipe form when opening Kochbuch with a pending review

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1284,7 +1284,14 @@ function App() {
   const handleNavigateToRecipesOverview = () => {
     handleViewChange('recipes');
     if (pendingReviewRecipes.length > 0) {
-      handleAddRecipe();
+      // Load the pending review recipe directly instead of handleAddRecipe():
+      // isFormOpen is set false (by handleViewChange above) and true (below)
+      // within the same batched update, so it never actually renders as
+      // false in between — the effect that swaps an empty add-form for the
+      // next pending review (triggered by isFormOpen going false) would
+      // never fire, leaving an empty "Rezept hinzufügen" form open until the
+      // user cancels it.
+      handleReviewTempRecipe(pendingReviewRecipes[0]);
     }
   };
 


### PR DESCRIPTION
Navigating to the Kochbuch tab while a background-imported recipe is
waiting for review opened an empty "Rezept hinzufügen" form first,
because it relied on an effect that only fires when isFormOpen
transitions to false in its own render — but handleViewChange sets it
false and the immediately-following handleAddRecipe() call sets it
true within the same batched update, so that transition never
actually renders. The pending recipe only loaded after cancelling the
empty form. Load it directly instead.