### PR TITLE
Kurzbefehl-Link in Einstellungen und Doku hinterlegen

### DIFF
--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -2,6 +2,14 @@
 
 Diese Anleitung erklärt, wie du Rezepte direkt aus einem Apple Kurzbefehl (Shortcut) in dein RecipeBook importieren kannst.
 
+## Fertigen Kurzbefehl herunterladen
+
+Statt den Kurzbefehl manuell nachzubauen (siehe unten), kannst du auch den fertigen Kurzbefehl laden, der den Rezept-Import per Deeplink startet:
+
+**[Kurzbefehl herunterladen](https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4)**
+
+Der Link ist außerdem in der App unter **Einstellungen → Allgemein → Kurzbefehle** hinterlegt.
+
 ## Authentifizierung
 
 Die `addRecipeViaAPI` Cloud Function verwendet **API Key Authentifizierung** statt Firebase Auth Tokens. Ein API Key ist dauerhaft gültig und muss nur einmal im Kurzbefehl hinterlegt werden.

--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -8,7 +8,7 @@ Statt den Kurzbefehl manuell nachzubauen (siehe unten), kannst du auch den ferti
 
 **[Kurzbefehl herunterladen](https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4)**
 
-Der Link ist außerdem in der App unter **Einstellungen → Allgemein → Kurzbefehle** hinterlegt.
+Der Link ist außerdem im Hamburger-Menü der App unter **Hilfe → Kurzbefehl installieren** hinterlegt und dort für alle Nutzer sichtbar (nicht nur Admins).
 
 ## Authentifizierung
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,6 +7,8 @@ import ImportProgressIndicator from './ImportProgressIndicator';
 import ImportProgressDialog from './ImportProgressDialog';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
 
+const RECIPE_IMPORT_SHORTCUT_URL = 'https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4';
+
 /**
  * Renders text with **bold** markdown syntax as <strong> elements.
  */
@@ -309,9 +311,9 @@ const Header = forwardRef(function Header({
                       </button>
                     </div>
                   )}
-                  {visibleFaqs.length > 0 && (
-                    <div className="menu-section">
-                      <div className="menu-section-title">Hilfe</div>
+                  <div className="menu-section">
+                    <div className="menu-section-title">Hilfe</div>
+                    {visibleFaqs.length > 0 && (
                       <button
                         className="menu-item"
                         onClick={() => {
@@ -322,8 +324,17 @@ const Header = forwardRef(function Header({
                       >
                         Kochschule
                       </button>
-                    </div>
-                  )}
+                    )}
+                    <button
+                      className="menu-item"
+                      onClick={() => {
+                        window.open(RECIPE_IMPORT_SHORTCUT_URL, '_blank', 'noopener,noreferrer');
+                        setMenuOpen(false);
+                      }}
+                    >
+                      Kurzbefehl installieren
+                    </button>
+                  </div>
                   {onSettingsClick && (currentUser?.isAdmin || currentUser?.settingsAccess) && (
                     <div className="menu-section">
                       <div className="menu-section-title">Verwaltung</div>

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1597,21 +1597,6 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
             </div>
 
             <div className="settings-section">
-              <h3>Kurzbefehle</h3>
-              <p className="section-description">
-                Apple Kurzbefehl, der den Rezept-Import per Deeplink startet. Auf einem iPhone, iPad oder Mac öffnen, um ihn zur Kurzbefehle-App hinzuzufügen.
-              </p>
-              <a
-                href="https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="image-upload-label"
-              >
-                Kurzbefehl herunterladen
-              </a>
-            </div>
-
-            <div className="settings-section">
               <h3>Onboarding</h3>
               <p className="section-description">
                 Aktiviert den generischen Onboarding-Testmodus. Onboarding-Overlays werden nur angezeigt, wenn dieser Schalter aktiv ist und die jeweilige Rolle zusätzlich die Berechtigung „Onboarding-Testmodus“ besitzt.

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1597,6 +1597,21 @@ function Settings({ onBack, currentUser, allUsers = [], allRecipes = [], onUpdat
             </div>
 
             <div className="settings-section">
+              <h3>Kurzbefehle</h3>
+              <p className="section-description">
+                Apple Kurzbefehl, der den Rezept-Import per Deeplink startet. Auf einem iPhone, iPad oder Mac öffnen, um ihn zur Kurzbefehle-App hinzuzufügen.
+              </p>
+              <a
+                href="https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="image-upload-label"
+              >
+                Kurzbefehl herunterladen
+              </a>
+            </div>
+
+            <div className="settings-section">
               <h3>Onboarding</h3>
               <p className="section-description">
                 Aktiviert den generischen Onboarding-Testmodus. Onboarding-Overlays werden nur angezeigt, wenn dieser Schalter aktiv ist und die jeweilige Rolle zusätzlich die Berechtigung „Onboarding-Testmodus“ besitzt.


### PR DESCRIPTION
Macht den fertigen Apple-Kurzbefehl (Rezept-Import per Deeplink) unter
Einstellungen > Allgemein zum Download verfügbar, statt nur die
manuelle Bau-Anleitung zu dokumentieren.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rc3GYM7QU85foYUtNwnGXs