### PR TITLE
Finalize background recipe imports server-side so they survive tab close

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -665,12 +665,106 @@ async function callGeminiAPI(base64Data, mimeType, lang, apiKey, cuisineTypes, m
 }
 
 /**
+ * Convert a raw Gemini/AI result into the recipe field shape used by
+ * RecipeForm/RecipeImportQueueContext. Node-side port of the browser
+ * buildRecipeFromAiResult (src/utils/ocrParser.js) so background import
+ * jobs can be finalized directly from a Cloud Function, without depending
+ * on the client tab staying open to write the result back.
+ *
+ * @param {Object} aiResult - Structured recipe data (title, ingredients, ...)
+ * @param {string} [authorId] - Optional author id to attach to the recipe
+ * @returns {Object} Recipe field object matching the RecipeForm shape
+ */
+function buildRecipeFieldsFromResult(aiResult, authorId = '') {
+  const parseTime = (timeStr) => {
+    if (!timeStr) return 0;
+    const numMatch = String(timeStr).match(/\d+/);
+    return numMatch ? parseInt(numMatch[0], 10) : 0;
+  };
+
+  const kulinarikTagKeywords = {vegetarisch: 'Vegetarisch', vegan: 'Vegan'};
+  const tags = Array.isArray(aiResult.tags) ? aiResult.tags : [];
+  const kulinarikFromTags = tags.reduce((result, tag) => {
+    const canonical = kulinarikTagKeywords[String(tag).toLowerCase().trim()];
+    if (canonical && !result.includes(canonical)) result.push(canonical);
+    return result;
+  }, []);
+  const kulinarikSet = new Set(aiResult.cuisine ? [aiResult.cuisine] : []);
+  kulinarikFromTags.forEach((k) => kulinarikSet.add(k));
+
+  return {
+    title: aiResult.title || '',
+    ingredients: aiResult.ingredients || [],
+    steps: aiResult.steps || [],
+    portionen: aiResult.servings || 4,
+    kochdauer: parseTime(aiResult.prepTime) || parseTime(aiResult.cookTime) || 30,
+    kulinarik: [...kulinarikSet],
+    schwierigkeit: aiResult.difficulty || 3,
+    speisekategorie: aiResult.category || '',
+    ...(authorId ? {authorId} : {}),
+  };
+}
+
+/**
+ * Write a completed background-import result directly to its temp-recipe
+ * Firestore document, so the job finishes even if the client tab that
+ * queued it (RecipeImportQueueContext) was closed before the Cloud
+ * Function call returned. Best-effort: swallows its own errors so a
+ * Firestore write failure never masks the actual AI result from a client
+ * that is still connected and waiting on the callable's response.
+ *
+ * @param {string} jobId - Firestore recipes/{jobId} doc id (the temp recipe)
+ * @param {string} authorId - Owner of the queued job
+ * @param {Object} aiResult - Structured recipe data to persist
+ * @returns {Promise<void>}
+ */
+async function finalizeImportJob(jobId, authorId, aiResult) {
+  if (!jobId) return;
+  try {
+    await admin.firestore().collection('recipes').doc(jobId).update({
+      ...buildRecipeFieldsFromResult(aiResult, authorId),
+      authorId,
+      isTemp: true,
+      importStatus: admin.firestore.FieldValue.delete(),
+      importProgress: admin.firestore.FieldValue.delete(),
+    });
+  } catch (error) {
+    console.error(`finalizeImportJob: failed to write result for job ${jobId}:`, error);
+  }
+}
+
+/**
+ * Mark a background-import job as failed directly in Firestore, mirroring
+ * finalizeImportJob above but for the error path. Best-effort for the same
+ * reason.
+ *
+ * @param {string} jobId - Firestore recipes/{jobId} doc id
+ * @param {string} message - User-facing error message
+ * @returns {Promise<void>}
+ */
+async function failImportJob(jobId, message) {
+  if (!jobId) return;
+  try {
+    await admin.firestore().collection('recipes').doc(jobId).update({
+      importStatus: 'error',
+      importError: message || 'Import fehlgeschlagen',
+    });
+  } catch (error) {
+    console.error(`failImportJob: failed to write error state for job ${jobId}:`, error);
+  }
+}
+
+/**
  * Cloud Function: Scan recipe with AI
  * This is a callable function that can be invoked from the client
  *
  * Input data:
  * - imageBase64: Base64 encoded image (with or without data URL prefix)
  * - language: Language code ('de' or 'en'), defaults to 'de'
+ * - jobId: Optional background-import job id (temp recipe doc). When set,
+ *   the result (or error) is written directly to that Firestore document so
+ *   the import survives the calling tab being closed mid-request.
+ * - authorId: Owner of the job; required for jobId to take effect.
  *
  * Returns: Structured recipe data
  */
