### PR TITLE
Webimport-PIN: optionaler PIN-Schutz für Webimporte

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -13,7 +13,7 @@ const nodemailer = require('nodemailer');
 const crypto = require('crypto');
 const sharp = require('sharp');
 const {createNutritionNormalizationUtils} = require('./nutritionNormalization');
-const {requireWebImportUnlocked} = require('./webImportPin');
+const {requireWebImportUnlocked, requireShortcutPin} = require('./webImportPin');
 
 // Initialize Firebase Admin
 admin.initializeApp();
@@ -2639,12 +2639,15 @@ exports.importRecipeCallable = onCall(
  *
  * Body (JSON):
  *   url {string}            Required – public recipe URL to import
+ *   pin {string}            Required, wenn der Zielnutzer einen Webimport-PIN
+ *                            eingerichtet hat (sonst nicht erforderlich) –
+ *                            siehe requireShortcutPin in webImportPin.js
  *   cuisineTypes {string[]} Optional – cuisine type list for AI prompt
  *   mealCategories {string[]} Optional – meal category list for AI prompt
  *
  * Returns:
  *   200 { success: true, recipe: <structured recipe data> }
- *   400/401/403/500 { success: false, error: string }
+ *   400/401/403/429/500 { success: false, error: string }
  */
 exports.importRecipeShortcut = onRequest(
     {
@@ -2751,12 +2754,24 @@ exports.importRecipeShortcut = onRequest(
         }
       }
 
-      const {url} = body || {};
+      const {url, pin} = body || {};
       if (!url || typeof url !== 'string') {
         res.status(400).json({
           success: false,
           error: 'Missing required field: url (string)',
         });
+        return;
+      }
+
+      // Webimport-PIN: no-op if the target user never set one; otherwise the
+      // Shortcut must send a matching `pin` field with every request (it has
+      // no interactive session to stay "unlocked" like the in-app modals).
+      try {
+        await requireShortcutPin(userId, pin);
+      } catch (pinErr) {
+        const status = pinErr.code === 'resource-exhausted' ? 429 :
+          pinErr.code === 'invalid-argument' ? 400 : 403;
+        res.status(status).json({success: false, error: pinErr.message || 'PIN erforderlich.'});
         return;
       }
 

--- a/functions/webImportPin.js
+++ b/functions/webImportPin.js
@@ -28,6 +28,17 @@ function getSecurityDocRef(db, uid) {
 }
 
 /**
+ * @param {string} code HttpsError-artiger Fehlercode (z.B. 'permission-denied').
+ * @param {string} message Für Nutzer bestimmte Fehlermeldung.
+ * @return {Error} Error-Objekt mit angehängtem `code`, wie es HttpsError erwartet.
+ */
+function pinError(code, message) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
+
+/**
  * Cloud Function: setWebImportPin
  * Sets, changes, or (pin === null/'') clears the caller's own Webimport-PIN.
  * The PIN is never stored in plaintext – only a salted scrypt hash lands in
@@ -83,33 +94,31 @@ exports.setWebImportPin = onCall({maxInstances: 10}, async (request) => {
 });
 
 /**
- * Cloud Function: verifyWebImportPin
- * Verifies the caller's PIN against the stored hash. On success, opens a
- * time-limited "unlock window" (UNLOCK_MINUTES) recorded server-side on the
- * security doc; requireWebImportUnlocked() below checks that window before
- * letting an import Cloud Function run, so the client never needs to resend
- * the PIN with every single import call. Failed attempts are counted and
- * lock the PIN out for LOCKOUT_MINUTES after MAX_FAILED_ATTEMPTS in a row.
+ * Core PIN check shared by verifyWebImportPin (onCall, used by the in-app
+ * modals) and requireShortcutPin (used inline by the importRecipeShortcut
+ * HTTP endpoint, which has no interactive "stay unlocked" session and so
+ * must send the PIN with every request). Verifies `pin` against the stored
+ * hash for `uid`, tracking failed attempts / lockout, and on success opens
+ * the UNLOCK_MINUTES window that requireWebImportUnlocked() checks for the
+ * in-app import calls. Throws an Error with an HttpsError-style `code`
+ * property on failure – callers translate that to their own error shape.
+ * @param {string} uid Firebase-Nutzer-ID.
+ * @param {string} pin Vom Aufrufer übermittelter PIN.
+ * @return {Promise<{configured: boolean}>} configured=false, wenn der Nutzer
+ *   keinen PIN eingerichtet hat (dann wurde nichts geprüft).
  */
-exports.verifyWebImportPin = onCall({maxInstances: 20}, async (request) => {
-  const auth = request.auth;
-  if (!auth) {
-    throw new HttpsError('unauthenticated', 'Login erforderlich.');
-  }
-
-  const {pin} = request.data || {};
-  if (typeof pin !== 'string' || !pin) {
-    throw new HttpsError('invalid-argument', 'PIN ist erforderlich.');
-  }
-
-  const uid = auth.uid;
+async function verifyPinCore(uid, pin) {
   const db = admin.firestore();
   const docRef = getSecurityDocRef(db, uid);
   const snap = await docRef.get();
 
   if (!snap.exists) {
     // No PIN configured for this user – nothing to verify against.
-    return {ok: true};
+    return {configured: false};
+  }
+
+  if (typeof pin !== 'string' || !pin) {
+    throw pinError('invalid-argument', 'PIN ist erforderlich.');
   }
 
   const data = snap.data();
@@ -117,7 +126,7 @@ exports.verifyWebImportPin = onCall({maxInstances: 20}, async (request) => {
 
   if (data.lockedUntil && data.lockedUntil.toMillis && data.lockedUntil.toMillis() > now) {
     const minutesLeft = Math.ceil((data.lockedUntil.toMillis() - now) / 60000);
-    throw new HttpsError(
+    throw pinError(
         'resource-exhausted',
         `Zu viele Fehlversuche. Bitte in ${minutesLeft} Minute${minutesLeft === 1 ? '' : 'n'} erneut versuchen.`,
     );
@@ -137,13 +146,36 @@ exports.verifyWebImportPin = onCall({maxInstances: 20}, async (request) => {
       update.failedAttempts = 0;
     }
     await docRef.set(update, {merge: true});
-    throw new HttpsError('permission-denied', 'Falscher PIN.');
+    throw pinError('permission-denied', 'Falscher PIN.');
   }
 
   const unlockedUntil = admin.firestore.Timestamp.fromMillis(now + UNLOCK_MINUTES * 60000);
   await docRef.set({failedAttempts: 0, lockedUntil: null, unlockedUntil}, {merge: true});
 
-  return {ok: true, unlockedUntilMs: unlockedUntil.toMillis()};
+  return {configured: true};
+}
+
+/**
+ * Cloud Function: verifyWebImportPin
+ * Verifies the caller's PIN against the stored hash (see verifyPinCore). On
+ * success, opens a time-limited "unlock window" (UNLOCK_MINUTES) recorded
+ * server-side on the security doc; requireWebImportUnlocked() below checks
+ * that window before letting an import Cloud Function run, so the client
+ * never needs to resend the PIN with every single import call.
+ */
+exports.verifyWebImportPin = onCall({maxInstances: 20}, async (request) => {
+  const auth = request.auth;
+  if (!auth) {
+    throw new HttpsError('unauthenticated', 'Login erforderlich.');
+  }
+
+  const {pin} = request.data || {};
+  try {
+    await verifyPinCore(auth.uid, pin);
+    return {ok: true};
+  } catch (err) {
+    throw new HttpsError(err.code || 'internal', err.message || 'PIN-Prüfung fehlgeschlagen.');
+  }
 });
 
 /**
@@ -174,3 +206,20 @@ async function requireWebImportUnlocked(uid) {
 }
 
 exports.requireWebImportUnlocked = requireWebImportUnlocked;
+
+/**
+ * Called by importRecipeShortcut (functions/index.js) on every request. The
+ * Apple Shortcut has no interactive session to "stay unlocked" the way the
+ * in-app modals do (see requireWebImportUnlocked above), so it must send the
+ * PIN with every call instead – this checks it directly against the stored
+ * hash. A no-op when the target user never configured a PIN, so existing
+ * Shortcuts keep working unchanged until their owner sets one.
+ * @param {string} uid Firebase-Nutzer-ID, für die importiert werden soll.
+ * @param {string} pin Vom Kurzbefehl übermittelter PIN.
+ * @return {Promise<void>}
+ */
+async function requireShortcutPin(uid, pin) {
+  await verifyPinCore(uid, pin);
+}
+
+exports.requireShortcutPin = requireShortcutPin;

--- a/src/components/PersonalDataPage.js
+++ b/src/components/PersonalDataPage.js
@@ -609,6 +609,11 @@ function PersonalDataPage({ currentUser, onBack, onProfileUpdated, privateLists 
         <p className="personal-data-password-hint">
           Schützt den Webimport zusätzlich mit einer PIN, die nur du kennst – so kann niemand mit deinem Zugang ungefragt Rezepte importieren.
         </p>
+        {pinActive && (
+          <p className="personal-data-password-hint">
+            Nutzt du den Apple-Kurzbefehl für den Webimport, musst du diesen PIN dort im Anfragetext als Feld „pin" ergänzen – sonst schlägt der Import ab jetzt fehl.
+          </p>
+        )}
 
         {pinActive ? (
           <div className="preferences-group">


### PR DESCRIPTION
## Summary
- Nutzer können unter „Chefkoch" → „Webimport-PIN" einen PIN (4–8 Ziffern) setzen, verwalten und wieder entfernen (Entfernen über `DeleteRowButton` + Sofort-weg-plus-6s-Undo-Snackbar gemäß CLAUDE.md).
- Der PIN wird nie im Klartext oder reversibel verschlüsselt gespeichert – nur ein gesalzener scrypt-Hash landet in `users/{uid}/security/webImportPin`, einer Subcollection ohne jeglichen Client-Lese-/Schreibzugriff (`firestore.rules`: `allow read, write: if false`). Nur die neuen Cloud Functions `setWebImportPin`/`verifyWebImportPin` (Admin SDK) kommen dran.
- Eine erfolgreiche PIN-Prüfung öffnet ein 30-minütiges serverseitiges Unlock-Fenster; `importRecipeCallable`, `scrapeInstagramReel` und `captureWebsiteScreenshot` prüfen dieses Fenster vor jeder Ausführung. Ohne gesetzten PIN bleibt der Webimport unverändert nutzbar (Opt-in-Feature).
- `WebImportModal` und `UniversalImportModal` fragen den PIN ab, sobald einer aktiv und das Fenster abgelaufen ist, und verifizieren ihn vor dem Import.
- 5 Fehlversuche in Folge sperren den PIN für 15 Minuten (serverseitig gezählt, in `users/{uid}/security/webImportPin`).
- Der Apple-Kurzbefehl-Endpunkt (`importRecipeShortcut`) verlangt den PIN jetzt ebenfalls, als zusätzliches `pin`-Feld im Request-Body – sonst könnte jeder mit dem geteilten `SHORTCUT_API_KEY` und einer beliebigen registrierten E-Mail-Adresse für einen fremden Account importieren, auch wenn dieser einen PIN gesetzt hat. Ohne gesetzten PIN funktioniert der Kurzbefehl unverändert.

## Test plan
- [x] `npx eslint` über alle geänderten Client- und Functions-Dateien lief fehlerfrei (bis auf eine vorbestehende, unveränderte Warnung/einen vorbestehenden Parsing-Fehler in nicht berührten Codestellen).
- [x] `npx react-scripts build` (Produktion) kompiliert erfolgreich.
- [ ] Manuelles Testen nach Deploy: PIN setzen/ändern/entfernen auf der Profilseite, Webimport mit und ohne PIN, Kurzbefehl mit `pin`-Feld.
- [ ] Deploy erforderlich, damit die Änderung wirksam wird: `firebase deploy --only functions` und `firebase deploy --only firestore:rules`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U28Y6gT6PZ9WcAuThqasSd)_