### PR TITLE
Unify swipe-delete max offset at 72px

### DIFF
--- a/src/components/MenuForm.js
+++ b/src/components/MenuForm.js
@@ -363,7 +363,7 @@ function SortableRecipeItem({ id, recipe, isFavorite, onRemove, sectionIndex, sw
     isDragging,
   } = useSortable({ id });
 
-  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ maxOffset: 72 });
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -439,7 +439,7 @@ function SortableDrinkItem({ id, displayName, isFavorite, onRemove, swipeDeleteI
     isDragging,
   } = useSortable({ id });
 
-  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete({ maxOffset: 72 });
+  const { offset, isDeleteVisible, reset, handlers } = useSwipeToDelete();
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/hooks/useSwipeToDelete.js
+++ b/src/hooks/useSwipeToDelete.js
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from 'react';
 // drinks, guests, recipe ingredients/steps). See CLAUDE.md: mobile uses this
 // gesture in place of the desktop DeleteRowButton.
 export const SWIPE_DELETE_THRESHOLD = 56;
-export const SWIPE_DELETE_MAX_OFFSET = 96;
+export const SWIPE_DELETE_MAX_OFFSET = 72;
 export const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
 
 /**
@@ -17,7 +17,7 @@ export const SWIPE_DIRECTION_LOCK_THRESHOLD = 6;
  *   Called on every touchmove with the raw gesture delta (or null when the move is ignored), for callers that need
  *   to react to movement beyond the swipe itself (e.g. cancelling a long-press timer).
  * @param {number} [options.maxOffset] - Overrides SWIPE_DELETE_MAX_OFFSET for callers whose row is narrower
- *   or wants a shorter reveal (e.g. MenuForm's recipe/drink rows).
+ *   or wants a shorter reveal.
  */
 export default function useSwipeToDelete({
   disabled = false,


### PR DESCRIPTION
SWIPE_DELETE_MAX_OFFSET was 96px, with MenuForm overriding it to 72px
for its narrower recipe/drink rows. Set the shared default to 72px and
drop the now-redundant override so all swipe-delete rows use the same
reveal distance.