@@ -682,7 +776,7 @@ exports.scanRecipeWithAI = onCall(
       timeoutSeconds: 60,
     },
     async (request) => {
-      const {imageBase64, language = 'de', cuisineTypes, mealCategories} = request.data;
+      const {imageBase64, language = 'de', cuisineTypes, mealCategories, jobId, authorId} = request.data;
 
       // Authentication check
       const auth = request.auth;
@@ -732,6 +826,7 @@ exports.scanRecipeWithAI = onCall(
       try {
         const result = await callGeminiAPI(base64Data, mimeType, language, apiKey, cuisineTypes, mealCategories);
         console.log(`AI Scan successful for user ${userId}`);
+        if (jobId) await finalizeImportJob(jobId, authorId || userId, result);
         return {
           ...result,
           remainingScans: rateLimitResult.remaining,
@@ -739,9 +834,204 @@ exports.scanRecipeWithAI = onCall(
         };
       } catch (error) {
         console.error(`AI Scan failed for user ${userId}:`, error);
+        if (jobId) await failImportJob(jobId, error.message);
         throw error;
       }
     }
+);
+
+/**
+ * Maximum number of images accepted by a single scanRecipesWithAI batch call.
+ */
+const MAX_BATCH_IMAGES = 10;
+
+/**
+ * Number of images processed concurrently within one scanRecipesWithAI call.
+ * Mirrors BATCH_CONCURRENCY in src/utils/importRunners.js.
+ */
+const BATCH_IMAGE_CONCURRENCY = 3;
+
+/**
+ * Levenshtein edit distance between two strings (Node-side port of the
+ * browser helper in src/utils/importRunners.js, used for near-duplicate
+ * ingredient/step filtering when merging multi-image scan results).
+ * @param {string} s1
+ * @param {string} s2
+ * @returns {number}
+ */
+function levenshteinDistance(s1, s2) {
+  const costs = [];
+  for (let i = 0; i <= s1.length; i++) {
+    let lastValue = i;
+    for (let j = 0; j <= s2.length; j++) {
+      if (i === 0) {
+        costs[j] = j;
+      } else if (j > 0) {
+        let newValue = costs[j - 1];
+        if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
+          newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
+        }
+        costs[j - 1] = lastValue;
+        lastValue = newValue;
+      }
+    }
+    if (i > 0) costs[s2.length] = lastValue;
+  }
+  return costs[s2.length];
+}
+
+/**
+ * @param {string} s1
+ * @param {string} s2
+ * @returns {number} Similarity ratio between 0 and 1
+ */
+function stringSimilarity(s1, s2) {
+  const longer = s1.length > s2.length ? s1 : s2;
+  const shorter = s1.length > s2.length ? s2 : s1;
+  if (longer.length === 0) return 1.0;
+  const editDistance = levenshteinDistance(longer, shorter);
+  return (longer.length - editDistance) / longer.length;
+}
+
+/**
+ * Remove near-duplicate strings (similarity > 0.8) from a list, keeping the
+ * first occurrence of each. Node-side port of the browser helper used to
+ * merge ingredients/steps collected from multiple scanned images.
+ * @param {string[]} items
+ * @returns {string[]}
+ */
+function removeDuplicateStrings(items) {
+  if (!items || items.length === 0) return [];
+  const unique = [];
+  for (const item of items) {
+    const normalized = item.toLowerCase().trim();
+    const isDuplicate = unique.some(
+        (existing) => stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8,
+    );
+    if (!isDuplicate) unique.push(item);
+  }
+  return unique;
+}
+
+/**
+ * Combine multiple per-image AI OCR results into one recipe. Node-side port
+ * of mergePhotoAiResults in src/utils/importRunners.js.
+ * @param {Array<Object>} results - Per-image results, each possibly {error}
+ * @returns {Object} Merged recipe data
+ */
+function mergePhotoAiResultsServer(results) {
+  const validResults = results.filter((r) => r && !r.error);
+  if (validResults.length === 0) {
+    throw new HttpsError('invalid-argument', 'Keine gültigen OCR-Ergebnisse gefunden');
+  }
+
+  const merged = {...validResults[0]};
+  merged.ingredients = removeDuplicateStrings(validResults.flatMap((r) => r.ingredients || []));
+  merged.steps = removeDuplicateStrings(validResults.flatMap((r) => r.steps || []));
+  merged.tags = [...new Set(validResults.flatMap((r) => r.tags || []))];
+  merged.notes = validResults.map((r) => r.notes).filter((n) => n && n.trim()).join('\n\n') || merged.notes;
+  merged.servings = merged.servings || validResults.find((r) => r.servings)?.servings;
+  merged.prepTime = merged.prepTime || validResults.find((r) => r.prepTime)?.prepTime;
+  merged.cookTime = merged.cookTime || validResults.find((r) => r.cookTime)?.cookTime;
+  merged.difficulty = merged.difficulty || validResults.find((r) => r.difficulty)?.difficulty;
+  merged.cuisine = merged.cuisine || validResults.find((r) => r.cuisine)?.cuisine;
+  merged.category = merged.category || validResults.find((r) => r.category)?.category;
+
+  return merged;
+}
+
+/**
+ * Cloud Function: Batch-scan multiple recipe photos with AI in one call.
+ * Replaces N separate scanRecipeWithAI calls from the client for multi-image
+ * Foto-Scan imports so the whole batch (concurrent OCR + merge) runs
+ * server-side and can finalize the background-import job even if the
+ * calling tab is closed before all images finish.
+ *
+ * Input data:
+ * - images: string[]   Required – base64-encoded images (1..MAX_BATCH_IMAGES)
+ * - language: string    Optional – 'de' or 'en', defaults to 'de'
+ * - jobId: string        Optional – background-import job id (temp recipe doc)
+ * - authorId: string     Optional – owner of the job; required for jobId to take effect
+ *
+ * Returns: Merged structured recipe data (same shape as scanRecipeWithAI)
+ */
+exports.scanRecipesWithAI = onCall(
+    {
+      secrets: [geminiApiKey],
+      maxInstances: 10,
+      memory: '1GiB',
+      timeoutSeconds: 180,
+    },
+    async (request) => {
+      const {images, language = 'de', cuisineTypes, mealCategories, jobId, authorId} = request.data;
+
+      const auth = request.auth;
+      if (!auth) {
+        throw new HttpsError('unauthenticated', 'You must be logged in to use AI recipe scanning');
+      }
+
+      const userId = auth.uid;
+      const isAuthenticated = auth.token.firebase?.sign_in_provider !== 'anonymous';
+      const isAdmin = auth.token.admin === true;
+      const isModerator = !isAdmin && await isModeratorUser(userId);
+
+      if (!Array.isArray(images) || images.length === 0) {
+        throw new HttpsError('invalid-argument', 'images must be a non-empty array');
+      }
+      if (images.length > MAX_BATCH_IMAGES) {
+        throw new HttpsError('invalid-argument', `A maximum of ${MAX_BATCH_IMAGES} images is supported per batch`);
+      }
+      if (!['de', 'en'].includes(language)) {
+        throw new HttpsError('invalid-argument', 'Language must be "de" or "en"');
+      }
+
+      const apiKey = geminiApiKey.value();
+      if (!apiKey) {
+        console.error('GEMINI_API_KEY secret not configured');
+        throw new HttpsError('failed-precondition', 'AI service not configured. Please contact administrator.');
+      }
+
+      console.log(`Batch AI Scan request from user ${userId}: ${images.length} images`);
+
+      const results = new Array(images.length);
+      let lastRateLimit = null;
+      let nextIndex = 0;
+      const worker = async () => {
+        while (nextIndex < images.length) {
+          const i = nextIndex++;
+          try {
+            const rateLimitResult = await checkRateLimit(userId, isAuthenticated, isAdmin, isModerator);
+            lastRateLimit = rateLimitResult;
+            if (!rateLimitResult.allowed) {
+              const limit = getRateLimit(isAdmin, isAuthenticated, isModerator);
+              throw new Error(`Tageslimit erreicht (${limit}/${limit} Scans). Versuche es morgen erneut oder nutze Standard-OCR.`);
+            }
+            const {mimeType, base64Data} = validateImageData(images[i]);
+            results[i] = await callGeminiAPI(base64Data, mimeType, language, apiKey, cuisineTypes, mealCategories);
+          } catch (error) {
+            results[i] = {error: error.message};
+          }
+        }
+      };
+
+      const workerCount = Math.min(BATCH_IMAGE_CONCURRENCY, images.length);
+      await Promise.all(Array.from({length: workerCount}, worker));
+
+      try {
+        const merged = mergePhotoAiResultsServer(results);
+        console.log(`Batch AI Scan successful for user ${userId}`);
+        if (jobId) await finalizeImportJob(jobId, authorId || userId, merged);
+        return {
+          ...merged,
+          remainingScans: lastRateLimit?.remaining,
+          dailyLimit: lastRateLimit?.limit,
+        };
+      } catch (error) {
+        console.error(`Batch AI Scan failed for user ${userId}:`, error);
+        if (jobId) await failImportJob(jobId, error.message);
+        throw error;
+      }
+    },
 );
 
 /**
@@ -979,7 +1269,7 @@ exports.processHtmlWithAI = onCall(
       timeoutSeconds: 60,
     },
     async (request) => {
-      const {rawHtml, language = 'de', cuisineTypes, mealCategories} = request.data;
+      const {rawHtml, language = 'de', cuisineTypes, mealCategories, jobId, authorId} = request.data;
 
       // Authentication check
       const auth = request.auth;
@@ -1033,6 +1323,7 @@ exports.processHtmlWithAI = onCall(
       try {
         const result = await callGeminiTextAPI(rawHtml, language, apiKey, cuisineTypes, mealCategories);
         console.log(`HTML processing successful for user ${userId}`);
+        if (jobId) await finalizeImportJob(jobId, authorId || userId, result);
         return {
           ...result,
           remainingScans: rateLimitResult.remaining,
@@ -1040,6 +1331,7 @@ exports.processHtmlWithAI = onCall(
         };
       } catch (error) {
         console.error(`HTML processing failed for user ${userId}:`, error);
+        if (jobId) await failImportJob(jobId, error.message);
         throw error;
       }
     },
@@ -1088,7 +1380,7 @@ exports.scrapeInstagramReel = onCall(
       timeoutSeconds: 180,
     },
     async (request) => {
-      const {url, language = 'de', cuisineTypes, mealCategories} = request.data;
+      const {url, language = 'de', cuisineTypes, mealCategories, jobId, authorId} = request.data;
 
       // Authentication check
       const auth = request.auth;
@@ -1330,6 +1622,7 @@ exports.scrapeInstagramReel = onCall(
         );
 
         console.log(`Instagram Reel import successful for user ${userId}`);
+        if (jobId) await finalizeImportJob(jobId, authorId || userId, result);
         return {
           ...result,
           remainingScans: rateLimitResult.remaining,
@@ -1346,22 +1639,21 @@ exports.scrapeInstagramReel = onCall(
         }
 
         if (error instanceof HttpsError) {
+          if (jobId) await failImportJob(jobId, error.message);
           throw error;
         }
 
         console.error(`Instagram Reel scrape failed for user ${userId}:`, error);
 
         if (error.message && error.message.includes('timeout')) {
-          throw new HttpsError(
-              'deadline-exceeded',
-              'Die Instagram-Seite hat zu lange gebraucht. Bitte versuche es erneut.',
-          );
+          const message = 'Die Instagram-Seite hat zu lange gebraucht. Bitte versuche es erneut.';
+          if (jobId) await failImportJob(jobId, message);
+          throw new HttpsError('deadline-exceeded', message);
         }
 
-        throw new HttpsError(
-            'internal',
-            'Instagram-Import fehlgeschlagen: ' + error.message,
-        );
+        const message = 'Instagram-Import fehlgeschlagen: ' + error.message;
+        if (jobId) await failImportJob(jobId, message);
+        throw new HttpsError('internal', message);
       }
     },
 );
@@ -2175,7 +2467,7 @@ exports.importRecipeCallable = onCall(
       invoker: 'public',
     },
     async (request) => {
-      const {url, cuisineTypes, mealCategories} = request.data;
+      const {url, cuisineTypes, mealCategories, jobId, authorId} = request.data;
 
       const auth = request.auth;
       if (!auth) {
@@ -2214,17 +2506,24 @@ exports.importRecipeCallable = onCall(
       }
 
       try {
-        return await runImportFromUrl(url, {
+        const result = await runImportFromUrl(url, {
           apiKey,
           cuisineTypes,
           mealCategories,
           source: 'callable',
           userId,
         });
+        if (jobId) await finalizeImportJob(jobId, authorId || userId, result);
+        return result;
       } catch (error) {
-        if (error instanceof HttpsError) throw error;
+        if (error instanceof HttpsError) {
+          if (jobId) await failImportJob(jobId, error.message);
+          throw error;
+        }
         console.error(`importRecipeCallable failed for user ${userId}:`, error);
-        throw new HttpsError('internal', 'Import failed: ' + error.message);
+        const message = 'Import failed: ' + error.message;
+        if (jobId) await failImportJob(jobId, message);
+        throw new HttpsError('internal', message);
       }
     },
 );

--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -33,7 +33,7 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
       label: images.length === 1 ? 'Foto-Scan' : `Foto-Scan (${images.length} Bilder)`,
       userId,
       context: importContext,
-      run: (onProgress) => runPhotoScanImport(images, language, onProgress),
+      run: (onProgress, jobMeta) => runPhotoScanImport(images, language, onProgress, jobMeta),
       source: { type: 'photo', images, language },
     });
     stopCamera();

--- a/src/components/OcrScanModal.test.js
+++ b/src/components/OcrScanModal.test.js
@@ -171,7 +171,11 @@ describe('OcrScanModal', () => {
     });
     fireEvent.click(screen.getByText(/Analyse starten \(1\)/i));
 
-    await expect(runQueuedJob()).rejects.toThrow('Keine gültigen OCR-Ergebnisse gefunden');
+    // A single-image scan now calls recognizeRecipeWithAI directly (see
+    // runPhotoScanImport) instead of always going through a merge step, so
+    // its rejection surfaces as-is rather than being flattened into the
+    // generic "no valid OCR results" message multi-image merges produce.
+    await expect(runQueuedJob()).rejects.toThrow('OCR processing failed');
   }, OCR_TIMEOUT);
 
   test('modal queues an immediate scan and closes when initialImage is provided', async () => {
@@ -231,7 +235,12 @@ describe('OcrScanModal', () => {
     const aiCall = recognizeRecipeWithAI.mock.calls[0];
     expect(aiCall).toHaveLength(2);
     expect(aiCall[1]).toHaveProperty('onProgress');
-    expect(aiCall[1].onProgress).toBeInstanceOf(Function);
+    // A single-image scan now forwards the queue's progress callback to
+    // recognizeRecipeWithAI directly (see runPhotoScanImport) instead of
+    // wrapping it in a local closure, so `onProgress` here is the same
+    // jest.fn() passed to job.run() — `typeof` avoids the jsdom/jest-mock
+    // realm mismatch that `toBeInstanceOf(Function)` hits on that value.
+    expect(typeof aiCall[1].onProgress).toBe('function');
   });
 
   test('queued job adds vegetarisch and vegan tags to kulinarik', async () => {

--- a/src/components/UniversalImportModal.js
+++ b/src/components/UniversalImportModal.js
@@ -47,7 +47,7 @@ function UniversalImportModal({ onCancel, initialImages = [], initialText = '', 
       label: snapshot.url.trim() || 'Rezept-Import',
       userId,
       context: importContext,
-      run: (onProgress) => runUniversalImport(snapshot, onProgress),
+      run: (onProgress, jobMeta) => runUniversalImport(snapshot, onProgress, jobMeta),
       source: { type: 'universal', images: snapshot.images, text: snapshot.text, url: snapshot.url },
     });
 

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -45,7 +45,7 @@ function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '',
       label: normalizedUrl,
       userId,
       context: importContext,
-      run: (onProgress) => runWebImport(normalizedUrl, authorId, onProgress),
+      run: (onProgress, jobMeta) => runWebImport(normalizedUrl, authorId, onProgress, jobMeta),
       source: { type: 'web', url: normalizedUrl, authorId },
     });
 

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -39,15 +39,19 @@ async function buildImportSourceSnapshot(source) {
 // Reconstructs the `run` function an import job was originally queued with,
 // from its persisted importSource — used to restart a job that is stuck
 // waiting (e.g. its owning tab was closed/reloaded before it could finish).
+// `run` receives (onProgress, jobMeta) — see processQueue below for how
+// jobMeta ({jobId, authorId}) is supplied on every attempt, fresh or
+// restarted, so the underlying Cloud Function call can finalize the job
+// directly in Firestore and survive this tab being closed again.
 function buildRunFromSource(source) {
   if (!source) return null;
   switch (source.type) {
     case 'web':
-      return (onProgress) => runWebImport(source.url, source.authorId, onProgress);
+      return (onProgress, jobMeta) => runWebImport(source.url, source.authorId, onProgress, jobMeta);
     case 'universal':
-      return (onProgress) => runUniversalImport({ images: source.images, text: source.text, url: source.url }, onProgress);
+      return (onProgress, jobMeta) => runUniversalImport({ images: source.images, text: source.text, url: source.url }, onProgress, jobMeta);
     case 'photo':
-      return (onProgress) => runPhotoScanImport(source.images, source.language, onProgress);
+      return (onProgress, jobMeta) => runPhotoScanImport(source.images, source.language, onProgress, jobMeta);
     default:
       return null;
   }
@@ -144,7 +148,10 @@ export function RecipeImportQueueProvider({ userId, children }) {
         }
         patchJob(job.id, { importStatus: 'processing' });
         try {
-          const recipe = await job.run((progress, label) => patchProgress(job.id, progress, label));
+          const recipe = await job.run(
+            (progress, label) => patchProgress(job.id, progress, label),
+            { jobId: job.id, authorId: job.userId },
+          );
           if (cancelledJobsRef.current.has(job.id)) {
             // Cancelled (or superseded by a restart) while running — the
             // recognition finished, but nobody is waiting on this result

--- a/src/utils/aiOcrService.js
+++ b/src/utils/aiOcrService.js
@@ -86,9 +86,12 @@ async function getRecipeExtractionPrompt(lang = 'de') {
  * @param {string} rawHtml - Raw HTML string to process
  * @param {string} lang - Language code ('de' or 'en')
  * @param {Function} onProgress - Optional progress callback
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side if this call is the job's sole/final step —
+ *   see RecipeImportQueueContext for how jobId/authorId are supplied.
  * @returns {Promise<Object>} Structured recipe data
  */
