### PR TITLE
Lock body scroll while the Rezept-Import dialog is open

### DIFF
--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './ImportProgressDialog.css';
 
 function statusLabel(status) {
@@ -19,6 +19,26 @@ function statusLabel(status) {
 // this list immediately and show up as pending reviews on "Neues Rezept
 // hinzufügen" instead.
 function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCancelJob }) {
+  // Lock body scroll while this dialog is open (iOS Safari safe)
+  useEffect(() => {
+    const scrollY = window.scrollY;
+    const prevOverflow = document.body.style.overflow;
+    const prevPosition = document.body.style.position;
+    const prevTop = document.body.style.top;
+    const prevWidth = document.body.style.width;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = '100%';
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      document.body.style.position = prevPosition;
+      document.body.style.top = prevTop;
+      document.body.style.width = prevWidth;
+      window.scrollTo(0, scrollY);
+    };
+  }, []);
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="import-progress-dialog" onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
Reuses the existing body-scroll-lock pattern from NutritionModal/Tagesmenu.