### PR TITLE
Zeige Anzahl freizugebender Rezeptimporte als Badge an

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,7 @@ import {
 } from './utils/groupFirestore';
 import { NutritionReferenceProvider, useNutritionReference } from './contexts/NutritionReferenceContext';
 import { RecipeImportQueueProvider, useRecipeImportQueue } from './contexts/RecipeImportQueueContext';
+import { updateAppBadge } from './utils/appBadge';
 import { resolveRecipeGroupContext, resolveImportGroupContext } from './utils/recipeGroupContext';
 
 // Lazily loaded: everything below is a secondary view/overlay that isn't
@@ -520,6 +521,18 @@ function App() {
     () => BOTTOM_NAV_TABS.filter((tab) => tab.view !== 'startseite' || currentUser?.startseite),
     [currentUser?.startseite]
   );
+  const bottomNavBadgeCounts = useMemo(
+    () => ({ recipes: pendingReviewRecipes.length }),
+    [pendingReviewRecipes.length]
+  );
+
+  // Mirrors the pending-review-imports count onto the installed app's home
+  // screen/taskbar icon via the Badging API, so it's visible even when the
+  // app isn't open (see AppReviewRecipesSync above for how pendingReviewRecipes
+  // is populated from the import queue).
+  useEffect(() => {
+    updateAppBadge(pendingReviewRecipes.length);
+  }, [pendingReviewRecipes.length]);
   const appBottomNavStyle = useMemo(() => ({
     '--bottom-nav-offset': showBottomNav && isBottomNavVisible ? 'var(--bottom-nav-height)' : '0px',
     '--bottom-spacing': showBottomNav && isBottomNavVisible ? 'calc(var(--bottom-nav-height) + 16px)' : '0px',
@@ -2454,6 +2467,7 @@ function App() {
             activeKey={bottomNavActiveKey}
             isVisible={isBottomNavVisible}
             onSelect={handleBottomNavSelect}
+            badgeCounts={bottomNavBadgeCounts}
           />
         )}
         {showAtelierOnboarding && (

--- a/src/components/BottomNavigation.css
+++ b/src/components/BottomNavigation.css
@@ -61,12 +61,38 @@
   outline-offset: 2px;
 }
 
-.bottom-navigation__icon {
+.bottom-navigation__icon,
+.bottom-navigation__icon-wrapper {
+  position: relative;
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
   min-height: 28px;
+}
+
+.bottom-navigation__badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: #C0392B;
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 0 0 2px #ffffff;
+}
+
+[data-theme="dark"] .bottom-navigation__badge {
+  box-shadow: 0 0 0 2px #1E1E1C;
 }
 
 .bottom-navigation__icon svg {

--- a/src/components/BottomNavigation.js
+++ b/src/components/BottomNavigation.js
@@ -111,13 +111,23 @@ function resolveTabIcon(tab, isActive, buttonIcons, isDarkMode) {
   return { Icon, iconValue: activeIconValue || normalIconValue };
 }
 
-function TabIcon({ tab, isActive, buttonIcons, isDarkMode, iconClassName }) {
+function NavBadge({ count }) {
+  if (!count || count < 1) return null;
+  return (
+    <span className="bottom-navigation__badge">
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}
+
+function TabIcon({ tab, isActive, buttonIcons, isDarkMode, iconClassName, badgeCount }) {
   const { Icon, iconValue } = resolveTabIcon(tab, isActive, buttonIcons, isDarkMode);
 
   if (isBase64Image(iconValue)) {
     return (
       <span className={`bottom-navigation__icon${iconClassName ? ` ${iconClassName}` : ''}`} aria-hidden="true">
         <img src={iconValue} alt="" className="bottom-navigation__icon-image" draggable="false" />
+        <NavBadge count={badgeCount} />
       </span>
     );
   }
@@ -125,13 +135,19 @@ function TabIcon({ tab, isActive, buttonIcons, isDarkMode, iconClassName }) {
     return (
       <span className={`bottom-navigation__icon bottom-navigation__icon-text${iconClassName ? ` ${iconClassName}` : ''}`} aria-hidden="true">
         {iconValue}
+        <NavBadge count={badgeCount} />
       </span>
     );
   }
-  return Icon ? <Icon className={iconClassName} /> : null;
+  return Icon ? (
+    <span className="bottom-navigation__icon-wrapper">
+      <Icon className={iconClassName} />
+      <NavBadge count={badgeCount} />
+    </span>
+  ) : null;
 }
 
-function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
+function BottomNavigation({ tabs, activeKey, isVisible, onSelect, badgeCounts }) {
   const [buttonIcons, setButtonIcons] = useState({ ...DEFAULT_BUTTON_ICONS });
   const [isDarkMode, setIsDarkMode] = useState(getDarkModePreference);
   const railRef = useRef(null);
@@ -191,16 +207,17 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
       >
         {tabs.map((tab) => {
           const isActive = tab.key === activeKey;
+          const badgeCount = badgeCounts?.[tab.key] || 0;
           return (
             <button
               key={tab.key}
               type="button"
               className={`bottom-navigation__tab${isActive ? ' bottom-navigation__tab--active' : ''}`}
               onClick={() => onSelect(tab)}
-              aria-label={tab.label}
+              aria-label={badgeCount > 0 ? `${tab.label} (${badgeCount})` : tab.label}
               aria-current={isActive ? 'page' : undefined}
             >
-              <TabIcon tab={tab} isActive={isActive} buttonIcons={buttonIcons} isDarkMode={isDarkMode} />
+              <TabIcon tab={tab} isActive={isActive} buttonIcons={buttonIcons} isDarkMode={isDarkMode} badgeCount={badgeCount} />
               <span className="bottom-navigation__label">{tab.label}</span>
             </button>
           );
@@ -218,13 +235,14 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
         >
           {tabs.map((tab) => {
             const isActive = tab.key === activeKey;
+            const badgeCount = badgeCounts?.[tab.key] || 0;
             return (
               <button
                 key={tab.key}
                 type="button"
                 className={`bottom-navigation-pill__item${isActive ? ' bottom-navigation-pill__item--active' : ''}`}
                 onClick={() => onSelect(tab)}
-                aria-label={tab.label}
+                aria-label={badgeCount > 0 ? `${tab.label} (${badgeCount})` : tab.label}
                 aria-current={isActive ? 'page' : undefined}
               >
                 <TabIcon
@@ -233,6 +251,7 @@ function BottomNavigation({ tabs, activeKey, isVisible, onSelect }) {
                   buttonIcons={buttonIcons}
                   isDarkMode={isDarkMode}
                   iconClassName="bottom-navigation-pill__icon"
+                  badgeCount={badgeCount}
                 />
                 <span className="bottom-navigation-pill__label">{tab.label}</span>
               </button>

--- a/src/components/BottomNavigation.test.js
+++ b/src/components/BottomNavigation.test.js
@@ -102,4 +102,40 @@ describe('BottomNavigation icon rendering', () => {
     expect(pill.getByLabelText('Küche')).toBeInTheDocument();
     expect(pill.getByLabelText('Chefkoch')).toBeInTheDocument();
   });
+
+  test('shows a count badge on a tab with pending items', async () => {
+    const { container } = render(
+      <BottomNavigation
+        tabs={tabs}
+        activeKey="home"
+        isVisible
+        onSelect={() => {}}
+        badgeCounts={{ recipes: 3 }}
+      />
+    );
+
+    await waitFor(() => expect(getButtonIcons).toHaveBeenCalled());
+
+    const fullBar = within(container.querySelector('.bottom-navigation'));
+    expect(fullBar.getByText('3')).toBeInTheDocument();
+    expect(fullBar.getByLabelText('Kochbuch (3)')).toBeInTheDocument();
+  });
+
+  test('hides the badge and plain label when the count is zero', async () => {
+    const { container } = render(
+      <BottomNavigation
+        tabs={tabs}
+        activeKey="home"
+        isVisible
+        onSelect={() => {}}
+        badgeCounts={{ recipes: 0 }}
+      />
+    );
+
+    await waitFor(() => expect(getButtonIcons).toHaveBeenCalled());
+
+    const fullBar = within(container.querySelector('.bottom-navigation'));
+    expect(container.querySelector('.bottom-navigation__badge')).not.toBeInTheDocument();
+    expect(fullBar.getByLabelText('Kochbuch')).toBeInTheDocument();
+  });
 });

--- a/src/utils/appBadge.js
+++ b/src/utils/appBadge.js
@@ -1,0 +1,18 @@
+// Wraps the Badging API (navigator.setAppBadge/clearAppBadge), which shows a
+// count on the app icon on the home screen / taskbar for an installed PWA.
+// Only supported by some browsers (e.g. Chrome/Edge on Android/desktop, not
+// Firefox or Safari), so every call is feature-detected and failures are
+// swallowed — this is a best-effort visual cue, never load-bearing.
+export function updateAppBadge(count) {
+  if (typeof navigator === 'undefined') return;
+  const value = Math.max(0, Math.round(count) || 0);
+  try {
+    if (value > 0 && typeof navigator.setAppBadge === 'function') {
+      navigator.setAppBadge(value).catch(() => {});
+    } else if (value === 0 && typeof navigator.clearAppBadge === 'function') {
+      navigator.clearAppBadge().catch(() => {});
+    }
+  } catch (error) {
+    // Badging API not available/allowed in this context — ignore.
+  }
+}

--- a/src/utils/appBadge.test.js
+++ b/src/utils/appBadge.test.js
@@ -1,0 +1,32 @@
+import { updateAppBadge } from './appBadge';
+
+describe('updateAppBadge', () => {
+  afterEach(() => {
+    delete navigator.setAppBadge;
+    delete navigator.clearAppBadge;
+  });
+
+  test('sets the badge count when the Badging API is available', () => {
+    navigator.setAppBadge = jest.fn().mockResolvedValue();
+    navigator.clearAppBadge = jest.fn().mockResolvedValue();
+
+    updateAppBadge(3);
+
+    expect(navigator.setAppBadge).toHaveBeenCalledWith(3);
+    expect(navigator.clearAppBadge).not.toHaveBeenCalled();
+  });
+
+  test('clears the badge when the count is zero', () => {
+    navigator.setAppBadge = jest.fn().mockResolvedValue();
+    navigator.clearAppBadge = jest.fn().mockResolvedValue();
+
+    updateAppBadge(0);
+
+    expect(navigator.clearAppBadge).toHaveBeenCalled();
+    expect(navigator.setAppBadge).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when the Badging API is unsupported', () => {
+    expect(() => updateAppBadge(5)).not.toThrow();
+  });
+});


### PR DESCRIPTION
- Bottom Navigation: Zähl-Badge am "Kochbuch"-Tab (voll und Pill-Modus),
  basierend auf reviewRecipes aus dem Import-Queue-Kontext.
- Homebildschirm: App-Icon-Badge via Badging API (navigator.setAppBadge/
  clearAppBadge), synchron zur selben Zahl.