### PR TITLE
Cache für nutritionReferences nach ingredientID-Zuordnung leeren

### DIFF
--- a/src/components/AppCallsPage.js
+++ b/src/components/AppCallsPage.js
@@ -745,6 +745,14 @@ function AppCallsPage({ onBack, currentUser, recipes = [], onUpdateRecipe, onSel
       }
     }
 
+    if (referencesToCreate.length > 0 || ingredientLearningData.size > 0) {
+      try {
+        await reloadNutritionReferences({ throwOnError: true });
+      } catch (err) {
+        console.error('Could not refresh nutritionReferences cache after ingredientID match:', err);
+      }
+    }
+
     await persistIngredientIDs(fieldName, nextIngredients, dialogRecipe);
     setIngredientMatchDialog(null);
     ingredientMatchFromModalRef.current = false;

--- a/src/components/RecipeDetail.js
+++ b/src/components/RecipeDetail.js
@@ -1037,6 +1037,14 @@ function RecipeDetail({ recipe: initialRecipe, onBack, onEdit, onDelete, onPubli
       }
     }
 
+    if (referencesToCreate.length > 0 || ingredientLearningData.size > 0) {
+      try {
+        await reloadNutritionReferences({ throwOnError: true });
+      } catch (err) {
+        console.error('Could not refresh nutritionReferences cache after ingredientID match:', err);
+      }
+    }
+
     await persistIngredientIDs(fieldName, nextIngredients);
     setIngredientMatchDialog(null);
     setOpenIngredientInfoIndex(null);


### PR DESCRIPTION
"Übernehmen & berechnen" im ingredientID-prüfen-Dialog leert und lädt
jetzt den nutritionReferences-Cache neu, sobald dabei neue ingredientIDs
angelegt oder Synonyme/Einheiten gelernt wurden – analog zum Button
"Cache leeren" in Küchenbetrieb -> Fehlende Zutaten-IDs.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bq79rfqvXJLVrbe9EcdadT