### PR TITLE
Allow moderator role on shortcut import endpoints

### DIFF
--- a/APPLE_SHORTCUT_SETUP.md
+++ b/APPLE_SHORTCUT_SETUP.md
@@ -183,7 +183,7 @@ Füge im Kurzbefehl eine **„Inhalt von URL laden"** Aktion hinzu und konfiguri
 |-------------|-----------|
 | 400 | Fehlende oder ungültige Felder im Body |
 | 401 | Fehlender oder ungültiger API Key / User Email Header |
-| 403 | E-Mail-Adresse unbekannt oder fehlende Berechtigung (Rolle muss `edit` oder `admin` sein) – aus Enumeration-Schutz gibt es hierfür bewusst nur eine generische Fehlermeldung |
+| 403 | E-Mail-Adresse unbekannt oder fehlende Berechtigung (Rolle muss `edit`, `admin` oder `moderator` sein) – aus Enumeration-Schutz gibt es hierfür bewusst nur eine generische Fehlermeldung |
 | 405 | Falsche HTTP-Methode (nur POST erlaubt) |
 | 500 | Fehler beim Speichern in Firestore oder fehlendes SHORTCUT_API_KEY Secret |
 
@@ -259,7 +259,7 @@ Nach dem API-Call öffnest du die `importUrl` mit der Aktion „URL öffnen".
 **„Access denied" / „Insufficient permissions" (403)**
 - Prüfe, ob die E-Mail-Adresse korrekt (und exakt wie registriert) eingetragen wurde
 - Stelle sicher, dass der Benutzer in der Firebase Authentication existiert und einen Eintrag in der `users` Firestore-Collection hat
-- Stelle sicher, dass der Benutzer die Rolle `edit` oder `admin` hat, oder `isShortcutUser: true` gesetzt ist
+- Stelle sicher, dass der Benutzer die Rolle `edit`, `admin` oder `moderator` hat, oder `isShortcutUser: true` gesetzt ist
 
 **„Method not allowed" (405)**
 - Stelle sicher, dass die HTTP-Methode auf `POST` gesetzt ist

--- a/functions/README.md
+++ b/functions/README.md
@@ -49,7 +49,7 @@ Authenticates via `SHORTCUT_API_KEY` (same mechanism as `addRecipeViaAPI`).
 **Features:**
 - ✅ Authentication: API Key (`X-Api-Key` header) + User Email (`X-User-Email` header, resolved server-side to a Firebase uid via `admin.auth().getUserByEmail`)
 - ✅ CORS enabled for allowed origins
-- ✅ Requires user role `edit`, `admin`, or flag `isShortcutUser: true`
+- ✅ Requires user role `edit`, `admin`, `moderator`, or flag `isShortcutUser: true`
 - ✅ Asynchronous: queues the job and responds in well under a second instead
   of waiting for the full import pipeline (HTML fetch → JSON-LD → text →
   screenshot fallback, ~10–20s) — a mobile Shortcut has no business holding
@@ -249,7 +249,7 @@ An HTTP endpoint that stores unstructured recipe text temporarily in Firestore a
 
 **Features:**
 - ✅ Authentication: API Key (`X-Api-Key` header) + User Email (`X-User-Email` header, resolved server-side to a Firebase uid via `admin.auth().getUserByEmail`)
-- ✅ Role check: only users with role `edit`, `admin`, or flag `isShortcutUser: true` may create imports
+- ✅ Role check: only users with role `edit`, `admin`, `moderator`, or flag `isShortcutUser: true` may create imports
 - ✅ Configurable TTL (default 10 minutes)
 - ✅ Returns a capability URL (`importUrl`) that is publicly accessible
 
@@ -291,7 +291,7 @@ X-User-Email: <registered email address of the user/service account>
 |--------|--------|
 | 400 | Missing or empty `rawText` |
 | 401 | Missing or invalid API Key / User Email header |
-| 403 | Unknown email address or role insufficient (requires `edit`, `admin`, or `isShortcutUser: true`) – same generic response for both, to avoid email enumeration |
+| 403 | Unknown email address or role insufficient (requires `edit`, `admin`, `moderator`, or `isShortcutUser: true`) – same generic response for both, to avoid email enumeration |
 | 405 | Wrong HTTP method (only POST allowed) |
 | 500 | Firestore write error |
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -2722,7 +2722,7 @@ exports.importRecipeShortcut = onRequest(
         const userData = userDoc.data();
         const role = userData?.role;
         const isShortcutUser = userData?.isShortcutUser === true;
-        if (role !== 'edit' && role !== 'admin' && !isShortcutUser) {
+        if (role !== 'edit' && role !== 'admin' && role !== 'moderator' && !isShortcutUser) {
           res.status(403).json({success: false, error: 'Insufficient permissions'});
           return;
         }
@@ -4664,7 +4664,7 @@ exports.addRecipeViaAPI = onRequest(
           return;
         }
         const role = userDoc.data()?.role;
-        if (role !== 'edit' && role !== 'admin') {
+        if (role !== 'edit' && role !== 'admin' && role !== 'moderator') {
           res.status(403).json({success: false, error: 'Insufficient permissions'});
           return;
         }
@@ -4822,7 +4822,7 @@ exports.createRecipeImportFromText = onRequest(
 
       const userRole = userData.role || '';
       const isShortcutUser = userData.isShortcutUser === true;
-      if (userRole !== 'edit' && userRole !== 'admin' && !userData.isAdmin && !isShortcutUser) {
+      if (userRole !== 'edit' && userRole !== 'admin' && userRole !== 'moderator' && !userData.isAdmin && !isShortcutUser) {
         res.status(403).json({
           success: false,
           error: 'Insufficient permissions.',


### PR DESCRIPTION
## Summary
Follow-up to #3084 (already merged). The three shortcut `onRequest` endpoints (`importRecipeShortcut`, `addRecipeViaAPI`, `createRecipeImportFromText`) only allowed roles `edit`/`admin` (plus the `isShortcutUser` flag), so a user with role `moderator` got `403 Insufficient permissions` when testing the Apple Shortcut integration.

`moderator` is already treated as a privileged role elsewhere in the codebase (e.g. the nutrition recalc callable), so this adds it here too for consistency.

## Changes
- `functions/index.js`: added `role !== 'moderator'` as an allowed bypass alongside `edit`/`admin` in all three shortcut endpoints' permission checks
- `functions/README.md`, `APPLE_SHORTCUT_SETUP.md`: updated role requirement docs and error-code tables to mention `moderator`

## Test plan
- [x] `node -c functions/index.js` (syntax check)
- [ ] Manual: Apple Shortcut request from a `moderator`-role account now returns `{"success": true, "jobId": ..., "status": "queued"}` instead of `Insufficient permissions`

https://claude.ai/code/session_01XcSeLTgMrHzw4b9CVZZHQ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcSeLTgMrHzw4b9CVZZHQ5)_