-export async function processHtmlWithGemini(rawHtml, lang = 'de', onProgress = null) {
+export async function processHtmlWithGemini(rawHtml, lang = 'de', onProgress = null, jobMeta = null) {
   if (onProgress) onProgress(10);
 
   if (!rawHtml || typeof rawHtml !== 'string') {
@@ -134,6 +137,8 @@ export async function processHtmlWithGemini(rawHtml, lang = 'de', onProgress = n
         language: lang,
         cuisineTypes,
         mealCategories,
+        jobId: jobMeta?.jobId,
+        authorId: jobMeta?.authorId,
       });
 
       clearInterval(progressInterval);
@@ -196,9 +201,11 @@ export async function processHtmlWithGemini(rawHtml, lang = 'de', onProgress = n
  * @param {string} imageBase64 - Base64 encoded image (with or without data URL prefix)
  * @param {string} lang - Language code ('de' or 'en')
  * @param {Function} onProgress - Optional progress callback
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side if this call is the job's sole/final step.
  * @returns {Promise<Object>} Structured recipe data
  */
-export async function recognizeRecipeWithGemini(imageBase64, lang = 'de', onProgress = null) {
+export async function recognizeRecipeWithGemini(imageBase64, lang = 'de', onProgress = null, jobMeta = null) {
   if (onProgress) onProgress(10);
 
   // Validate image data
@@ -248,6 +255,8 @@ export async function recognizeRecipeWithGemini(imageBase64, lang = 'de', onProg
         language: lang,
         cuisineTypes,
         mealCategories,
+        jobId: jobMeta?.jobId,
+        authorId: jobMeta?.authorId,
       });
 
       clearInterval(progressInterval);
@@ -310,6 +319,99 @@ export async function recognizeRecipeWithGemini(imageBase64, lang = 'de', onProg
 }
 
 /**
+ * Batch-scan multiple recipe photos with AI in a single Cloud Function call.
+ * Used for multi-image imports (Foto-Scan, Universal-Import photos-only) so
+ * the concurrent per-image OCR and the merge into one recipe both run
+ * server-side and can finalize a queued background-import job even if the
+ * tab that started it is closed before every image finishes.
+ *
+ * @param {string[]} images - Base64 encoded images (max 10)
+ * @param {string} lang - Language code ('de' or 'en')
+ * @param {Function} onProgress - Optional progress callback (0-100)
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side.
+ * @returns {Promise<Object>} Merged structured recipe data
+ */
+export async function scanRecipesWithAI(images, lang = 'de', onProgress = null, jobMeta = null) {
+  if (onProgress) onProgress(10);
+
+  if (!Array.isArray(images) || images.length === 0) {
+    throw new Error('Invalid image data');
+  }
+
+  let cuisineTypes;
+  let mealCategories;
+  try {
+    const lists = await getCustomLists();
+    cuisineTypes = lists.cuisineTypes;
+    mealCategories = lists.mealCategories;
+  } catch (e) {
+    console.warn('Failed to load custom lists for AI prompt, using base prompt:', e);
+  }
+
+  let progressInterval = null;
+  try {
+    const scanRecipesWithAICallable = httpsCallable(functions, 'scanRecipesWithAI');
+
+    let simulatedProgress = 20;
+    if (onProgress) {
+      onProgress(20);
+      progressInterval = setInterval(() => {
+        simulatedProgress = Math.min(85, simulatedProgress + 1);
+        onProgress(simulatedProgress);
+      }, 400);
+    }
+
+    const result = await scanRecipesWithAICallable({
+      images,
+      language: lang,
+      cuisineTypes,
+      mealCategories,
+      jobId: jobMeta?.jobId,
+      authorId: jobMeta?.authorId,
+    });
+
+    clearInterval(progressInterval);
+    progressInterval = null;
+    if (onProgress) onProgress(100);
+
+    const recipeData = result.data;
+    if (!recipeData) {
+      throw new Error('No response from AI service');
+    }
+
+    return recipeData;
+  } catch (error) {
+    clearInterval(progressInterval);
+    progressInterval = null;
+    if (onProgress) onProgress(0);
+
+    const errorDetails = getCallableErrorDetails(error);
+    const { code: errorCode } = errorDetails;
+
+    if (errorCode === 'unauthenticated' && !isInvokerAuthFailure(errorDetails)) {
+      throw new Error('Bitte melde dich an, um AI-Scan zu nutzen.');
+    } else if (errorCode === 'permission-denied' || isInvokerAuthFailure(errorDetails)) {
+      throw new Error(INVOKER_ERROR_MESSAGE_OCR);
+    } else if (errorCode === 'resource-exhausted') {
+      throw new Error(error.message || 'Tageslimit erreicht. Versuche es morgen erneut oder nutze Standard-OCR.');
+    } else if (errorCode === 'invalid-argument') {
+      throw new Error(error.message || 'Ungültige Bilder.');
+    } else if (errorCode === 'failed-precondition') {
+      throw new Error('AI-Service nicht konfiguriert. Bitte kontaktiere den Administrator.');
+    } else if (errorCode === 'unavailable') {
+      throw new Error('Netzwerkfehler. Bitte überprüfe deine Internetverbindung.');
+    } else if (errorCode === 'deadline-exceeded') {
+      throw new Error('Zeitüberschreitung. Bitte versuche es erneut.');
+    } else if (error.message) {
+      throw new Error(error.message);
+    }
+
+    throw new Error('KI-Bildverarbeitung fehlgeschlagen. Bitte versuche es erneut.');
+  }
+}
+
+/**
  * Recognize recipe using OpenAI GPT-4o Vision (future implementation)
  * @param {string} imageBase64 - Base64 encoded image
  * @param {string} lang - Language code ('de' or 'en')
@@ -344,13 +446,16 @@ export async function recognizeRecipeWithOpenAI(imageBase64, lang = 'de', onProg
  * @param {string} options.language - Language code ('de' or 'en')
  * @param {string} options.provider - Preferred provider ('gemini' or 'openai')
  * @param {Function} options.onProgress - Progress callback (0-100)
+ * @param {{jobId?: string, authorId?: string}} [options.jobMeta] - Background-import
+ *   job to finalize server-side if this call is the job's sole/final step.
  * @returns {Promise<Object>} Structured recipe data
  */
 export async function recognizeRecipeWithAI(imageBase64, options = {}) {
   const {
     language = 'de',
     provider = 'gemini',
-    onProgress = null
+    onProgress = null,
+    jobMeta = null,
   } = options;
 
   // Validate image data
@@ -375,7 +480,7 @@ export async function recognizeRecipeWithAI(imageBase64, options = {}) {
   // Call the appropriate provider
   switch (selectedProvider) {
     case 'gemini':
-      return await recognizeRecipeWithGemini(imageBase64, language, onProgress);
+      return await recognizeRecipeWithGemini(imageBase64, language, onProgress, jobMeta);
     case 'openai':
       return await recognizeRecipeWithOpenAI(imageBase64, language, onProgress);
     default:

--- a/src/utils/importRunners.js
+++ b/src/utils/importRunners.js
@@ -7,7 +7,7 @@ import {
   captureWebsiteScreenshot,
 } from './webImportService';
 import { buildRecipeFromAiResult } from './ocrParser';
-import { recognizeRecipeWithAI } from './aiOcrService';
+import { recognizeRecipeWithAI, scanRecipesWithAI } from './aiOcrService';
 
 // Max number of images processed at the same time during a multi-image
 // import/scan. Images are independent OCR calls, so processing several in
@@ -21,18 +21,24 @@ const BATCH_CONCURRENCY = 3;
 // the `run` function to enqueueImportJob() from WebImportModal, and
 // reconstructed identically by RecipeImportQueueContext when restarting a
 // job whose importSource was persisted to Firestore.
-export async function runWebImport(normalizedUrl, authorId, onProgress) {
+//
+// jobMeta ({jobId, authorId}), when supplied by RecipeImportQueueContext,
+// lets the Cloud Function write its result directly to the queued temp
+// recipe document — so the import still finishes even if this tab is
+// closed before the call returns. See RecipeImportQueueContext for how
+// jobMeta is threaded through.
+export async function runWebImport(normalizedUrl, authorId, onProgress, jobMeta) {
   let result;
 
   if (isInstagramUrl(normalizedUrl)) {
     // Instagram path (post, reel, or IGTV) – extract caption and page text with Puppeteer + Gemini
-    result = await importInstagramReel(normalizedUrl, onProgress);
+    result = await importInstagramReel(normalizedUrl, onProgress, jobMeta);
   } else if (isRecipeImportPageUrl(normalizedUrl)) {
     // Direct HTML parsing path – no screenshot or AI needed
-    result = await parseRecipeImportPage(normalizedUrl, onProgress);
+    result = await parseRecipeImportPage(normalizedUrl, onProgress, jobMeta);
   } else {
     // Multi-step import: JSON-LD → Text+Gemini → Screenshot+Vision
-    result = await importRecipeFromUrl(normalizedUrl, onProgress);
+    result = await importRecipeFromUrl(normalizedUrl, onProgress, jobMeta);
   }
 
   return buildRecipeFromAiResult(result, authorId);
@@ -79,8 +85,17 @@ function mergeUniversalAiResults(results) {
 // Runs recognition for a combination of images/text/url and returns the
 // merged recipe. Passed as the `run` function to enqueueImportJob() from
 // UniversalImportModal, and reconstructed identically on restart.
-export async function runUniversalImport({ images, text, url }, onProgress) {
+//
+// jobMeta ({jobId, authorId}) lets the underlying Cloud Function call write
+// its result directly to the queued temp recipe document, so the import
+// survives this tab being closed mid-run. That's only safe when exactly one
+// content leg (url XOR text XOR images) was submitted — with several legs,
+// the final recipe only exists after mergeUniversalAiResults() below runs
+// client-side, so soleLegMeta stays null and none of them finalize the job.
+export async function runUniversalImport({ images, text, url }, onProgress, jobMeta) {
   const results = [];
+  const legCount = (url.trim() ? 1 : 0) + (text.trim() ? 1 : 0) + (images.length > 0 ? 1 : 0);
+  const soleLegMeta = legCount === 1 ? jobMeta : null;
 
   if (url.trim()) {
     const screenshotBase64 = await captureWebsiteScreenshot(url.trim(), (prog) => {
@@ -92,6 +107,7 @@ export async function runUniversalImport({ images, text, url }, onProgress) {
         language: 'de',
         provider: 'gemini',
         onProgress: (prog) => onProgress(50 + Math.round(prog * 0.5)),
+        jobMeta: soleLegMeta,
       });
       results.push(result);
     } catch (err) {
@@ -136,6 +152,7 @@ export async function runUniversalImport({ images, text, url }, onProgress) {
         language: 'de',
         provider: 'gemini',
         onProgress: (prog) => onProgress(prog),
+        jobMeta: soleLegMeta,
       });
       results.push(result);
     } catch (err) {
@@ -143,13 +160,36 @@ export async function runUniversalImport({ images, text, url }, onProgress) {
     }
   }
 
-  if (images.length > 0) {
+  if (images.length === 1) {
+    onProgress(0, 'Analysiere Bild...');
+    try {
+      const result = await recognizeRecipeWithAI(images[0], {
+        language: 'de',
+        provider: 'gemini',
+        onProgress: (prog) => onProgress(prog),
+        jobMeta: soleLegMeta,
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  } else if (images.length > 1 && soleLegMeta) {
+    // Sole leg, several images: run the whole batch (concurrent OCR + merge)
+    // server-side in one call so it can still finalize the job if this tab
+    // closes before every image finishes — see scanRecipesWithAI.
+    try {
+      const merged = await scanRecipesWithAI(images, 'de', onProgress, soleLegMeta);
+      results.push(merged);
+    } catch (err) {
+      results.push({ error: err.message });
+    }
+  } else if (images.length > 1) {
     const imageResults = new Array(images.length);
     const progressPerImage = new Array(images.length).fill(0);
 
     const updateOverallProgress = () => {
       const sum = progressPerImage.reduce((a, b) => a + b, 0);
-      onProgress(Math.round(sum / images.length), images.length === 1 ? 'Analysiere Bild...' : `Analysiere ${images.length} Bilder...`);
+      onProgress(Math.round(sum / images.length), `Analysiere ${images.length} Bilder...`);
     };
 
     let nextIndex = 0;
@@ -184,124 +224,26 @@ export async function runUniversalImport({ images, text, url }, onProgress) {
   return buildRecipeFromAiResult(merged);
 }
 
-// Remove duplicate strings using Levenshtein similarity
-function stringSimilarity(s1, s2) {
-  const longer = s1.length > s2.length ? s1 : s2;
-  const shorter = s1.length > s2.length ? s2 : s1;
-  if (longer.length === 0) return 1.0;
-  const editDistance = levenshteinDistance(longer, shorter);
-  return (longer.length - editDistance) / longer.length;
-}
-
-function levenshteinDistance(s1, s2) {
-  const costs = [];
-  for (let i = 0; i <= s1.length; i++) {
-    let lastValue = i;
-    for (let j = 0; j <= s2.length; j++) {
-      if (i === 0) {
-        costs[j] = j;
-      } else if (j > 0) {
-        let newValue = costs[j - 1];
-        if (s1.charAt(i - 1) !== s2.charAt(j - 1)) {
-          newValue = Math.min(Math.min(newValue, lastValue), costs[j]) + 1;
-        }
-        costs[j - 1] = lastValue;
-        lastValue = newValue;
-      }
-    }
-    if (i > 0) costs[s2.length] = lastValue;
-  }
-  return costs[s2.length];
-}
-
-function removeDuplicates(items) {
-  if (!items || items.length === 0) return [];
-  const unique = [];
-  for (const item of items) {
-    const normalized = item.toLowerCase().trim();
-    const isDuplicate = unique.some(existing =>
-      stringSimilarity(existing.toLowerCase().trim(), normalized) > 0.8
-    );
-    if (!isDuplicate) {
-      unique.push(item);
-    }
-  }
-  return unique;
-}
-
-// Combine multiple per-image AI OCR results into one recipe
-function mergePhotoAiResults(results) {
-  const validResults = results.filter(r => !r.error);
-  if (validResults.length === 0) {
-    throw new Error('Keine gültigen OCR-Ergebnisse gefunden');
+// Runs AI OCR on a batch of images and returns the merged recipe. Passed as
+// the `run` function to enqueueImportJob() from OcrScanModal, and
+// reconstructed identically on restart.
+//
+// A single image is scanned directly so the one Cloud Function call can
+// finalize the queued job (jobMeta) server-side on its own. Several images
+// are handed to the scanRecipesWithAI batch function instead, which runs the
+// concurrent per-image OCR and the merge server-side in one call — both
+// paths survive this tab being closed before the scan finishes.
+export async function runPhotoScanImport(images, language, onProgress, jobMeta) {
+  if (images.length === 1) {
+    const result = await recognizeRecipeWithAI(images[0], {
+      language,
+      provider: 'gemini',
+      onProgress,
+      jobMeta,
+    });
+    return buildRecipeFromAiResult(result);
   }
 
-  const merged = { ...validResults[0] };
-
-  const allIngredients = validResults.flatMap(r => r.ingredients || []);
-  merged.ingredients = removeDuplicates(allIngredients);
-
-  const allSteps = validResults.flatMap(r => r.steps || []);
-  merged.steps = removeDuplicates(allSteps);
-
-  const allTags = validResults.flatMap(r => r.tags || []);
-  merged.tags = [...new Set(allTags)];
-
-  const allNotes = validResults
-    .map(r => r.notes)
-    .filter(n => n && n.trim())
-    .join('\n\n');
-  merged.notes = allNotes || merged.notes;
-
-  merged.servings = merged.servings || validResults.find(r => r.servings)?.servings;
-  merged.prepTime = merged.prepTime || validResults.find(r => r.prepTime)?.prepTime;
-  merged.cookTime = merged.cookTime || validResults.find(r => r.cookTime)?.cookTime;
-  merged.difficulty = merged.difficulty || validResults.find(r => r.difficulty)?.difficulty;
-  merged.cuisine = merged.cuisine || validResults.find(r => r.cuisine)?.cuisine;
-  merged.category = merged.category || validResults.find(r => r.category)?.category;
-
-  return merged;
-}
-
-// Runs AI OCR on a batch of images (concurrently, up to BATCH_CONCURRENCY at
-// once) and returns the merged recipe. Passed as the `run` function to
-// enqueueImportJob() from OcrScanModal, and reconstructed identically on
-// restart.
-export async function runPhotoScanImport(images, language, onProgress) {
-  const total = images.length;
-  const results = new Array(total);
-  const progressPerImage = new Array(total).fill(0);
-
-  const updateOverall = () => {
-    const sum = progressPerImage.reduce((a, b) => a + b, 0);
-    onProgress(Math.round(sum / total));
-  };
-
-  let nextIndex = 0;
-  const worker = async () => {
-    while (nextIndex < total) {
-      const i = nextIndex++;
-      try {
-        const result = await recognizeRecipeWithAI(images[i], {
-          language,
-          provider: 'gemini',
-          onProgress: (progress) => {
-            progressPerImage[i] = progress;
-            updateOverall();
-          },
-        });
-        results[i] = result;
-      } catch (err) {
-        results[i] = { error: err.message };
-      }
-      progressPerImage[i] = 100;
-      updateOverall();
-    }
-  };
-
-  const workerCount = Math.min(BATCH_CONCURRENCY, total);
-  await Promise.all(Array.from({ length: workerCount }, worker));
-
-  const merged = mergePhotoAiResults(results);
+  const merged = await scanRecipesWithAI(images, language, onProgress, jobMeta);
   return buildRecipeFromAiResult(merged);
 }

--- a/src/utils/webImportService.js
+++ b/src/utils/webImportService.js
@@ -200,9 +200,11 @@ export const isInstagramReelUrl = isInstagramUrl;
  *
  * @param {string} url - Instagram Reel URL
  * @param {Function} [onProgress] - Optional progress callback (0–100)
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side so it survives the tab being closed mid-import.
  * @returns {Promise<Object>} Structured recipe data
  */
-export async function importInstagramReel(url, onProgress = null) {
+export async function importInstagramReel(url, onProgress = null, jobMeta = null) {
   const normalizedUrl = normalizeImportedUrl(url);
 
   if (!isInstagramUrl(normalizedUrl)) {
@@ -243,6 +245,8 @@ export async function importInstagramReel(url, onProgress = null) {
       language: 'de',
       cuisineTypes,
       mealCategories,
+      jobId: jobMeta?.jobId,
+      authorId: jobMeta?.authorId,
     });
 
     clearInterval(progressInterval);
@@ -379,9 +383,14 @@ export function extractTextFromHtml(html) {
  *
  * @param {string} url - A recipeImportPage URL (validated by isRecipeImportPageUrl)
  * @param {Function} [onProgress] - Optional progress callback (0–100)
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side. Only honored on the raw-HTML branch below
+ *   (processHtmlWithGemini); the JSON-LD/canvas-vision branch can still fall
+ *   back to local text parsing on AI failure, so it isn't wired up as the
+ *   job's authoritative final step.
  * @returns {Promise<Object>} Structured recipe data
  */
-export async function parseRecipeImportPage(url, onProgress = null) {
+export async function parseRecipeImportPage(url, onProgress = null, jobMeta = null) {
   if (onProgress) onProgress(10);
 
   let response;
@@ -448,6 +457,7 @@ export async function parseRecipeImportPage(url, onProgress = null) {
     try {
       aiResult = await processHtmlWithGemini(cleanedText, 'de',
         onProgress ? (p) => onProgress(50 + Math.round(p * 0.5)) : null,
+        jobMeta,
       );
     } catch (htmlAiError) {
       throw new Error(
@@ -768,9 +778,11 @@ export function jsonLdToText(candidate) {
  *
  * @param {string} url - The recipe URL to import
  * @param {Function} [onProgress] - Optional progress callback (0–100)
+ * @param {{jobId?: string, authorId?: string}} [jobMeta] - Background-import
+ *   job to finalize server-side so it survives the tab being closed mid-import.
  * @returns {Promise<Object>} Structured recipe data
  */
-export async function importRecipeFromUrl(url, onProgress = null) {
+export async function importRecipeFromUrl(url, onProgress = null, jobMeta = null) {
   const normalizedUrl = normalizeImportedUrl(url);
 
   if (onProgress) onProgress(10);
@@ -806,6 +818,8 @@ export async function importRecipeFromUrl(url, onProgress = null) {
       url: normalizedUrl,
       cuisineTypes,
       mealCategories,
+      jobId: jobMeta?.jobId,
+      authorId: jobMeta?.authorId,
     });
 
     clearInterval(progressInterval);

--- a/src/utils/webImportService.test.js
+++ b/src/utils/webImportService.test.js
@@ -493,6 +493,7 @@ ${withJsonLd ? `<script type="application/ld+json">${jsonLd}</script>` : ''}
       expect.not.stringMatching(/<[^>]+>/),
       'de',
       null,
+      null,
     );
 
     // recognizeRecipeWithAI (canvas-based) should NOT have been called
@@ -524,6 +525,7 @@ ${withJsonLd ? `<script type="application/ld+json">${jsonLd}</script>` : ''}
     expect(processHtmlWithGemini).toHaveBeenCalledWith(
       expect.not.stringMatching(/<[^>]+>/),
       'de',
+      null,
       null,
     );
     expect(recognizeRecipeWithAI).not.toHaveBeenCalled();


### PR DESCRIPTION
Web-Import, Instagram-Import and Foto-Scan/Universal-Import previously only
wrote their result back to Firestore from the browser tab that started them.
If that tab was closed before the (often 30-180s) Cloud Function call
returned, the queued job was left stuck at "processing" forever.

The relevant Cloud Functions (scanRecipeWithAI, importRecipeCallable,
scrapeInstagramReel, processHtmlWithAI) now accept an optional jobId and
write their result (or error) directly to the queued temp-recipe Firestore
document via the Admin SDK before returning. A new batch scanRecipesWithAI
function does the same for multi-image scans, running the concurrent
per-image OCR and merge server-side in one call.

RecipeImportQueueContext threads {jobId, authorId} through every run()
call (fresh and restarted alike) so the finalize/fail write only happens
when a Cloud Function call is the job's sole, authoritative result —
multi-leg Universal-Import combinations (e.g. URL + text together) still
merge client-side as before and are unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GQnfS2ijXa4iukTNgAwk3w