### PR TITLE
Redesign OCR scan dialog to match photo-upload template

### DIFF
--- a/src/components/OcrScanModal.css
+++ b/src/components/OcrScanModal.css
@@ -13,16 +13,53 @@
 
 .ocr-modal-header {
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
+  gap: 16px;
   padding: 20px;
   border-bottom: 1px solid #e0e0e0;
+}
+
+.ocr-modal-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ocr-step-label {
+  font-family: 'Courier New', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #8a827a;
 }
 
 .ocr-modal-header h2 {
   margin: 0;
   font-size: 1.5rem;
   color: #333;
+}
+
+.ocr-modal-header .close-button {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: 11px;
+  border: 1px solid #e2dcd1;
+  background: transparent;
+  color: #6d675e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.14s;
+}
+
+.ocr-modal-header .close-button:hover {
+  background: #f2ede4;
+  color: #1c1a17;
 }
 
 .ocr-modal-content {
@@ -841,100 +878,181 @@
 .image-preview-section {
   display: flex;
   flex-direction: column;
+  gap: 18px;
+}
+
+/* Status row */
+.ocr-status-row {
+  display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 11px;
+  padding: 11px 14px;
+  border-radius: 13px;
+  background: #f6f1e8;
+}
+
+.ocr-status-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: #1e8fe6;
+}
+
+.ocr-status-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ocr-status-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #231f1b;
+}
+
+.ocr-status-subtitle {
+  font-size: 0.78rem;
+  color: #787166;
 }
 
 .image-preview-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
   width: 100%;
 }
 
 .image-preview-item {
   position: relative;
-  flex-shrink: 0;
+  aspect-ratio: 3 / 4;
+  border-radius: 14px;
+  border: 1px solid #e2dcd1;
+  overflow: hidden;
 }
 
 .image-preview-thumb {
-  width: 90px;
-  height: 90px;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border-radius: 6px;
-  border: 2px solid #2196F3;
   display: block;
 }
 
 .image-preview-remove {
   position: absolute;
-  top: -6px;
-  right: -6px;
-  width: 20px;
-  height: 20px;
+  top: 7px;
+  right: 7px;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
-  background-color: #f44336;
-  color: white;
-  border: none;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #ded7cb;
+  color: #4a443c;
   cursor: pointer;
-  font-size: 0.65rem;
-  font-weight: bold;
+  font-size: 11px;
   display: flex;
   align-items: center;
   justify-content: center;
   line-height: 1;
   padding: 0;
+  transition: all 0.14s;
 }
 
 .image-preview-remove:hover {
-  background-color: #c62828;
+  background: #d64726;
+  border-color: transparent;
+  color: #fff;
 }
 
 .image-preview-number {
   position: absolute;
-  bottom: 2px;
-  left: 2px;
-  background-color: rgba(0, 0, 0, 0.6);
-  color: white;
-  font-size: 0.7rem;
-  font-weight: bold;
-  border-radius: 3px;
-  padding: 1px 4px;
-  line-height: 1.4;
+  left: 8px;
+  bottom: 8px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.63rem;
+  letter-spacing: 0.08em;
+  color: #fdfbf7;
+  background: rgba(28, 26, 23, 0.6);
+  padding: 3px 6px;
+  border-radius: 6px;
+  line-height: 1.3;
 }
 
 .image-preview-add {
-  width: 90px;
-  height: 90px;
-  border: 2px dashed #2196F3;
-  border-radius: 6px;
+  aspect-ratio: 3 / 4;
+  border-radius: 14px;
+  border: 1px dashed #cfc6b8;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   cursor: pointer;
-  color: #2196F3;
-  font-size: 2rem;
-  font-weight: 300;
-  transition: background-color 0.2s;
-  flex-shrink: 0;
+  color: #8d8578;
+  transition: all 0.14s;
 }
 
 .image-preview-add:hover {
-  background-color: #e3f2fd;
+  border-color: #1e8fe6;
+  color: #1878c4;
+}
+
+.image-preview-add-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.image-preview-add-label {
+  font-family: 'Courier New', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ocr-file-hint {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  color: #8d8578;
+  text-align: center;
 }
 
 .image-preview-actions {
   display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: center;
+  gap: 10px;
+}
+
+.image-preview-actions .start-analysis-button {
+  flex: 1;
+  height: 50px;
+  border-radius: 14px;
+  font-size: 0.97rem;
+}
+
+.image-preview-cancel {
+  width: 130px;
+  height: 50px;
+  flex: none;
+  border-radius: 14px;
+  border: 1px solid #ded7cb;
+  background: transparent;
+  color: #33302a;
+  font-size: 0.94rem;
+  cursor: pointer;
+  transition: all 0.14s;
+}
+
+.image-preview-cancel:hover {
+  background: #f2ede4;
 }
 
 @media (max-width: 480px) {
-  .image-preview-thumb,
-  .image-preview-add {
-    width: 72px;
-    height: 72px;
+  .image-preview-actions {
+    flex-wrap: wrap;
+  }
+
+  .image-preview-cancel {
+    width: 100%;
   }
 }

--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -5,6 +5,8 @@ import { runPhotoScanImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
 const MAX_CAMERA_PHOTOS = 10;
+const MAX_UPLOAD_PAGES = 8;
+const UPLOAD_ACCEPT = 'image/jpeg,image/jpg,image/png,image/heic,image/heif,.heic,.heif';
 
 // initialImage: single image that triggers an immediate background scan (takes precedence over initialImages)
 // initialImages: array of base64 images to pre-fill the image-preview step
@@ -65,7 +67,13 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
     setError('');
     try {
       const base64s = await Promise.all(files.map(f => fileToBase64(f)));
-      setUploadedImages(prev => [...prev, ...base64s]);
+      setUploadedImages(prev => {
+        const combined = [...prev, ...base64s];
+        if (combined.length > MAX_UPLOAD_PAGES) {
+          setError(`Maximal ${MAX_UPLOAD_PAGES} Seiten möglich.`);
+        }
+        return combined.slice(0, MAX_UPLOAD_PAGES);
+      });
       setStep('image-preview');
     } catch (err) {
       setError(err.message);
@@ -81,7 +89,13 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
     setError('');
     try {
       const base64s = await Promise.all(files.map(f => fileToBase64(f)));
-      setUploadedImages(prev => [...prev, ...base64s]);
+      setUploadedImages(prev => {
+        const combined = [...prev, ...base64s];
+        if (combined.length > MAX_UPLOAD_PAGES) {
+          setError(`Maximal ${MAX_UPLOAD_PAGES} Seiten möglich.`);
+        }
+        return combined.slice(0, MAX_UPLOAD_PAGES);
+      });
     } catch (err) {
       setError(err.message);
     }
@@ -171,8 +185,11 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
     <div className="modal-overlay">
       <div className="ocr-modal">
         <div className="ocr-modal-header">
-          <h2>Rezept scannen</h2>
-          <button className="close-button" onClick={handleCancel}>×</button>
+          <div className="ocr-modal-heading">
+            <span className="ocr-step-label">Schritt {step === 'image-preview' ? 2 : 1} von 2</span>
+            <h2>Rezept scannen</h2>
+          </div>
+          <button className="close-button" onClick={handleCancel} aria-label="Schließen">×</button>
         </div>
 
         <div className="ocr-modal-content">
@@ -212,7 +229,7 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
                   <input
                     type="file"
                     id="imageUpload"
-                    accept="image/jpeg,image/jpg,image/png"
+                    accept={UPLOAD_ACCEPT}
                     multiple
                     onChange={handleMultiFileUpload}
                     style={{ display: 'none' }}
@@ -297,9 +314,15 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
           {/* Image Preview Step – review & extend selection before analysis */}
           {step === 'image-preview' && (
             <div className="image-preview-section">
-              <p className="ocr-instructions">
-                {uploadedImages.length} Bild{uploadedImages.length !== 1 ? 'er' : ''} ausgewählt – Weitere hinzufügen oder Analyse starten
-              </p>
+              <div className="ocr-status-row">
+                <span className="ocr-status-dot" />
+                <div className="ocr-status-text">
+                  <div className="ocr-status-title">
+                    {uploadedImages.length} Bild{uploadedImages.length !== 1 ? 'er' : ''} ausgewählt
+                  </div>
+                  <div className="ocr-status-subtitle">Weitere Seiten hinzufügen oder Analyse starten</div>
+                </div>
+              </div>
 
               <div className="image-preview-grid">
                 {uploadedImages.map((src, index) => (
@@ -309,6 +332,7 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
                       alt={`Bild ${index + 1}`}
                       className="image-preview-thumb"
                     />
+                    <span className="image-preview-number">S{index + 1}</span>
                     <button
                       className="image-preview-remove"
                       onClick={() => handleRemoveUploadedImage(index)}
@@ -317,22 +341,26 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
                     >
                       ×
                     </button>
-                    <span className="image-preview-number">{index + 1}</span>
                   </div>
                 ))}
 
-                <label className="image-preview-add" title="Weitere Bilder hinzufügen">
-                  <span>+</span>
-                  <input
-                    ref={addMoreInputRef}
-                    type="file"
-                    accept="image/jpeg,image/jpg,image/png"
-                    multiple
-                    onChange={handleAddMoreImages}
-                    style={{ display: 'none' }}
-                  />
-                </label>
+                {uploadedImages.length < MAX_UPLOAD_PAGES && (
+                  <label className="image-preview-add" title="Weitere Seiten hinzufügen">
+                    <span className="image-preview-add-icon">+</span>
+                    <span className="image-preview-add-label">Seite</span>
+                    <input
+                      ref={addMoreInputRef}
+                      type="file"
+                      accept={UPLOAD_ACCEPT}
+                      multiple
+                      onChange={handleAddMoreImages}
+                      style={{ display: 'none' }}
+                    />
+                  </label>
+                )}
               </div>
+
+              <p className="ocr-file-hint">JPG · PNG · HEIC — max. {MAX_UPLOAD_PAGES} Seiten</p>
 
               <div className="image-preview-actions">
                 <button
@@ -340,13 +368,13 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
                   onClick={startUploadedAnalysis}
                   aria-label={`Analyse starten für ${uploadedImages.length} Bild${uploadedImages.length !== 1 ? 'er' : ''}`}
                 >
-                  ✓ Analyse starten ({uploadedImages.length})
+                  Analyse starten ({uploadedImages.length})
                 </button>
                 <button
-                  className="new-scan-button"
-                  onClick={() => setStep('upload')}
+                  className="image-preview-cancel"
+                  onClick={handleCancel}
                 >
-                  Zurück
+                  Abbrechen
                 </button>
               </div>
             </div>
@@ -359,11 +387,13 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
           )}
         </div>
 
-        <div className="ocr-modal-actions">
-          <button className="cancel-button" onClick={handleCancel}>
-            Abbrechen
-          </button>
-        </div>
+        {step !== 'image-preview' && (
+          <div className="ocr-modal-actions">
+            <button className="cancel-button" onClick={handleCancel}>
+              Abbrechen
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/OcrScanModal.test.js
+++ b/src/components/OcrScanModal.test.js
@@ -137,6 +137,42 @@ describe('OcrScanModal', () => {
     });
   }, OCR_TIMEOUT);
 
+  test('shows step indicator and status row on the image-preview step', async () => {
+    const { fileToBase64 } = require('../utils/imageUtils');
+    fileToBase64.mockResolvedValue('data:image/png;base64,test');
+
+    render(<OcrScanModal onCancel={mockOnCancel} />);
+
+    expect(screen.getByText('Schritt 1 von 2')).toBeInTheDocument();
+
+    const fileInput = screen.getByLabelText('Bild(er) hochladen');
+    const file = new File(['test'], 'test.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Schritt 2 von 2')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Weitere Seiten hinzufügen oder Analyse starten')).toBeInTheDocument();
+    expect(screen.getByText('JPG · PNG · HEIC — max. 8 Seiten')).toBeInTheDocument();
+  });
+
+  test('caps uploaded pages at 8 and hides the add-page tile once reached', async () => {
+    const { fileToBase64 } = require('../utils/imageUtils');
+    fileToBase64.mockImplementation((f) => Promise.resolve(`data:image/png;base64,${f.name}`));
+
+    render(<OcrScanModal onCancel={mockOnCancel} />);
+
+    const files = Array.from({ length: 9 }, (_, i) => new File(['x'], `p${i}.png`, { type: 'image/png' }));
+    const fileInput = screen.getByLabelText('Bild(er) hochladen');
+    fireEvent.change(fileInput, { target: { files } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Analyse starten \(8\)/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Maximal 8 Seiten möglich/i)).toBeInTheDocument();
+    expect(screen.queryByTitle('Weitere Seiten hinzufügen')).not.toBeInTheDocument();
+  });
+
   test('handles file upload error', async () => {
     const { fileToBase64 } = require('../utils/imageUtils');
 

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -1357,6 +1357,20 @@
   color: #e8e8e8;
 }
 
+[data-theme="dark"] .ocr-step-label {
+  color: #8f867c;
+}
+
+[data-theme="dark"] .ocr-modal-header .close-button {
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #a8a099;
+}
+
+[data-theme="dark"] .ocr-modal-header .close-button:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f1ea;
+}
+
 [data-theme="dark"] .close-button,
 [data-theme="dark"] .cook-date-modal-close,
 [data-theme="dark"] .rating-modal-close,
@@ -2750,19 +2764,61 @@
 }
 
 [data-theme="dark"] .image-preview-item {
-  background: #2a2a2a;
-  border-color: #3d3d3d;
+  background: #221f1c;
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
 [data-theme="dark"] .image-preview-add {
-  background: #2a2a2a;
-  border-color: #555;
-  color: #7a8fdf;
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #8f867c;
+}
+
+[data-theme="dark"] .image-preview-add:hover {
+  border-color: #2f9bf5;
+  color: #5cb3f8;
 }
 
 [data-theme="dark"] .image-preview-number {
-  background: #333;
-  color: #e8e8e8;
+  background: rgba(0, 0, 0, 0.45);
+  color: #cfc7bd;
+}
+
+[data-theme="dark"] .image-preview-remove {
+  background: rgba(15, 14, 13, 0.78);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #e6e0d8;
+}
+
+[data-theme="dark"] .image-preview-remove:hover {
+  background: #d64726;
+  border-color: transparent;
+  color: #fff;
+}
+
+[data-theme="dark"] .ocr-status-row {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+[data-theme="dark"] .ocr-status-title {
+  color: #f0ece5;
+}
+
+[data-theme="dark"] .ocr-status-subtitle {
+  color: #938b82;
+}
+
+[data-theme="dark"] .ocr-file-hint {
+  color: #7d756d;
+}
+
+[data-theme="dark"] .image-preview-cancel {
+  border-color: rgba(255, 255, 255, 0.14);
+  color: #ddd6cd;
+}
+
+[data-theme="dark"] .image-preview-cancel:hover {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 /* ---- RecipeDetail additional ---- */


### PR DESCRIPTION
Adds a "Schritt X von 2" step indicator and a status pill to the
header, restyles the page grid to 3:4 thumbnails with an "S1..."
badge and corner remove button, adds a dashed add-page tile and a
"JPG · PNG · HEIC — max. 8 Seiten" footer hint, and enforces an
8-page cap with HEIC accepted on upload. Restyles the preview step's
footer to match (primary "Analyse starten" + "Abbrechen"), with
matching dark-theme rules.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015EHHVJVZb4fTzGSmhCpbU2