### PR TITLE
fix: return to previous page after starting URL import or photo OCR

### DIFF
--- a/src/components/OcrScanModal.js
+++ b/src/components/OcrScanModal.js
@@ -10,7 +10,7 @@ const UPLOAD_ACCEPT = 'image/jpeg,image/jpg,image/png,image/heic,image/heif,.hei
 
 // initialImage: single image that triggers an immediate background scan (takes precedence over initialImages)
 // initialImages: array of base64 images to pre-fill the image-preview step
-function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId = '', importContext = {} }) {
+function OcrScanModal({ onCancel, onImported, initialImage = '', initialImages = [], userId = '', importContext = {} }) {
   // initialImage queues immediately (no step UI shown); initialImages shows the
   // image-preview step; neither → upload step
   const [step, setStep] = useState(initialImage ? 'queuing' : (initialImages.length > 0 ? 'image-preview' : 'upload'));
@@ -39,7 +39,10 @@ function OcrScanModal({ onCancel, initialImage = '', initialImages = [], userId 
       source: { type: 'photo', images, language },
     });
     stopCamera();
-    onCancel();
+    // Once the job is queued, hand control back to whoever wants to leave
+    // the empty add-recipe form (e.g. return to the page the user came
+    // from) rather than just closing this modal on top of it.
+    (onImported || onCancel)();
   };
 
   // When initialImage is provided, queue the scan automatically on mount

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -1201,6 +1201,23 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
     setOcrImagesBase64([]);
   };
 
+  // Once a URL import or photo scan has actually been queued, leave the
+  // empty "Neues Rezept hinzufügen" form entirely and return to whichever
+  // page the user was on before starting it, instead of leaving them on
+  // the now-pointless blank add-recipe form. These modals only ever open
+  // from that blank form (the buttons that show them are gated on !recipe),
+  // so it's always safe to close the whole form here.
+  const handleOcrImported = () => {
+    setShowOcrModal(false);
+    setOcrImagesBase64([]);
+    onCancel();
+  };
+
+  const handleWebImportImported = () => {
+    setShowWebImportModal(false);
+    onCancel();
+  };
+
   const handleRecipeSelect = (selectedRecipe) => {
     if (typeaheadIngredientIndex !== null) {
       const newIngredients = [...ingredients];
@@ -1822,6 +1839,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
       {showOcrModal && (
         <OcrScanModal
           onCancel={handleOcrCancel}
+          onImported={handleOcrImported}
           initialImages={ocrImagesBase64}
           userId={currentUser?.id}
           importContext={importContext}
@@ -1832,6 +1850,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
         <WebImportModal
           initialUrl={initialWebImportUrl}
           onCancel={() => setShowWebImportModal(false)}
+          onImported={handleWebImportImported}
           authorId={initialWebImportAuthorId}
           userId={currentUser?.id}
           importContext={importContext}

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -4,7 +4,7 @@ import { normalizeImportedUrl } from '../utils/webImportService';
 import { runWebImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
-function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '', importContext = {} }) {
+function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', userId = '', importContext = {} }) {
   const [url, setUrl] = useState(() => normalizeImportedUrl(initialUrl));
   const [error, setError] = useState('');
   const { enqueueImportJob } = useRecipeImportQueue();
@@ -49,7 +49,10 @@ function WebImportModal({ onCancel, initialUrl = '', authorId = '', userId = '',
       source: { type: 'web', url: normalizedUrl, authorId },
     });
 
-    onCancel();
+    // Once the job is queued, hand control back to whoever wants to leave
+    // the empty add-recipe form (e.g. return to the page the user came
+    // from) rather than just closing this modal on top of it.
+    (onImported || onCancel)();
   };
 
   // Handle URL submission from the form


### PR DESCRIPTION
After clicking "Analyse starten"/"Import starten", the app stayed on
the now-empty "Neues Rezept hinzufügen" form instead of returning to
the page the user came from. Both modals now call a distinct
onImported callback once the background job is queued, letting
RecipeForm close the whole add-recipe form via its own onCancel
instead of just hiding the modal on top of it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XU4ADKAqVgF9CY8mj1f5mc