### PR TITLE
Replace X-User-Id with X-User-Email in API authentication

### DIFF
--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -17,7 +17,7 @@ Der Link ist außerdem im Hamburger-Menü der App unter **Hilfe → Kurzbefehl i
 Alle Shortcut-Endpoints (`importRecipeShortcut`, `addRecipeViaAPI`, `createRecipeImportFromText`) verwenden **API Key Authentifizierung** statt Firebase Auth Tokens. Ein API Key ist dauerhaft gültig und muss nur einmal im Kurzbefehl hinterlegt werden – derselbe Key funktioniert für alle drei Endpoints.
 
 - **`X-Api-Key`** Header: dein persönlicher API Key (als Firebase Secret gespeichert)
-- **`X-User-Id`** Header: deine Firebase User ID
+- **`X-User-Email`** Header: deine registrierte E-Mail-Adresse (wird serverseitig per `admin.auth().getUserByEmail` zur Firebase User ID aufgelöst – du musst deine UID nicht mehr nachschlagen)
 
 ---
 
@@ -38,7 +38,7 @@ Für den Fall „ich habe eine Rezept-URL und will sie importieren" (der Anwendu
 |------|------|
 | `Content-Type` | `application/json` |
 | `X-Api-Key` | `<dein-api-key>` |
-| `X-User-Id` | `<deine-firebase-uid>` |
+| `X-User-Email` | `<deine-e-mail-adresse>` |
 
 **Body:**
 
@@ -89,13 +89,9 @@ firebase deploy --only functions:addRecipeViaAPI
 
 ---
 
-## Schritt 3: User ID herausfinden
+## Schritt 3: E-Mail-Adresse verwenden
 
