### PR TITLE
Speichere die Quell-URL beim Web-Import am Rezept

### DIFF
--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -404,6 +404,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
   const [schwierigkeit, setSchwierigkeit] = useState(0);
   const [kochdauer, setKochdauer] = useState('');
   const [speisekategorie, setSpeisekategorie] = useState([]);
+  const [sourceUrl, setSourceUrl] = useState('');
   const [ingredients, setIngredients] = useState([{ type: 'ingredient', text: '' }]);
   const [steps, setSteps] = useState([{ type: 'step', text: '' }]);
   const [imageError, setImageError] = useState(false); // eslint-disable-line no-unused-vars
@@ -590,6 +591,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
       setIngredients(recipe.ingredients?.length > 0 ? normalizeIngredients(recipe.ingredients) : [{ type: 'ingredient', text: '' }]);
       setSteps(recipe.steps?.length > 0 ? normalizeSteps(recipe.steps) : [{ type: 'step', text: '' }]);
       setIsPrivate(recipe.isPrivate || false);
+      setSourceUrl(recipe.sourceUrl || '');
       
       // If creating a version, set current user as author and track parent
       if (isCreatingVersion) {
@@ -604,6 +606,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
       setAuthorId(currentUser?.id || '');
       setParentRecipeId('');
       setIsPrivate(false);
+      setSourceUrl('');
       if (!initialWebImportUrl) {
         setSelectedPrivateListId('');
       }
@@ -1088,6 +1091,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
         isPrivate: isPrivate,
         createdAt: isCreatingVersion ? new Date().toISOString() : recipe?.createdAt,
         versionCreatedFrom: isCreatingVersion ? recipe?.title : null,
+        ...(sourceUrl ? { sourceUrl } : {}),
         ...(((!recipe && !isCreatingVersion) || recipe?.isTemp) && selectedPrivateListId ? { selectedGroupId: selectedPrivateListId } : {}),
       };
 

--- a/src/utils/importRunners.js
+++ b/src/utils/importRunners.js
@@ -41,7 +41,7 @@ export async function runWebImport(normalizedUrl, authorId, onProgress, jobMeta)
     result = await importRecipeFromUrl(normalizedUrl, onProgress, jobMeta);
   }
 
-  return buildRecipeFromAiResult(result, authorId);
+  return buildRecipeFromAiResult(result, authorId, normalizedUrl);
 }
 
 function mergeUniversalAiResults(results) {
@@ -221,7 +221,7 @@ export async function runUniversalImport({ images, text, url }, onProgress, jobM
   }
 
   const merged = mergeUniversalAiResults(results);
-  return buildRecipeFromAiResult(merged);
+  return buildRecipeFromAiResult(merged, '', url.trim());
 }
 
 // Runs AI OCR on a batch of images and returns the merged recipe. Passed as

--- a/src/utils/ocrParser.js
+++ b/src/utils/ocrParser.js
@@ -129,9 +129,10 @@ export function extractKulinarikFromTags(tags) {
  * into the recipe object shape expected by RecipeForm's handleImport().
  * @param {Object} aiResult - Raw AI result (title, ingredients, steps, servings, ...)
  * @param {string} [authorId] - Optional author id to attach to the recipe
+ * @param {string} [sourceUrl] - Optional URL the recipe was imported from
  * @returns {Object} - Recipe object ready for onImport()
  */
-export function buildRecipeFromAiResult(aiResult, authorId = '') {
+export function buildRecipeFromAiResult(aiResult, authorId = '', sourceUrl = '') {
   const parseTime = (timeStr) => {
     if (!timeStr) return 0;
     const numMatch = String(timeStr).match(/\d+/);
@@ -153,6 +154,7 @@ export function buildRecipeFromAiResult(aiResult, authorId = '') {
     schwierigkeit: aiResult.difficulty || 3,
     speisekategorie: aiResult.category || '',
     ...(authorId ? { authorId } : {}),
+    ...(sourceUrl ? { sourceUrl } : {}),
   };
 }
 


### PR DESCRIPTION
Web- und Universal-Import (URL-Zweig) hängen die importierte URL jetzt als
sourceUrl an das erzeugte Rezept an. Der Wert überlebt die Review-/
Bearbeitungs-Runde im RecipeForm (wird geladen und beim Speichern
mitgeschrieben), sodass er auch am fertigen Rezept-Dokument in Firestore
landet.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J3Yx2qGfdhxqqQYiUnkmfq