### PR TITLE
Move recipe rating aggregation to Cloud Function

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -40,13 +40,10 @@ service cloud.firestore {
       allow get: if isAnyUser() || !resource.data.isPrivate;
       allow list: if isAnyUser() || resource.data.shareId != null;
       allow create, delete: if isEditOrAdmin();
-      allow update: if isEditOrAdmin()
-                 || (
-                      // Allow anyone (authenticated or guest-rated) to update only the
-                      // rating summary fields written by updateRatingSummary().
-                      request.resource.data.diff(resource.data).affectedKeys()
-                        .hasOnly(['ratingAvg', 'ratingCount'])
-                    );
+      // ratingAvg/ratingCount are written exclusively by the aggregateRecipeRating
+      // Cloud Function (Admin SDK bypasses these rules) in response to changes in
+      // the ratings subcollection below; no client write path for these fields.
+      allow update: if isEditOrAdmin();
 
       // Ratings subcollection – anyone (including guests) may read and write their own rating.
       // Guests are identified by a localStorage-generated ID (prefixed 'guest_');

--- a/functions/index.js
+++ b/functions/index.js
@@ -7136,3 +7136,7 @@ exports.calculateEventDrinks = require('./calculateEventDrinks').calculateEventD
 exports.submitConsumption = require('./submitConsumption').submitConsumption;
 exports.reminderConsumption = require('./reminderConsumption').reminderConsumption;
 exports.manageGuestProfile = require('./manageGuestProfile').manageGuestProfile;
+
+// Server-seitige Aggregation von ratingAvg/ratingCount auf recipes/{recipeId}
+// aus der ratings-Subcollection (ersetzt den bisherigen offenen Client-Write).
+exports.aggregateRecipeRating = require('./recipeRatingAggregation').aggregateRecipeRating;

--- a/functions/recipeRatingAggregation.js
+++ b/functions/recipeRatingAggregation.js
@@ -1,0 +1,44 @@
+const {onDocumentWritten} = require('firebase-functions/v2/firestore');
+const admin = require('firebase-admin');
+
+/**
+ * Rundet einen Rating-Durchschnitt auf 1 Nachkommastelle (analog zur bisherigen
+ * Client-Logik in src/utils/recipeRatings.js).
+ * @param {number} sum Summe aller Rating-Werte.
+ * @param {number} count Anzahl der Ratings.
+ * @return {number} Gerundeter Durchschnitt.
+ */
+function computeAvg(sum, count) {
+  return Math.round((sum / count) * 10) / 10;
+}
+
+/**
+ * Firestore-Trigger: aggregiert bei jeder Aenderung (Create/Update/Delete) eines
+ * Rating-Dokuments in recipes/{recipeId}/ratings/{raterKey} die gesamte
+ * Subcollection neu und schreibt ratingAvg/ratingCount auf das Rezept-Dokument.
+ * Ersetzt den bisherigen Client-Write auf diese Felder, der ueber die Firestore
+ * Rules ohne Auth-Check offen war.
+ */
+exports.aggregateRecipeRating = onDocumentWritten(
+    {document: 'recipes/{recipeId}/ratings/{raterKey}'},
+    async (event) => {
+      const {recipeId} = event.params;
+      const db = admin.firestore();
+
+      const snapshot = await db.collection('recipes').doc(recipeId).collection('ratings').get();
+      const recipeRef = db.collection('recipes').doc(recipeId);
+
+      if (snapshot.empty) {
+        await recipeRef.update({ratingAvg: null, ratingCount: 0});
+        return;
+      }
+
+      let sum = 0;
+      snapshot.forEach((doc) => {
+        sum += doc.data().rating;
+      });
+      const count = snapshot.size;
+
+      await recipeRef.update({ratingAvg: computeAvg(sum, count), ratingCount: count});
+    },
+);

--- a/src/utils/recipeRatings.js
+++ b/src/utils/recipeRatings.js
@@ -14,8 +14,7 @@ import {
   collection,
   getDocs,
   onSnapshot,
-  serverTimestamp,
-  updateDoc
+  serverTimestamp
 } from 'firebase/firestore';
 
 /**
@@ -48,32 +47,6 @@ export const getRaterKey = (currentUser) => {
  * @returns {number} Rounded average
  */
 const computeAvg = (sum, count) => Math.round((sum / count) * 10) / 10;
-
-/**
- * Recompute and store the rating summary (avg, count) on the recipe document.
- * Does NOT update the recipe's updatedAt timestamp to avoid polluting update history.
- * @param {string} recipeId - Recipe ID
- * @returns {Promise<void>}
- */
-const updateRatingSummary = async (recipeId) => {
-  const ratingsRef = collection(db, 'recipes', recipeId, 'ratings');
-  const snapshot = await getDocs(ratingsRef);
-
-  const recipeRef = doc(db, 'recipes', recipeId);
-  if (snapshot.empty) {
-    await updateDoc(recipeRef, { ratingAvg: null, ratingCount: 0 });
-    return;
-  }
-
-  let sum = 0;
-  snapshot.forEach((d) => {
-    sum += d.data().rating;
-  });
-  const count = snapshot.size;
-  const avg = computeAvg(sum, count);
-
-  await updateDoc(recipeRef, { ratingAvg: avg, ratingCount: count });
-};
 
 /**
  * Submit or update a rating for a recipe.
@@ -115,8 +88,6 @@ export const rateRecipe = async (recipeId, rating, currentUser, comment = null, 
   }
 
   await setDoc(ratingRef, data, { merge: true });
-
-  await updateRatingSummary(recipeId);
 };
 
 /**
@@ -198,7 +169,7 @@ export const getAllRatings = async (recipeId) => {
 };
 
 /**
- * Delete a specific rating from a recipe and update the summary.
+ * Delete a specific rating from a recipe.
  * @param {string} recipeId - Recipe ID
  * @param {string} ratingId - Rating document ID (raterKey) to delete
  * @returns {Promise<void>}
@@ -209,7 +180,6 @@ export const deleteRating = async (recipeId, ratingId) => {
   }
   const ratingRef = doc(db, 'recipes', recipeId, 'ratings', ratingId);
   await deleteDoc(ratingRef);
-  await updateRatingSummary(recipeId);
 };
 
 /**

--- a/src/utils/recipeRatings.test.js
+++ b/src/utils/recipeRatings.test.js
@@ -21,7 +21,6 @@ const mockSetDoc = jest.fn();
 const mockGetDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockOnSnapshot = jest.fn();
-const mockUpdateDoc = jest.fn();
 const mockCollection = jest.fn();
 const mockDoc = jest.fn();
 const mockServerTimestamp = jest.fn(() => 'mock-timestamp');
@@ -34,7 +33,6 @@ jest.mock('firebase/firestore', () => ({
   getDoc: (...args) => mockGetDoc(...args),
   getDocs: (...args) => mockGetDocs(...args),
   onSnapshot: (...args) => mockOnSnapshot(...args),
-  updateDoc: (...args) => mockUpdateDoc(...args),
   deleteDoc: (...args) => mockDeleteDoc(...args),
   collection: (...args) => mockCollection(...args),
   serverTimestamp: () => mockServerTimestamp()
@@ -157,17 +155,9 @@ describe('rateRecipe', () => {
   beforeEach(() => {
     mockDoc.mockReturnValue('ref');
     mockSetDoc.mockResolvedValue();
-    mockUpdateDoc.mockResolvedValue();
     mockServerTimestamp.mockReturnValue('mock-timestamp');
     // getDoc returns non-existing doc by default (new rating)
     mockGetDoc.mockResolvedValue({ exists: () => false });
-    // getDocs returns an empty snapshot by default (for updateRatingSummary)
-    mockGetDocs.mockResolvedValue({
-      empty: false,
-      size: 1,
-      forEach: (cb) => cb({ data: () => ({ rating: 3 }) })
-    });
-    mockCollection.mockReturnValue('ratings-ref');
   });
 
   it('throws on invalid rating value', async () => {
@@ -222,27 +212,12 @@ describe('rateRecipe', () => {
     const [, data] = mockSetDoc.mock.calls[0];
     expect(data.createdAt).toBeUndefined();
   });
-
-  it('updates the rating summary on the recipe document', async () => {
-    await rateRecipe('recipe1', 4, { id: 'user1', vorname: 'Max' });
-    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
-    const [, updates] = mockUpdateDoc.mock.calls[0];
-    expect(updates.ratingAvg).toBeDefined();
-    expect(updates.ratingCount).toBeDefined();
-  });
 });
 
 describe('deleteRating', () => {
   beforeEach(() => {
     mockDoc.mockReturnValue('ref');
     mockDeleteDoc.mockResolvedValue();
-    mockUpdateDoc.mockResolvedValue();
-    mockGetDocs.mockResolvedValue({
-      empty: false,
-      size: 1,
-      forEach: (cb) => cb({ data: () => ({ rating: 4 }) })
-    });
-    mockCollection.mockReturnValue('ratings-ref');
   });
 
   it('throws when recipeId is missing', async () => {
@@ -257,13 +232,5 @@ describe('deleteRating', () => {
     await deleteRating('recipe1', 'rater1');
     expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
     expect(mockDeleteDoc).toHaveBeenCalledWith('ref');
-  });
-
-  it('updates the rating summary after deletion', async () => {
-    await deleteRating('recipe1', 'rater1');
-    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
-    const [, updates] = mockUpdateDoc.mock.calls[0];
-    expect(updates.ratingAvg).toBeDefined();
-    expect(updates.ratingCount).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
Moves the responsibility for aggregating recipe rating summaries (`ratingAvg`, `ratingCount`) from the client to a Cloud Function, eliminating an open security vulnerability where any authenticated user could directly write these fields.

## Key Changes
- **New Cloud Function** (`functions/recipeRatingAggregation.js`): Implements `aggregateRecipeRating` trigger that automatically recomputes and updates rating summaries whenever a rating document is created, updated, or deleted in the `recipes/{recipeId}/ratings` subcollection
- **Client-side cleanup** (`src/utils/recipeRatings.js`): Removed `updateRatingSummary()` function and its calls from `rateRecipe()` and `deleteRating()` — rating aggregation now happens server-side only
- **Security hardening** (`firestore.rules`): Restricted recipe document updates to `isEditOrAdmin()` only; removed the permissive rule that allowed any authenticated user to update `ratingAvg` and `ratingCount` fields
- **Test updates** (`src/utils/recipeRatings.test.js`): Removed test cases and mocks related to client-side rating summary updates
- **Function exports** (`functions/index.js`): Registered the new Cloud Function

## Implementation Details
- The Cloud Function uses the Admin SDK (which bypasses Firestore rules) to safely update recipe documents in response to rating changes
- Rating average computation logic (`computeAvg`) remains identical to the previous client implementation, ensuring consistent rounding behavior (1 decimal place)
- When all ratings are deleted, the function sets `ratingAvg` to `null` and `ratingCount` to `0`
- No changes to the ratings subcollection rules — guests and authenticated users can still read/write their own ratings

https://claude.ai/code/session_01CAYcsqKBLWStiJZ2N5EKYe