-1. Öffne die [Firebase Console](https://console.firebase.google.com/)
-2. Wähle dein Projekt aus
-3. Navigiere zu **Authentication** → **Benutzer**
-4. Suche deinen Benutzer und klicke darauf
-5. Kopiere die **UID** (z. B. `abc123XYZdef456`)
+Nutze einfach die E-Mail-Adresse, mit der du in RecipeBook registriert bist – eine UID musst du dafür nicht mehr nachschlagen.
 
 ---
 
@@ -116,7 +112,7 @@ Füge im Kurzbefehl eine **„Inhalt von URL laden"** Aktion hinzu und konfiguri
 |------|------|
 | `Content-Type` | `application/json` |
 | `X-Api-Key` | `<dein-api-key>` |
-| `X-User-Id` | `<deine-firebase-uid>` |
+| `X-User-Email` | `<deine-e-mail-adresse>` |
 
 **Body:** JSON (siehe Beispiel unten)
 
@@ -186,8 +182,8 @@ Füge im Kurzbefehl eine **„Inhalt von URL laden"** Aktion hinzu und konfiguri
 | HTTP Status | Bedeutung |
 |-------------|-----------|
 | 400 | Fehlende oder ungültige Felder im Body |
-| 401 | Fehlender oder ungültiger API Key / User ID Header |
-| 403 | User nicht gefunden oder fehlende Berechtigung (Rolle muss `edit` oder `admin` sein) |
+| 401 | Fehlender oder ungültiger API Key / User Email Header |
+| 403 | E-Mail-Adresse unbekannt oder fehlende Berechtigung (Rolle muss `edit` oder `admin` sein) – aus Enumeration-Schutz gibt es hierfür bewusst nur eine generische Fehlermeldung |
 | 405 | Falsche HTTP-Methode (nur POST erlaubt) |
 | 500 | Fehler beim Speichern in Firestore oder fehlendes SHORTCUT_API_KEY Secret |
 
@@ -214,7 +210,7 @@ Für den Kurzbefehl „Rezept exportieren" wird ein technischer **Service-User**
 
 1. Erstelle einen dedizierten Service-User in Firebase Authentication (z. B. `shortcut-service@example.com`)
 2. Setze in der Firestore `users`-Collection auf diesem User-Dokument: `isShortcutUser: true`
-3. Notiere die UID des Service-Users
+3. Notiere die E-Mail-Adresse des Service-Users
 
 ### Kurzbefehl-Aktion: `createRecipeImportFromText`
 
@@ -231,7 +227,7 @@ Füge eine **„Inhalt von URL laden"** Aktion hinzu:
 |------|------|
 | `Content-Type` | `application/json` |
 | `X-Api-Key` | `<dein-api-key>` |
-| `X-User-Id` | `<uid-des-service-users>` |
+| `X-User-Email` | `<e-mail-adresse-des-service-users>` |
 
 **Body:** `{ "rawText": "<Rezepttext>" }`
 
@@ -260,8 +256,8 @@ Nach dem API-Call öffnest du die `importUrl` mit der Aktion „URL öffnen".
 - Prüfe, ob der API Key im Header exakt mit dem gespeicherten Secret übereinstimmt
 - Stelle sicher, dass die Function neu deployt wurde: `firebase deploy --only functions:addRecipeViaAPI`
 
-**„User not found" oder „Insufficient permissions" (403)**
-- Prüfe, ob die User ID korrekt kopiert wurde
+**„Access denied" / „Insufficient permissions" (403)**
+- Prüfe, ob die E-Mail-Adresse korrekt (und exakt wie registriert) eingetragen wurde
 - Stelle sicher, dass der Benutzer in der Firebase Authentication existiert und einen Eintrag in der `users` Firestore-Collection hat
 - Stelle sicher, dass der Benutzer die Rolle `edit` oder `admin` hat, oder `isShortcutUser: true` gesetzt ist
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -9,7 +9,7 @@ The web import flow uses a **hybrid architecture** to avoid browser CORS/auth is
 | Path | Function | Auth |
 |------|----------|------|
 | Web app | `importRecipeCallable` (onCall) | Firebase Auth (httpsCallable) |
-| Apple Shortcut | `importRecipeShortcut` (onRequest) | `X-Api-Key` + `X-User-Id` headers |
+| Apple Shortcut | `importRecipeShortcut` (onRequest) | `X-Api-Key` + `X-User-Email` headers |
 
 Both endpoints share the same internal `runImportFromUrl` pipeline:
 1. **fetch_html** – server-side HTTP GET of the recipe URL
@@ -47,7 +47,7 @@ HTTP endpoint for **Apple Shortcut** deep-link imports.
 Authenticates via `SHORTCUT_API_KEY` (same mechanism as `addRecipeViaAPI`).
 
 **Features:**
-- ✅ Authentication: API Key (`X-Api-Key` header) + User ID (`X-User-Id` header)
+- ✅ Authentication: API Key (`X-Api-Key` header) + User Email (`X-User-Email` header, resolved server-side to a Firebase uid via `admin.auth().getUserByEmail`)
 - ✅ CORS enabled for allowed origins
 - ✅ Requires user role `edit`, `admin`, or flag `isShortcutUser: true`
 - ✅ Asynchronous: queues the job and responds in well under a second instead
@@ -65,7 +65,7 @@ Authenticates via `SHORTCUT_API_KEY` (same mechanism as `addRecipeViaAPI`).
 **Setup:**
 1. Generate API key: `openssl rand -hex 32`
 2. Store as secret: `firebase functions:secrets:set SHORTCUT_API_KEY`
-3. Copy Firebase User ID from Firebase Console (Authentication → select user → UID)
+3. Use the registered email address of the target account – no UID lookup needed
 
 **Request:**
 
@@ -73,7 +73,7 @@ Authenticates via `SHORTCUT_API_KEY` (same mechanism as `addRecipeViaAPI`).
 POST https://<region>-<project-id>.cloudfunctions.net/importRecipeShortcut
 Content-Type: application/json
 X-Api-Key: <SHORTCUT_API_KEY>
-X-User-Id: <Firebase User ID>
+X-User-Email: <registered email address>
 ```
 
 **Body (JSON):**
@@ -96,9 +96,9 @@ X-User-Id: <Firebase User ID>
 Method: POST
 URL:    https://us-central1-broubook.cloudfunctions.net/importRecipeShortcut
 Headers:
-  Content-Type: application/json
-  X-Api-Key:  <your SHORTCUT_API_KEY>
-  X-User-Id:  <your Firebase UID>
+  Content-Type:  application/json
+  X-Api-Key:     <your SHORTCUT_API_KEY>
+  X-User-Email:  <your registered email address>
 Body:   {"url": "<the recipe URL>"}
 ```
 
@@ -117,8 +117,8 @@ Body:   {"url": "<the recipe URL>"}
 | Status | Reason |
 |--------|--------|
 | 400 | Missing or invalid `url` field |
-| 401 | Missing or invalid `X-Api-Key` / `X-User-Id` |
-| 403 | User not found or insufficient permissions |
+| 401 | Missing or invalid `X-Api-Key` / `X-User-Email` |
+| 403 | Unknown email address or insufficient permissions (same generic response for both, to avoid email enumeration) |
 | 405 | Wrong HTTP method (only POST allowed) |
 | 500 | Server misconfiguration, or the job could not be written to Firestore |
 
@@ -135,7 +135,7 @@ HTTP error.
 An HTTP endpoint that lets external tools – such as an **Apple Shortcut** – create recipes directly in Firestore without going through the RecipeBook UI.
 
 **Features:**
-- ✅ Authentication: API Key (`X-Api-Key` header) + User ID (`X-User-Id` header)
+- ✅ Authentication: API Key (`X-Api-Key` header) + User Email (`X-User-Email` header, resolved server-side to a Firebase uid via `admin.auth().getUserByEmail`)
 - ✅ Accepts both German and English field names (compatible with AI/Shortcut output)
 - ✅ Input validation with descriptive error messages
 - ✅ CORS enabled
@@ -147,7 +147,7 @@ An HTTP endpoint that lets external tools – such as an **Apple Shortcut** – 
 **Setup:**
 1. API Key generieren: `openssl rand -hex 32`
 2. Als Secret speichern: `firebase functions:secrets:set SHORTCUT_API_KEY`
-3. User ID aus Firebase Console kopieren (Authentication → Benutzer auswählen → UID kopieren)
+3. Registrierte E-Mail-Adresse des Ziel-Accounts verwenden – keine UID nötig
 
 **Request:**
 
@@ -155,7 +155,7 @@ An HTTP endpoint that lets external tools – such as an **Apple Shortcut** – 
 POST https://<region>-<project-id>.cloudfunctions.net/addRecipeViaAPI
 Content-Type: application/json
 X-Api-Key: <API Key>
-X-User-Id: <Firebase User ID>
+X-User-Email: <registrierte E-Mail-Adresse>
 ```
 
 **Body (JSON) – supported field names:**
@@ -218,8 +218,8 @@ X-User-Id: <Firebase User ID>
 | Status | Reason |
 |--------|--------|
 | 400 | Missing or invalid fields |
-| 401 | Missing or invalid API Key / User ID header |
-| 404 | User not found |
+| 401 | Missing or invalid API Key / User Email header |
+| 403 | Unknown email address or insufficient permissions (same generic response for both, to avoid email enumeration) |
 | 405 | Wrong HTTP method (only POST allowed) |
 | 500 | Firestore write error |
 
@@ -231,11 +231,11 @@ See [APPLE_SHORTCUT_SETUP.md](../APPLE_SHORTCUT_SETUP.md) for a full step-by-ste
 
 1. **Generate an API key** once: `openssl rand -hex 32`
 2. **Store the key** as a Firebase Secret: `firebase functions:secrets:set SHORTCUT_API_KEY`
-3. **Find your User ID** in Firebase Console → Authentication → select your user → copy UID.
+3. **Use your registered email address** – no UID lookup needed.
 4. **Send the recipe** with a "Get Contents of URL" action:
    - Method: `POST`
    - URL: `https://us-central1-<project-id>.cloudfunctions.net/addRecipeViaAPI`
-   - Headers: `X-Api-Key: <your-api-key>`, `X-User-Id: <your-uid>`, `Content-Type: application/json`
+   - Headers: `X-Api-Key: <your-api-key>`, `X-User-Email: <your-email>`, `Content-Type: application/json`
    - Body: JSON with the recipe fields listed above.
 5. **Check the result**: the response contains `recipeId` if successful.
 
@@ -248,7 +248,7 @@ See [APPLE_SHORTCUT_SETUP.md](../APPLE_SHORTCUT_SETUP.md) for a full step-by-ste
 An HTTP endpoint that stores unstructured recipe text temporarily in Firestore and returns a public URL that renders the text as structured HTML. This enables Apple Shortcuts or other tools to hand off raw text to an AI/website-import workflow without having to build JSON arrays manually.
 
 **Features:**
-- ✅ Authentication: API Key (`X-Api-Key` header) + User ID (`X-User-Id` header)
+- ✅ Authentication: API Key (`X-Api-Key` header) + User Email (`X-User-Email` header, resolved server-side to a Firebase uid via `admin.auth().getUserByEmail`)
 - ✅ Role check: only users with role `edit`, `admin`, or flag `isShortcutUser: true` may create imports
 - ✅ Configurable TTL (default 10 minutes)
 - ✅ Returns a capability URL (`importUrl`) that is publicly accessible
@@ -259,7 +259,7 @@ An HTTP endpoint that stores unstructured recipe text temporarily in Firestore a
 POST https://<region>-<project-id>.cloudfunctions.net/createRecipeImportFromText
 Content-Type: application/json
 X-Api-Key: <API Key>
-X-User-Id: <Firebase User ID of the service/shortcut user>
+X-User-Email: <registered email address of the user/service account>
 ```
 
 **Body (JSON):**
@@ -290,9 +290,8 @@ X-User-Id: <Firebase User ID of the service/shortcut user>
 | Status | Reason |
 |--------|--------|
 | 400 | Missing or empty `rawText` |
-| 401 | Missing or invalid API Key / User ID header |
-| 403 | User role insufficient (requires `edit`, `admin`, or `isShortcutUser: true`) |
-| 404 | User not found |
+| 401 | Missing or invalid API Key / User Email header |
+| 403 | Unknown email address or role insufficient (requires `edit`, `admin`, or `isShortcutUser: true`) – same generic response for both, to avoid email enumeration |
 | 405 | Wrong HTTP method (only POST allowed) |
 | 500 | Firestore write error |
 
@@ -302,7 +301,7 @@ To use a technical service account for authentication:
 
 1. Create a dedicated user in Firebase Authentication for the shortcut/service account
 2. In Firestore `users` collection, set `isShortcutUser: true` on that user's document
-3. In the iOS Shortcut, use the service user's UID in `X-User-Id`
+3. In the iOS Shortcut, use the service user's email address in `X-User-Email`
 
 ---
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -109,6 +109,29 @@ function assertPublicUrl(urlString) {
 }
 
 /**
+ * Resolves a Shortcut request's X-User-Email header to a Firebase Auth uid.
+ * Returns null (instead of throwing) for any lookup failure so callers can
+ * respond with the same generic 403 used for other permission failures —
+ * this avoids letting a caller who already holds a valid API key enumerate
+ * which email addresses are registered.
+ * @param {string} email - raw X-User-Email header value
+ * @return {Promise<string|null>}
+ */
+async function resolveShortcutUserId(email) {
+  const normalizedEmail = String(email || '').trim().toLowerCase();
+  if (!normalizedEmail) return null;
+  try {
+    const userRecord = await admin.auth().getUserByEmail(normalizedEmail);
+    return userRecord.uid;
+  } catch (err) {
+    if (err.code !== 'auth/user-not-found') {
+      console.error('resolveShortcutUserId: error looking up user by email:', err);
+    }
+    return null;
+  }
+}
+
+/**
  * Input validation constants
  */
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB in bytes (Gemini API limit)
@@ -2603,8 +2626,8 @@ exports.importRecipeCallable = onCall(
  * POST /importRecipeShortcut
  *
  * Headers:
- *   X-Api-Key:  <SHORTCUT_API_KEY secret>
- *   X-User-Id:  <Firebase User ID>
+ *   X-Api-Key:    <SHORTCUT_API_KEY secret>
+ *   X-User-Email: <registrierte E-Mail-Adresse des Users>
  *   Content-Type: application/json
  *
  * Body (JSON):
@@ -2633,7 +2656,7 @@ exports.importRecipeShortcut = onRequest(
         res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
         res.set(
             'Access-Control-Allow-Headers',
-            'Content-Type, X-Api-Key, X-User-Id',
+            'Content-Type, X-Api-Key, X-User-Email',
         );
         if (req.method === 'OPTIONS') {
           res.status(204).send('');
@@ -2649,15 +2672,15 @@ exports.importRecipeShortcut = onRequest(
         return;
       }
 
-      // Authentication via SHORTCUT_API_KEY + user ID
+      // Authentication via SHORTCUT_API_KEY + user email
       const apiKeyHeader = req.headers['x-api-key'];
-      const userId = req.headers['x-user-id'];
+      const userEmail = req.headers['x-user-email'];
 
-      if (!apiKeyHeader || !userId) {
+      if (!apiKeyHeader || !userEmail) {
         res.status(401).json({
           success: false,
           error: 'Missing authentication headers',
-          requiredHeaders: ['X-Api-Key', 'X-User-Id'],
+          requiredHeaders: ['X-Api-Key', 'X-User-Email'],
         });
         return;
       }
@@ -2687,11 +2710,12 @@ exports.importRecipeShortcut = onRequest(
         return;
       }
 
-      // Validate user role in Firestore
+      // Resolve the email to a Firebase uid, then validate role in Firestore
+      const userId = await resolveShortcutUserId(userEmail);
       const db = admin.firestore();
       try {
-        const userDoc = await db.collection('users').doc(userId).get();
-        if (!userDoc.exists) {
+        const userDoc = userId ? await db.collection('users').doc(userId).get() : null;
+        if (!userId || !userDoc.exists) {
           res.status(403).json({success: false, error: 'Access denied'});
           return;
         }
@@ -4552,8 +4576,8 @@ function validateAndNormaliseRecipeInput(body) {
  * POST /addRecipeViaAPI
  *
  * Headers:
- *   X-Api-Key: <API Key stored as SHORTCUT_API_KEY secret>
- *   X-User-Id: <Firebase User ID>
+ *   X-Api-Key:    <API Key stored as SHORTCUT_API_KEY secret>
+ *   X-User-Email: <registrierte E-Mail-Adresse des Users>
  *   Content-Type: application/json
  *
  * Body (JSON) – supports both German and English field names:
@@ -4583,7 +4607,7 @@ exports.addRecipeViaAPI = onRequest(
       if (origin && ALLOWED_ORIGINS.includes(origin)) {
         res.set('Access-Control-Allow-Origin', origin);
         res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
-        res.set('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-User-Id');
+        res.set('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-User-Email');
         if (req.method === 'OPTIONS') {
           res.status(204).send('');
           return;
@@ -4600,13 +4624,13 @@ exports.addRecipeViaAPI = onRequest(
 
       // --- Authentication via API Key ---
       const apiKey = req.headers['x-api-key'];
-      const userId = req.headers['x-user-id'];
+      const userEmail = req.headers['x-user-email'];
 
-      if (!apiKey || !userId) {
+      if (!apiKey || !userEmail) {
         res.status(401).json({
           success: false,
           error: 'Missing authentication headers',
-          requiredHeaders: ['X-Api-Key', 'X-User-Id'],
+          requiredHeaders: ['X-Api-Key', 'X-User-Email'],
         });
         return;
       }
@@ -4630,11 +4654,12 @@ exports.addRecipeViaAPI = onRequest(
         return;
       }
 
-      // --- Validate user exists in Firestore and has required role ---
+      // --- Resolve email to uid, then validate user exists and has required role ---
+      const userId = await resolveShortcutUserId(userEmail);
       const db = admin.firestore();
       try {
-        const userDoc = await db.collection('users').doc(userId).get();
-        if (!userDoc.exists) {
+        const userDoc = userId ? await db.collection('users').doc(userId).get() : null;
+        if (!userId || !userDoc.exists) {
           res.status(403).json({success: false, error: 'Access denied'});
           return;
         }
@@ -4710,8 +4735,8 @@ const RECIPE_IMPORT_TTL_MS = 10 * 60 * 1000;
  * POST /createRecipeImportFromText
  *
  * Headers:
- *   X-Api-Key: <API Key stored as SHORTCUT_API_KEY secret>
- *   X-User-Id: <Firebase User ID>
+ *   X-Api-Key:    <API Key stored as SHORTCUT_API_KEY secret>
+ *   X-User-Email: <registrierte E-Mail-Adresse des Users/Service-Users>
  *   Content-Type: application/json
  *
  * Body (JSON):
@@ -4722,7 +4747,6 @@ const RECIPE_IMPORT_TTL_MS = 10 * 60 * 1000;
  *   400 { success: false, error: string }
  *   401 { success: false, error: string }
  *   403 { success: false, error: string }
- *   404 { success: false, error: string }
  *   405 { success: false, error: string }
  *   500 { success: false, error: string }
  */
@@ -4733,7 +4757,7 @@ exports.createRecipeImportFromText = onRequest(
       if (origin && ALLOWED_ORIGINS.includes(origin)) {
         res.set('Access-Control-Allow-Origin', origin);
         res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
-        res.set('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-User-Id');
+        res.set('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key, X-User-Email');
         if (req.method === 'OPTIONS') {
           res.status(204).send('');
           return;
@@ -4750,13 +4774,13 @@ exports.createRecipeImportFromText = onRequest(
 
       // --- Authentication via API Key ---
       const apiKey = req.headers['x-api-key'];
-      const userId = req.headers['x-user-id'];
+      const userEmail = req.headers['x-user-email'];
 
-      if (!apiKey || !userId) {
+      if (!apiKey || !userEmail) {
         res.status(401).json({
           success: false,
           error: 'Missing authentication headers',
-          required: ['X-Api-Key', 'X-User-Id'],
+          required: ['X-Api-Key', 'X-User-Email'],
         });
         return;
       }
@@ -4779,13 +4803,14 @@ exports.createRecipeImportFromText = onRequest(
         return;
       }
 
-      // --- Validate user exists and has required role ---
+      // --- Resolve email to uid, then validate user exists and has required role ---
+      const userId = await resolveShortcutUserId(userEmail);
       const db = admin.firestore();
       let userData;
       try {
-        const userDoc = await db.collection('users').doc(userId).get();
-        if (!userDoc.exists) {
-          res.status(404).json({success: false, error: 'User not found'});
+        const userDoc = userId ? await db.collection('users').doc(userId).get() : null;
+        if (!userId || !userDoc.exists) {
+          res.status(403).json({success: false, error: 'Access denied'});
           return;
         }
         userData = userDoc.data();


### PR DESCRIPTION
## Summary
Refactors API authentication across three HTTP endpoints (`importRecipeShortcut`, `addRecipeViaAPI`, `createRecipeImportFromText`) to accept user email addresses instead of Firebase User IDs, with server-side resolution to UIDs via `admin.auth().getUserByEmail()`.

## Key Changes

- **New helper function `resolveShortcutUserId(email)`**: Converts email addresses to Firebase UIDs, returning `null` on lookup failure to prevent email enumeration attacks (same generic 403 response for both unknown emails and insufficient permissions)

- **Updated three API endpoints**:
  - `importRecipeShortcut`
  - `addRecipeViaAPI`
  - `createRecipeImportFromText`
  
  Each now:
  - Accepts `X-User-Email` header instead of `X-User-Id`
  - Calls `resolveShortcutUserId()` to resolve email → uid
  - Returns 403 (not 404) for unknown emails, avoiding enumeration

- **CORS headers updated**: Changed `Access-Control-Allow-Headers` from `X-User-Id` to `X-User-Email` across all three endpoints

- **Documentation updates** (README.md, APPLE_SHORTCUT_SETUP.md):
  - Removed requirement to manually copy Firebase UIDs from Console
  - Simplified setup: users now just provide their registered email address
  - Updated all code examples and error response descriptions
  - Clarified that email enumeration is prevented by generic 403 responses

## Implementation Details

- Email normalization: trimmed and lowercased before lookup
- Error handling: logs unexpected auth errors but silently returns `null` for `user-not-found` to avoid leaking information
- Backward compatibility: none (breaking change to API contract, but documented in setup guides)

https://claude.ai/code/session_01XcSeLTgMrHzw4b9CVZZHQ5