### PR TITLE
Make recipe import from Shortcuts async via Firestore trigger

### DIFF
--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -4,18 +4,55 @@ Diese Anleitung erklärt, wie du Rezepte direkt aus einem Apple Kurzbefehl (Shor
 
 ## Fertigen Kurzbefehl herunterladen
 
-Statt den Kurzbefehl manuell nachzubauen (siehe unten), kannst du auch den fertigen Kurzbefehl laden, der den Rezept-Import per Deeplink startet:
+Statt den Kurzbefehl manuell nachzubauen (siehe unten), kannst du auch den fertigen Kurzbefehl laden:
 
 **[Kurzbefehl herunterladen](https://www.icloud.com/shortcuts/47ecb3c5292d473eb92ee5ae2f2a92e4)**
 
 Der Link ist außerdem im Hamburger-Menü der App unter **Hilfe → Kurzbefehl installieren** hinterlegt und dort für alle Nutzer sichtbar (nicht nur Admins) – der Menüpunkt erscheint aber nur auf iPhone, iPad und Mac, da nur dort eine Kurzbefehle-App existiert.
 
+**Hinweis:** Dieser fertige Kurzbefehl startet den Import per **Deeplink** (`https://broubook.web.app/?webimport=<url>`, Aktion „URL öffnen"). Das öffnet dabei jedes Mal die komplette Web-App in Safari (JS-Bundle laden, Firebase-Auth initialisieren) und wartet erst danach auf den eigentlichen Import – das kann sich auf dem iPhone lange und wackelig anfühlen. Für einen deutlich schnelleren und stabileren Import per URL nutze stattdessen den Abschnitt **„Rezept von einer URL importieren"** unten – dafür musst du den heruntergeladenen Kurzbefehl entsprechend abändern (die „URL öffnen"-Aktion durch „Inhalt von URL laden" ersetzen) oder ihn manuell nachbauen.
+
 ## Authentifizierung
 
-Die `addRecipeViaAPI` Cloud Function verwendet **API Key Authentifizierung** statt Firebase Auth Tokens. Ein API Key ist dauerhaft gültig und muss nur einmal im Kurzbefehl hinterlegt werden.
+Alle Shortcut-Endpoints (`importRecipeShortcut`, `addRecipeViaAPI`, `createRecipeImportFromText`) verwenden **API Key Authentifizierung** statt Firebase Auth Tokens. Ein API Key ist dauerhaft gültig und muss nur einmal im Kurzbefehl hinterlegt werden – derselbe Key funktioniert für alle drei Endpoints.
 
 - **`X-Api-Key`** Header: dein persönlicher API Key (als Firebase Secret gespeichert)
 - **`X-User-Id`** Header: deine Firebase User ID
+
+---
+
+## Rezept von einer URL importieren (empfohlen)
+
+Für den Fall „ich habe eine Rezept-URL und will sie importieren" (der Anwendungsfall des bisherigen Deeplink-Kurzbefehls) rufst du direkt die `importRecipeShortcut` Cloud Function auf. Sie legt die URL sofort als Import-Job in Firestore ab und antwortet in unter einer Sekunde – der eigentliche Import (Website laden, JSON-LD/Text/Screenshot + Gemini AI) läuft danach serverseitig im Hintergrund, unabhängig davon, ob der Kurzbefehl/das Handy währenddessen online bleibt. Das fertige Rezept erscheint automatisch in der Review-Queue „Neue Rezepte" der App, sobald du sie das nächste Mal öffnest.
+
+### Aktion: „Inhalt von URL laden"
+
+| Feld | Wert |
+|------|------|
+| URL | `https://us-central1-<PROJECT-ID>.cloudfunctions.net/importRecipeShortcut` |
+| Methode | `POST` |
+
+**Headers:**
+
+| Name | Wert |
+|------|------|
+| `Content-Type` | `application/json` |
+| `X-Api-Key` | `<dein-api-key>` |
+| `X-User-Id` | `<deine-firebase-uid>` |
+
+**Body:**
+
+```json
+{ "url": "<Rezept-URL, z. B. aus „Text abrufen aus Eingabe“>" }
+```
+
+**Antwort (HTTP 200) – Job wurde eingereiht, noch nicht fertig importiert:**
+
+```json
+{ "success": true, "jobId": "abc123xyz", "status": "queued" }
+```
+
+Der Kurzbefehl braucht auf diese Antwort hin nichts weiter zu tun – kein Warten, kein Öffnen der App nötig. Ein `success: true` bedeutet nur „URL wurde entgegengenommen", nicht „Rezept wurde korrekt erkannt"; falls die Erkennung fehlschlägt, taucht der Job mit Fehlermeldung (statt als fertiges Rezept) in der Review-Queue auf und kann dort neu gestartet werden.
 
 ---
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -49,8 +49,18 @@ Authenticates via `SHORTCUT_API_KEY` (same mechanism as `addRecipeViaAPI`).
 **Features:**
 - ✅ Authentication: API Key (`X-Api-Key` header) + User ID (`X-User-Id` header)
 - ✅ CORS enabled for allowed origins
-- ✅ Full import pipeline (HTML fetch → JSON-LD → text → screenshot fallback)
 - ✅ Requires user role `edit`, `admin`, or flag `isShortcutUser: true`
+- ✅ Asynchronous: queues the job and responds in well under a second instead
+  of waiting for the full import pipeline (HTML fetch → JSON-LD → text →
+  screenshot fallback, ~10–20s) — a mobile Shortcut has no business holding
+  an HTTP connection open that long. The queued job (a temp recipe document
+  with `importOrigin: 'shortcut'`) is picked up within seconds by the
+  `processShortcutImportJob` Firestore trigger, which runs the same pipeline
+  server-side and finalizes the result — or, if that instant trigger is ever
+  missed, by the `recoverStuckImportJobs` sweeper (every 10 min) as a
+  fallback. Either way the imported recipe shows up in the app's normal
+  "Neue Rezepte" review queue; there's nothing further to poll from the
+  Shortcut.
 
 **Setup:**
 1. Generate API key: `openssl rand -hex 32`
@@ -71,8 +81,6 @@ X-User-Id: <Firebase User ID>
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `url` | string | ✅ | Public recipe URL to import |
-| `cuisineTypes` | string[] | – | Cuisine types for AI prompt |
-| `mealCategories` | string[] | – | Meal categories for AI prompt |
 
 **Example request body:**
 
@@ -94,22 +102,13 @@ Headers:
 Body:   {"url": "<the recipe URL>"}
 ```
 
-**Success response (200):**
+**Success response (200) — job queued, not yet imported:**
 
 ```json
 {
   "success": true,
-  "recipe": {
-    "title": "Zucchini-Kartoffel-Puffer",
-    "ingredients": ["500 g Zucchini", "300 g Kartoffeln"],
-    "steps": ["Zucchini raspeln ...", "Kartoffeln schälen ..."],
-    "servings": 4,
-    "cookTime": "30 min",
-    "difficulty": 2,
-    "cuisine": "Deutsch",
-    "category": "Hauptgericht",
-    "tags": ["vegetarisch"]
-  }
+  "jobId": "aBcD1234efGh",
+  "status": "queued"
 }
 ```
 
@@ -121,8 +120,13 @@ Body:   {"url": "<the recipe URL>"}
 | 401 | Missing or invalid `X-Api-Key` / `X-User-Id` |
 | 403 | User not found or insufficient permissions |
 | 405 | Wrong HTTP method (only POST allowed) |
-| 500 | Server misconfiguration or unexpected error |
-| 504 | Import timed out (deadline exceeded) |
+| 500 | Server misconfiguration, or the job could not be written to Firestore |
+
+A 200 response only means the import was queued successfully — it does not
+guarantee the recipe was recognized correctly. Check the app's review queue
+for the actual result; a failed job shows up there with `importStatus:
+'error'` (visible/retryable from the "Neue Rezepte" queue) rather than as an
+HTTP error.
 
 ---
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -2720,7 +2720,7 @@ exports.importRecipeShortcut = onRequest(
         }
       }
 
-      const {url, cuisineTypes, mealCategories} = body || {};
+      const {url} = body || {};
       if (!url || typeof url !== 'string') {
         res.status(400).json({
           success: false,
@@ -2746,28 +2746,34 @@ exports.importRecipeShortcut = onRequest(
         return;
       }
 
-      console.log(`importRecipeShortcut: import requested by user ${userId} for URL: ${url}`);
+      console.log(`importRecipeShortcut: import queued by user ${userId} for URL: ${url}`);
 
+      // Queue the job and respond immediately instead of running the whole
+      // import (screenshot/JSON-LD + Gemini, ~10-20s) inline — a Shortcut's
+      // HTTP call over a mobile connection has no business staying open that
+      // long. processShortcutImportJob (a Firestore trigger, see above)
+      // picks this up within seconds and finishes it server-side; the result
+      // shows up in the app's normal import review queue like any other
+      // import. cuisineTypes/mealCategories aren't persisted onto the job —
+      // same tradeoff recoverStuckImportJobs already accepts for redriven
+      // 'web' jobs (see runImportFromWebSource).
       try {
-        const recipe = await runImportFromUrl(url, {
-          apiKey: geminiKey,
-          cuisineTypes,
-          mealCategories,
-          source: 'shortcut',
-          userId,
+        const db = admin.firestore();
+        const jobRef = db.collection('recipes').doc();
+        await jobRef.set({
+          title: 'Rezept-Import',
+          authorId: userId,
+          isTemp: true,
+          importStatus: 'queued',
+          importProgress: 0,
+          importHeartbeatAt: Date.now(),
+          importOrigin: 'shortcut',
+          importSource: {type: 'web', url},
         });
-        res.status(200).json({success: true, recipe});
+        res.status(200).json({success: true, jobId: jobRef.id, status: 'queued'});
       } catch (err) {
-        let statusCode = 500;
-        if (err instanceof HttpsError) {
-          if (err.code === 'deadline-exceeded') {
-            statusCode = 504;
-          } else if (err.code === 'invalid-argument') {
-            statusCode = 400;
-          }
-        }
-        console.error(`importRecipeShortcut: import failed for user ${userId}:`, err);
-        res.status(statusCode).json({success: false, error: err.message});
+        console.error(`importRecipeShortcut: failed to queue import for user ${userId}:`, err);
+        res.status(500).json({success: false, error: 'Import konnte nicht in die Warteschlange gestellt werden.'});
       }
     },
 );
@@ -6963,6 +6969,46 @@ async function runImportFromSource(source, authorId, jobId) {
     }
   }
 }
+
+/**
+ * Firestore trigger: instantly processes background-import jobs that were
+ * queued by importRecipeShortcut (see below) — there is no browser tab
+ * involved for those, so unlike the normal web-import flow (where the
+ * client that just created the job immediately starts processing it itself
+ * via RecipeImportQueueContext) they would otherwise sit untouched until
+ * recoverStuckImportJobs' next sweep, up to STUCK_IMPORT_JOB_MS +
+ * (sweep interval) later. Scoped to importOrigin:'shortcut' specifically so
+ * it never races the client-driven flow for jobs a live tab already owns.
+ */
+exports.processShortcutImportJob = onDocumentCreated(
+    {
+      document: 'recipes/{recipeId}',
+      region: 'us-central1',
+      secrets: [geminiApiKey],
+    },
+    async (event) => {
+      const jobId = event.params.recipeId;
+      const data = event.data ? event.data.data() : null;
+      if (!data || data.importOrigin !== 'shortcut' || data.importStatus !== 'queued') {
+        return;
+      }
+
+      const authorId = data.authorId || 'unknown';
+      await event.data.ref.update({
+        importStatus: 'processing',
+        importHeartbeatAt: Date.now(),
+        importAttempts: 1,
+      });
+
+      try {
+        const result = await runImportFromSource(data.importSource, authorId, jobId);
+        await finalizeImportJob(jobId, authorId, result);
+      } catch (error) {
+        console.error(`processShortcutImportJob: job ${jobId} failed`, error);
+        await failImportJob(jobId, error);
+      }
+    },
+);
 
 /**
  * Threshold above which a queued/processing (or already-failed-but-


### PR DESCRIPTION
## Summary
Refactors the `importRecipeShortcut` endpoint to queue import jobs asynchronously instead of blocking on the full import pipeline. The endpoint now returns immediately (~1s) after creating a temporary recipe document in Firestore, while a new `processShortcutImportJob` Firestore trigger handles the actual import (HTML fetch, JSON-LD extraction, Gemini AI processing) server-side in the background.

## Key Changes

- **`importRecipeShortcut` endpoint** (`functions/index.js`):
  - Removed `cuisineTypes` and `mealCategories` from request body (no longer passed to AI)
  - Changed from synchronous `runImportFromUrl()` call to creating a queued job document in Firestore
  - Returns `{success: true, jobId, status: 'queued'}` instead of the full recipe object
  - Simplified error handling (no more timeout/deadline-exceeded distinction)
  - Response time reduced from ~10–20s to <1s

- **New `processShortcutImportJob` Firestore trigger** (`functions/index.js`):
  - Automatically fires when a recipe document with `importOrigin: 'shortcut'` and `importStatus: 'queued'` is created
  - Runs the full import pipeline (`runImportFromSource` → `finalizeImportJob`) server-side
  - Handles errors via `failImportJob` (result shows in app's review queue with error status)
  - Scoped to `importOrigin: 'shortcut'` to avoid racing the client-driven import flow for web imports

- **Documentation updates** (`APPLE_SHORTCUT_SETUP.md`, `functions/README.md`):
  - Clarified that the endpoint is now asynchronous and queues jobs
  - Removed `cuisineTypes`/`mealCategories` from request body spec
  - Updated response format to show `jobId` and `status: 'queued'`
  - Explained that imported recipes appear in the app's "Neue Rezepte" review queue, not returned directly
  - Added note that Deeplink-based imports are slower; direct API calls are recommended

## Implementation Details

- Job documents are created with `importStatus: 'queued'` and `importOrigin: 'shortcut'`
- The Firestore trigger updates the job to `importStatus: 'processing'` before starting the import
- If the trigger is missed, the existing `recoverStuckImportJobs` sweeper (10-min interval) will pick up and retry the job as a fallback
- No polling or further HTTP calls needed from the Shortcut; the result is automatically available in the app's review queue on next open

https://claude.ai/code/session_01WWFNm7Cx7oWZPNx9VecMTo