### PR TITLE
Webimport-PIN: optionaler PIN-Schutz für Webimporte

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -161,6 +161,14 @@ service cloud.firestore {
       allow delete: if isAdmin();
     }
 
+    // Webimport-PIN (gehashter PIN + Lockout-Zähler). Ausschließlich über die
+    // Cloud Functions setWebImportPin/verifyWebImportPin lesbar/schreibbar
+    // (Admin SDK umgeht diese Regeln) – kein Client-Zugriff, auch nicht durch
+    // den Owner, damit der Hash niemals an den Client geht.
+    match /users/{userId}/security/webImportPin {
+      allow read, write: if false;
+    }
+
     // User favorites subcollection
     match /users/{userId}/favorites/{favoriteId} {
       allow read, write: if isAuthenticated() && request.auth.uid == userId;

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,6 +13,7 @@ const nodemailer = require('nodemailer');
 const crypto = require('crypto');
 const sharp = require('sharp');
 const {createNutritionNormalizationUtils} = require('./nutritionNormalization');
+const {requireWebImportUnlocked} = require('./webImportPin');
 
 // Initialize Firebase Admin
 admin.initializeApp();
@@ -1710,6 +1711,8 @@ exports.scrapeInstagramReel = onCall(
         throw new HttpsError('invalid-argument', 'Language must be "de" or "en"');
       }
 
+      await requireWebImportUnlocked(userId);
+
       // Rate limiting (shared with image scanning)
       const rateLimitResult = await checkRateLimit(userId, isAuthenticated, isAdmin, isModerator);
       if (!rateLimitResult.allowed) {
@@ -1890,6 +1893,8 @@ exports.captureWebsiteScreenshot = onCall(
         throw new HttpsError('invalid-argument', 'URL must be a non-empty string');
       }
       assertPublicUrl(url);
+
+      await requireWebImportUnlocked(userId);
 
       // Rate limiting
       const rateLimitResult = await checkRateLimit(userId, isAuthenticated, isAdmin, isModerator);
@@ -2577,6 +2582,8 @@ exports.importRecipeCallable = onCall(
         throw new HttpsError('invalid-argument', 'URL must be a non-empty string');
       }
       assertPublicUrl(url);
+
+      await requireWebImportUnlocked(userId);
 
       const rateLimitResult = await checkRateLimit(userId, isAuthenticated, isAdmin, isModerator);
       if (!rateLimitResult.allowed) {
@@ -7161,6 +7168,12 @@ exports.calculateEventDrinks = require('./calculateEventDrinks').calculateEventD
 exports.submitConsumption = require('./submitConsumption').submitConsumption;
 exports.reminderConsumption = require('./reminderConsumption').reminderConsumption;
 exports.manageGuestProfile = require('./manageGuestProfile').manageGuestProfile;
+
+// Webimport-PIN: pro Nutzer optionaler PIN-Schutz für die Webimport-Funktionen
+// (importRecipeCallable/scrapeInstagramReel/captureWebsiteScreenshot unten
+// rufen requireWebImportUnlocked() auf, bevor sie loslegen).
+exports.setWebImportPin = require('./webImportPin').setWebImportPin;
+exports.verifyWebImportPin = require('./webImportPin').verifyWebImportPin;
 
 // Server-seitige Aggregation von ratingAvg/ratingCount auf recipes/{recipeId}
 // aus der ratings-Subcollection (ersetzt den bisherigen offenen Client-Write).

--- a/functions/webImportPin.js
+++ b/functions/webImportPin.js
@@ -1,0 +1,176 @@
+const {onCall, HttpsError} = require('firebase-functions/v2/https');
+const admin = require('firebase-admin');
+const crypto = require('crypto');
+
+const PIN_MIN_LENGTH = 4;
+const PIN_MAX_LENGTH = 8;
+const MAX_FAILED_ATTEMPTS = 5;
+const LOCKOUT_MINUTES = 15;
+const UNLOCK_MINUTES = 30;
+const SCRYPT_KEYLEN = 64;
+
+/**
+ * @param {string} pin Der PIN im Klartext.
+ * @param {string} salt Hex-kodierter Salt.
+ * @return {string} Hex-kodierter scrypt-Hash von PIN + Salt.
+ */
+function hashPin(pin, salt) {
+  return crypto.scryptSync(pin, salt, SCRYPT_KEYLEN).toString('hex');
+}
+
+/**
+ * @param {admin.firestore.Firestore} db Firestore-Instanz.
+ * @param {string} uid Firebase-Nutzer-ID.
+ * @return {admin.firestore.DocumentReference} Referenz auf das gesperrte PIN-Dokument.
+ */
+function getSecurityDocRef(db, uid) {
+  return db.collection('users').doc(uid).collection('security').doc('webImportPin');
+}
+
+/**
+ * Cloud Function: setWebImportPin
+ * Sets, changes, or (pin === null/'') clears the caller's own Webimport-PIN.
+ * The PIN is never stored in plaintext – only a salted scrypt hash lands in
+ * users/{uid}/security/webImportPin, a subcollection with no client read/write
+ * access (see firestore.rules). A non-sensitive `webImportPinEnabled` flag is
+ * mirrored onto the user's own document so the UI can show PIN status without
+ * needing to read the locked-down security doc.
+ */
+exports.setWebImportPin = onCall({maxInstances: 10}, async (request) => {
+  const auth = request.auth;
+  if (!auth) {
+    throw new HttpsError('unauthenticated', 'Login erforderlich.');
+  }
+
+  const uid = auth.uid;
+  const {pin} = request.data || {};
+  const db = admin.firestore();
+  const docRef = getSecurityDocRef(db, uid);
+  const userRef = db.collection('users').doc(uid);
+
+  if (pin === null || pin === undefined || pin === '') {
+    await docRef.delete();
+    await userRef.set({webImportPinEnabled: false}, {merge: true});
+    return {success: true, enabled: false};
+  }
+
+  if (
+    typeof pin !== 'string' ||
+    !/^\d+$/.test(pin) ||
+    pin.length < PIN_MIN_LENGTH ||
+    pin.length > PIN_MAX_LENGTH
+  ) {
+    throw new HttpsError(
+        'invalid-argument',
+        `PIN muss aus ${PIN_MIN_LENGTH} bis ${PIN_MAX_LENGTH} Ziffern bestehen.`,
+    );
+  }
+
+  const salt = crypto.randomBytes(16).toString('hex');
+  const hash = hashPin(pin, salt);
+
+  await docRef.set({
+    hash,
+    salt,
+    failedAttempts: 0,
+    lockedUntil: null,
+    unlockedUntil: null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  await userRef.set({webImportPinEnabled: true}, {merge: true});
+
+  return {success: true, enabled: true};
+});
+
+/**
+ * Cloud Function: verifyWebImportPin
+ * Verifies the caller's PIN against the stored hash. On success, opens a
+ * time-limited "unlock window" (UNLOCK_MINUTES) recorded server-side on the
+ * security doc; requireWebImportUnlocked() below checks that window before
+ * letting an import Cloud Function run, so the client never needs to resend
+ * the PIN with every single import call. Failed attempts are counted and
+ * lock the PIN out for LOCKOUT_MINUTES after MAX_FAILED_ATTEMPTS in a row.
+ */
+exports.verifyWebImportPin = onCall({maxInstances: 20}, async (request) => {
+  const auth = request.auth;
+  if (!auth) {
+    throw new HttpsError('unauthenticated', 'Login erforderlich.');
+  }
+
+  const {pin} = request.data || {};
+  if (typeof pin !== 'string' || !pin) {
+    throw new HttpsError('invalid-argument', 'PIN ist erforderlich.');
+  }
+
+  const uid = auth.uid;
+  const db = admin.firestore();
+  const docRef = getSecurityDocRef(db, uid);
+  const snap = await docRef.get();
+
+  if (!snap.exists) {
+    // No PIN configured for this user – nothing to verify against.
+    return {ok: true};
+  }
+
+  const data = snap.data();
+  const now = Date.now();
+
+  if (data.lockedUntil && data.lockedUntil.toMillis && data.lockedUntil.toMillis() > now) {
+    const minutesLeft = Math.ceil((data.lockedUntil.toMillis() - now) / 60000);
+    throw new HttpsError(
+        'resource-exhausted',
+        `Zu viele Fehlversuche. Bitte in ${minutesLeft} Minute${minutesLeft === 1 ? '' : 'n'} erneut versuchen.`,
+    );
+  }
+
+  const candidateHash = hashPin(pin, data.salt);
+  const expected = Buffer.from(data.hash, 'hex');
+  const candidate = Buffer.from(candidateHash, 'hex');
+  const matches = expected.length === candidate.length &&
+    crypto.timingSafeEqual(expected, candidate);
+
+  if (!matches) {
+    const failedAttempts = (data.failedAttempts || 0) + 1;
+    const update = {failedAttempts};
+    if (failedAttempts >= MAX_FAILED_ATTEMPTS) {
+      update.lockedUntil = admin.firestore.Timestamp.fromMillis(now + LOCKOUT_MINUTES * 60000);
+      update.failedAttempts = 0;
+    }
+    await docRef.set(update, {merge: true});
+    throw new HttpsError('permission-denied', 'Falscher PIN.');
+  }
+
+  const unlockedUntil = admin.firestore.Timestamp.fromMillis(now + UNLOCK_MINUTES * 60000);
+  await docRef.set({failedAttempts: 0, lockedUntil: null, unlockedUntil}, {merge: true});
+
+  return {ok: true, unlockedUntilMs: unlockedUntil.toMillis()};
+});
+
+/**
+ * Called by the actual web-import Cloud Functions (importRecipeCallable,
+ * scrapeInstagramReel, captureWebsiteScreenshot) before doing any work.
+ * A no-op when the user never configured a PIN, so the feature stays
+ * usable without one; once a PIN is set, it requires a recent successful
+ * verifyWebImportPin call (see UNLOCK_MINUTES above).
+ * @param {string} uid Firebase-Nutzer-ID des Aufrufers.
+ * @return {Promise<void>}
+ */
+async function requireWebImportUnlocked(uid) {
+  const db = admin.firestore();
+  const snap = await getSecurityDocRef(db, uid).get();
+  if (!snap.exists) return;
+
+  const data = snap.data();
+  const now = Date.now();
+  const unlockedUntilMs = data.unlockedUntil && data.unlockedUntil.toMillis ?
+    data.unlockedUntil.toMillis() : 0;
+
+  if (unlockedUntilMs <= now) {
+    throw new HttpsError(
+        'permission-denied',
+        'Webimport-PIN erforderlich. Bitte gib deinen PIN ein, bevor du importierst.',
+    );
+  }
+}
+
+exports.requireWebImportUnlocked = requireWebImportUnlocked;

--- a/src/App.js
+++ b/src/App.js
@@ -2412,6 +2412,7 @@ function App() {
               onCancel={handleUniversalImportCancel}
               userId={currentUser?.id}
               importContext={resolveImportGroupContext({ activeGroupId, groups, publicGroupId })}
+              webImportPinEnabled={currentUser?.webImportPinEnabled || false}
             />
           </Suspense>
         )}

--- a/src/components/PersonalDataPage.css
+++ b/src/components/PersonalDataPage.css
@@ -184,6 +184,10 @@
   background: none;
 }
 
+.settings-row--static {
+  cursor: default;
+}
+
 .settings-row-label {
   font-size: 1rem;
   color: #1a1a1a;

--- a/src/components/PersonalDataPage.js
+++ b/src/components/PersonalDataPage.js
@@ -4,6 +4,12 @@ import { updateUserProfile, changePassword, saveFcmToken } from '../utils/userMa
 import { ALARM_SOUNDS, getAlarmSoundPreference, saveAlarmSoundPreference, getDarkModeMode, saveDarkModePreference, applyDarkModePreference } from '../utils/customLists';
 import { previewAlarmSound } from '../utils/alarmAudioUtils';
 import { requestNotificationPermission } from '../utils/pushNotifications';
+import { setWebImportPin, clearWebImportPin } from '../utils/webImportPin';
+import DeleteRowButton from './DeleteRowButton';
+import UndoSnackbar from './UndoSnackbar';
+import useUndoableDelete from '../hooks/useUndoableDelete';
+
+const PIN_PATTERN = /^\d{4,8}$/;
 
 const NO_LIST_OPTION = { id: '', name: '– Keine Vorauswahl –' };
 
@@ -40,6 +46,15 @@ function PersonalDataPage({ currentUser, onBack, onProfileUpdated, privateLists 
   const [notificationPermission, setNotificationPermission] = useState('default');
   const [notificationSupported, setNotificationSupported] = useState(false);
   const [requestingNotification, setRequestingNotification] = useState(false);
+
+  const [webImportPinEnabled, setWebImportPinEnabledState] = useState(Boolean(currentUser?.webImportPinEnabled));
+  const [pinRemovedLocally, setPinRemovedLocally] = useState(false);
+  const [newPin, setNewPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [savingPin, setSavingPin] = useState(false);
+  const [pinMessage, setPinMessage] = useState(null);
+  const { banners: pinBanners, scheduleDelete: schedulePinDelete, undoDelete: undoPinDelete } = useUndoableDelete();
+  const pinActive = webImportPinEnabled && !pinRemovedLocally;
 
   useEffect(() => {
     if (typeof Notification === 'undefined') {
@@ -159,6 +174,54 @@ function PersonalDataPage({ currentUser, onBack, onProfileUpdated, privateLists 
       setNewPassword('');
       setConfirmPassword('');
     }
+  };
+
+  const handleSetPin = async (e) => {
+    e.preventDefault();
+    setPinMessage(null);
+
+    if (!PIN_PATTERN.test(newPin)) {
+      setPinMessage({ success: false, text: 'PIN muss aus 4 bis 8 Ziffern bestehen.' });
+      return;
+    }
+    if (newPin !== confirmPin) {
+      setPinMessage({ success: false, text: 'Die PINs stimmen nicht überein.' });
+      return;
+    }
+
+    setSavingPin(true);
+    try {
+      await setWebImportPin(newPin);
+      setWebImportPinEnabledState(true);
+      setPinRemovedLocally(false);
+      setNewPin('');
+      setConfirmPin('');
+      setPinMessage({ success: true, text: 'Webimport-PIN gespeichert.' });
+      if (onProfileUpdated) onProfileUpdated({ ...currentUser, webImportPinEnabled: true });
+    } catch (err) {
+      setPinMessage({ success: false, text: err.message });
+    } finally {
+      setSavingPin(false);
+    }
+  };
+
+  const handleRemovePin = () => {
+    setPinRemovedLocally(true);
+    schedulePinDelete({
+      key: 'webImportPin',
+      message: '„Webimport-PIN" entfernt',
+      onConfirm: async () => {
+        try {
+          await clearWebImportPin();
+          setWebImportPinEnabledState(false);
+          if (onProfileUpdated) onProfileUpdated({ ...currentUser, webImportPinEnabled: false });
+        } catch (err) {
+          setPinRemovedLocally(false);
+          setPinMessage({ success: false, text: err.message });
+        }
+      },
+      onUndo: () => setPinRemovedLocally(false),
+    });
   };
 
   return (
@@ -538,7 +601,69 @@ function PersonalDataPage({ currentUser, onBack, onProfileUpdated, privateLists 
           </div>
         </form>
       </section>
+
+      <div className="personal-data-section-divider" />
+
+      <section className="personal-data-webimport-pin-section">
+        <h3 className="personal-data-section-title">Webimport-PIN</h3>
+        <p className="personal-data-password-hint">
+          Schützt den Webimport zusätzlich mit einer PIN, die nur du kennst – so kann niemand mit deinem Zugang ungefragt Rezepte importieren.
+        </p>
+
+        {pinActive ? (
+          <div className="preferences-group">
+            <div className="settings-row settings-row--static delete-row-hover-target">
+              <span className="settings-row-label">PIN aktiv</span>
+              <span className="settings-row-right">
+                <DeleteRowButton itemName="Webimport-PIN" onClick={handleRemovePin} />
+              </span>
+            </div>
+          </div>
+        ) : (
+          <p className="personal-data-password-hint">Kein PIN gesetzt.</p>
+        )}
+
+        <form className="personal-data-form" onSubmit={handleSetPin}>
+          <div className="personal-data-field">
+            <label htmlFor="newPin">{pinActive ? 'Neuer PIN (4–8 Ziffern)' : 'PIN (4–8 Ziffern)'}</label>
+            <input
+              id="newPin"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              value={newPin}
+              onChange={(e) => setNewPin(e.target.value)}
+              required
+            />
+          </div>
+          <div className="personal-data-field">
+            <label htmlFor="confirmPin">PIN bestätigen</label>
+            <input
+              id="confirmPin"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              value={confirmPin}
+              onChange={(e) => setConfirmPin(e.target.value)}
+              required
+            />
+          </div>
+          {pinMessage && (
+            <div className={`personal-data-message ${pinMessage.success ? 'success' : 'error'}`}>
+              {pinMessage.text}
+            </div>
+          )}
+          <div className="personal-data-actions">
+            <button type="submit" className="personal-data-save-btn" disabled={savingPin}>
+              {savingPin ? 'Wird gespeichert…' : pinActive ? 'PIN ändern' : 'PIN setzen'}
+            </button>
+          </div>
+        </form>
+      </section>
       </div>
+      {pinBanners.length > 0 && (
+        <UndoSnackbar itemName="Webimport-PIN" onUndo={() => undoPinDelete(pinBanners[0].id)} />
+      )}
     </div>
   );
 }

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -1858,6 +1858,7 @@ function RecipeForm({ recipe, onSave, onBulkImport, onCancel, currentUser, isCre
           authorId={initialWebImportAuthorId}
           userId={currentUser?.id}
           importContext={importContext}
+          webImportPinEnabled={currentUser?.webImportPinEnabled || false}
         />
       )}
 

--- a/src/components/UniversalImportModal.js
+++ b/src/components/UniversalImportModal.js
@@ -3,21 +3,27 @@ import './UniversalImportModal.css';
 import { fileToBase64 } from '../utils/imageUtils';
 import { runUniversalImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
+import { isWebImportUnlocked, verifyWebImportPin } from '../utils/webImportPin';
 
 function buildInitialText(title, text) {
   return [title, text].filter(Boolean).join('\n\n');
 }
 
-function UniversalImportModal({ onCancel, initialImages = [], initialText = '', initialUrl = '', initialTitle = '', userId = '', importContext = {} }) {
+function UniversalImportModal({ onCancel, initialImages = [], initialText = '', initialUrl = '', initialTitle = '', userId = '', importContext = {}, webImportPinEnabled = false }) {
   const [images, setImages] = useState(initialImages);
   const [text, setText] = useState(buildInitialText(initialTitle, initialText));
   const [url, setUrl] = useState(initialUrl);
+  const [pin, setPin] = useState('');
+  const [verifyingPin, setVerifyingPin] = useState(false);
   const [error, setError] = useState('');
   const { enqueueImportJob } = useRecipeImportQueue();
 
   const fileInputRef = useRef(null);
 
   const hasContent = images.length > 0 || text.trim() || url.trim();
+  // A PIN is only needed for the URL leg – images/text alone never call the
+  // Webimport Cloud Functions (see runUniversalImport in importRunners.js).
+  const pinRequired = url.trim() && webImportPinEnabled && !isWebImportUnlocked();
 
   const handleAddImages = async (e) => {
     const files = Array.from(e.target.files);
@@ -36,10 +42,26 @@ function UniversalImportModal({ onCancel, initialImages = [], initialText = '', 
     setImages(prev => prev.filter((_, i) => i !== index));
   };
 
-  const handleQueueImport = () => {
+  const handleQueueImport = async () => {
     if (!hasContent) {
       setError('Bitte fügen Sie mindestens einen Inhalt hinzu.');
       return;
+    }
+
+    if (pinRequired) {
+      if (!pin.trim()) {
+        setError('Bitte gib deinen Webimport-PIN ein');
+        return;
+      }
+      setVerifyingPin(true);
+      try {
+        await verifyWebImportPin(pin.trim());
+      } catch (pinError) {
+        setVerifyingPin(false);
+        setError(pinError.message);
+        return;
+      }
+      setVerifyingPin(false);
     }
 
     const snapshot = { images: [...images], text, url };
@@ -92,6 +114,21 @@ function UniversalImportModal({ onCancel, initialImages = [], initialText = '', 
               onChange={(e) => setUrl(e.target.value)}
             />
           </div>
+
+          {pinRequired && (
+            <div className="universal-import-field">
+              <label className="universal-import-label">Webimport-PIN</label>
+              <input
+                type="password"
+                inputMode="numeric"
+                autoComplete="off"
+                className="universal-import-url-input"
+                placeholder="PIN eingeben"
+                value={pin}
+                onChange={(e) => setPin(e.target.value)}
+              />
+            </div>
+          )}
 
           {/* Text field */}
           <div className="universal-import-field">
@@ -146,9 +183,9 @@ function UniversalImportModal({ onCancel, initialImages = [], initialText = '', 
           <button
             className="universal-analyse-button"
             onClick={handleQueueImport}
-            disabled={!hasContent}
+            disabled={!hasContent || verifyingPin}
           >
-            Import starten
+            {verifyingPin ? 'PIN wird geprüft…' : 'Import starten'}
           </button>
         </div>
       </div>

--- a/src/components/WebImportModal.js
+++ b/src/components/WebImportModal.js
@@ -3,11 +3,16 @@ import './WebImportModal.css';
 import { normalizeImportedUrl } from '../utils/webImportService';
 import { runWebImport } from '../utils/importRunners';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
+import { isWebImportUnlocked, verifyWebImportPin } from '../utils/webImportPin';
 
-function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', userId = '', importContext = {} }) {
+function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', userId = '', importContext = {}, webImportPinEnabled = false }) {
   const [url, setUrl] = useState(() => normalizeImportedUrl(initialUrl));
+  const [pin, setPin] = useState('');
   const [error, setError] = useState('');
+  const [verifyingPin, setVerifyingPin] = useState(false);
   const { enqueueImportJob } = useRecipeImportQueue();
+
+  const pinRequired = webImportPinEnabled && !isWebImportUnlocked();
 
   useEffect(() => {
     setUrl(normalizeImportedUrl(initialUrl));
@@ -27,7 +32,7 @@ function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', 
   // actual recognition as a background job and closes immediately; the
   // recipe is saved with a TEMP flag once analysis finishes and shows up
   // for review on "Neues Rezept hinzufügen".
-  const submitUrl = (urlToSubmit) => {
+  const submitUrl = async (urlToSubmit) => {
     const normalizedUrl = normalizeImportedUrl(urlToSubmit);
     setError('');
 
@@ -39,6 +44,22 @@ function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', 
     if (!isValidUrl(normalizedUrl)) {
       setError('Bitte geben Sie eine gültige URL ein (z.B. https://example.com)');
       return;
+    }
+
+    if (webImportPinEnabled && !isWebImportUnlocked()) {
+      if (!pin.trim()) {
+        setError('Bitte gib deinen Webimport-PIN ein');
+        return;
+      }
+      setVerifyingPin(true);
+      try {
+        await verifyWebImportPin(pin.trim());
+      } catch (pinError) {
+        setVerifyingPin(false);
+        setError(pinError.message);
+        return;
+      }
+      setVerifyingPin(false);
     }
 
     enqueueImportJob({
@@ -58,10 +79,11 @@ function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', 
   // Handle URL submission from the form
   const handleSubmit = () => submitUrl(url);
 
-  // Auto-submit when initialUrl is provided and valid
+  // Auto-submit when initialUrl is provided and valid. Skipped while a PIN
+  // still needs to be entered – the user has to confirm it manually first.
   useEffect(() => {
     const normalizedInitialUrl = normalizeImportedUrl(initialUrl);
-    if (normalizedInitialUrl && isValidUrl(normalizedInitialUrl)) {
+    if (normalizedInitialUrl && isValidUrl(normalizedInitialUrl) && !pinRequired) {
       submitUrl(normalizedInitialUrl);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -98,6 +120,26 @@ function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', 
               />
             </div>
 
+            {pinRequired && (
+              <div className="url-input-container">
+                <label htmlFor="webImportPinInput">Webimport-PIN:</label>
+                <input
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="off"
+                  id="webImportPinInput"
+                  value={pin}
+                  onChange={(e) => setPin(e.target.value)}
+                  placeholder="PIN eingeben"
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleSubmit();
+                    }
+                  }}
+                />
+              </div>
+            )}
+
             <div className="url-input-hint">
               <p>Tipp: Die Website wird automatisch erfasst und das Rezept extrahiert.</p>
               <p>Instagram Reels werden direkt unterstützt – die Caption wird automatisch ausgelesen.</p>
@@ -116,8 +158,8 @@ function WebImportModal({ onCancel, onImported, initialUrl = '', authorId = '', 
           <button className="cancel-button" onClick={onCancel}>
             Abbrechen
           </button>
-          <button className="submit-button" onClick={handleSubmit}>
-            Import starten
+          <button className="submit-button" onClick={handleSubmit} disabled={verifyingPin}>
+            {verifyingPin ? 'PIN wird geprüft…' : 'Import starten'}
           </button>
         </div>
       </div>

--- a/src/utils/webImportPin.js
+++ b/src/utils/webImportPin.js
@@ -1,0 +1,83 @@
+/**
+ * Webimport-PIN
+ * Client-side helpers around the setWebImportPin/verifyWebImportPin Cloud
+ * Functions. The PIN itself never lands in Firestore in plaintext or
+ * reversible form – functions/webImportPin.js only ever stores a salted hash
+ * in a subcollection the client cannot read (see firestore.rules).
+ *
+ * A successful verifyWebImportPin() call opens a server-side "unlock window"
+ * (see UNLOCK_MINUTES in functions/webImportPin.js) during which the actual
+ * import Cloud Functions accept requests without asking for the PIN again.
+ * unlockedUntilMs below mirrors that window client-side (slightly shorter)
+ * purely so the UI can hide the PIN field once unlocked for this tab – the
+ * server-side check is the actual security boundary.
+ */
+import { functions } from '../firebase';
+import { httpsCallable } from 'firebase/functions';
+import { getCallableErrorDetails } from './webImportService';
+
+const CLIENT_UNLOCK_WINDOW_MS = 25 * 60 * 1000;
+
+let unlockedUntilMs = 0;
+
+/**
+ * @returns {boolean} Whether this tab has verified the PIN recently enough
+ *   that the import Cloud Functions should still accept requests without it.
+ */
+export function isWebImportUnlocked() {
+  return Date.now() < unlockedUntilMs;
+}
+
+/**
+ * Verify the given PIN against the caller's configured Webimport-PIN.
+ * @param {string} pin - The PIN as entered by the user.
+ * @returns {Promise<void>} Resolves on success; throws with a German message on failure.
+ */
+export async function verifyWebImportPin(pin) {
+  try {
+    await httpsCallable(functions, 'verifyWebImportPin')({ pin });
+    unlockedUntilMs = Date.now() + CLIENT_UNLOCK_WINDOW_MS;
+  } catch (error) {
+    const { code, message } = getCallableErrorDetails(error);
+    if (code === 'unauthenticated') {
+      throw new Error('Bitte melde dich an, um den Webimport-PIN zu prüfen.');
+    } else if (code === 'permission-denied') {
+      throw new Error(message || 'Falscher PIN.');
+    } else if (code === 'resource-exhausted') {
+      throw new Error(message || 'Zu viele Fehlversuche. Bitte später erneut versuchen.');
+    } else if (message) {
+      throw new Error(message);
+    }
+    throw new Error('PIN-Prüfung fehlgeschlagen. Bitte versuche es erneut.');
+  }
+}
+
+/**
+ * Set or change the caller's Webimport-PIN.
+ * @param {string} pin - 4–8 digit PIN.
+ * @returns {Promise<void>}
+ */
+export async function setWebImportPin(pin) {
+  try {
+    await httpsCallable(functions, 'setWebImportPin')({ pin });
+  } catch (error) {
+    const { code, message } = getCallableErrorDetails(error);
+    if (code === 'unauthenticated') {
+      throw new Error('Bitte melde dich an, um einen Webimport-PIN zu setzen.');
+    } else if (code === 'invalid-argument') {
+      throw new Error(message || 'Ungültiger PIN.');
+    } else if (message) {
+      throw new Error(message);
+    }
+    throw new Error('PIN konnte nicht gespeichert werden. Bitte versuche es erneut.');
+  }
+}
+
+/**
+ * Remove the caller's Webimport-PIN entirely (Webimport then works unprotected again).
+ * @returns {Promise<void>}
+ */
+export async function clearWebImportPin() {
+  await setWebImportPin(null);
+  unlockedUntilMs = 0;
+}

--- a/src/utils/webImportService.js
+++ b/src/utils/webImportService.js
@@ -16,7 +16,7 @@ import { parseOcrText } from './ocrParser';
  * @param {Error & {code?: string}} error - Error thrown by a callable function
  * @returns {{code: string, message: string, lowerMessage: string}}
  */
-function getCallableErrorDetails(error) {
+export function getCallableErrorDetails(error) {
   const rawCode = error?.code ? String(error.code) : '';
   const code = rawCode.replace(/^functions\//, '').toLowerCase();
   const message = error?.message ? String(error.message).trim() : '';


### PR DESCRIPTION
Nutzer können auf der Chefkoch-Seite (PersonalDataPage) einen PIN setzen,
der vor jedem Webimport einmalig bestätigt werden muss – so kann niemand
mit demselben Zugang ungefragt Rezepte importieren. Der PIN wird nie im
Klartext gespeichert: nur ein gesalzener scrypt-Hash landet in
users/{uid}/security/webImportPin, einer Subcollection ohne jeglichen
Client-Lese-/Schreibzugriff (nur die neuen Cloud Functions
setWebImportPin/verifyWebImportPin via Admin SDK). Eine erfolgreiche
PIN-Prüfung öffnet ein 30-minütiges serverseitiges Unlock-Fenster, das
importRecipeCallable/scrapeInstagramReel/captureWebsiteScreenshot vor
jeder Ausführung prüfen; Fehlversuche werden gezählt und sperren den PIN
nach 5 Fehlversuchen für 15 Minuten.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U28Y6gT6PZ9WcAuThqasSd