### PR TITLE
Always offer Abbrechen for queued import jobs

### DIFF
--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -46,16 +46,27 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCan
                       />
                     </div>
                   )}
-                  {job.status === 'queued' && job.canRestart && (
+                  {job.status === 'queued' && (
                     <div className="import-progress-item-actions">
+                      {job.canRestart && (
+                        <button
+                          type="button"
+                          className="import-progress-item-restart"
+                          onClick={() => onRestartJob(job.id)}
+                          title="Import neu starten"
+                          aria-label={`${job.label || 'Import'} neu starten`}
+                        >
+                          Neu starten
+                        </button>
+                      )}
                       <button
                         type="button"
-                        className="import-progress-item-restart"
-                        onClick={() => onRestartJob(job.id)}
-                        title="Import neu starten"
-                        aria-label={`${job.label || 'Import'} neu starten`}
+                        className="import-progress-item-dismiss"
+                        onClick={() => onCancelJob(job.id)}
+                        title="Import abbrechen"
+                        aria-label={`${job.label || 'Import'} abbrechen`}
                       >
-                        Neu starten
+                        Abbrechen
                       </button>
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Follow-up to #3070. That PR added automatic recovery for orphaned import jobs, but only for jobs that have a persisted `importSource` — needed to rebuild the `run` function. This surfaced a pre-existing gap: a `queued` job **without** an `importSource` (e.g. a legacy job predating that field) has no action at all in the import progress dialog — no "Neu starten" (nothing to rebuild the run from), and unlike `processing`/`error` jobs, no "Abbrechen" either. It's stuck in the UI with no way to remove it, which is exactly what a user hit: a kochbar.de import stuck on "Wartet…" that a hard reload didn't fix, because it had no `importSource` and thus no visible action.

- `ImportProgressDialog`: show the existing cancel action (`onCancelJob`, already wired up in `Header.js`) for every `queued` job, restarting only when `importSource` makes it possible — mirroring the pattern already used for `processing` jobs (restart conditionally + cancel always).

## Test plan

- [ ] Manually verify: a `queued` job with `importSource` still shows both "Neu starten" and "Abbrechen".
- [ ] Manually verify: a `queued` job without `importSource` now shows "Abbrechen" (previously showed nothing).
- [ ] Manually verify clicking "Abbrechen" on a queued job removes it from the dialog (existing `cancelJob` behavior, unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWtRD2dCU7YukAVoHJAYk5)_