### PR TITLE
Rezept-Import-Dialog: kompaktes Redesign (Option A)

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -66,7 +66,14 @@ const Header = forwardRef(function Header({
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const menuRef = useRef(null);
   const searchRef = useRef(null);
-  const { jobs: importJobs, dismissJob: dismissImportJob, restartJob: restartImportJob, cancelJob: cancelImportJob } = useRecipeImportQueue();
+  const {
+    jobs: importJobs,
+    deleteBanners: importDeleteBanners,
+    dismissJob: dismissImportJob,
+    restartJob: restartImportJob,
+    cancelJob: cancelImportJob,
+    undoDelete: undoImportDelete,
+  } = useRecipeImportQueue();
 
   useImperativeHandle(ref, () => ({
     openSearch() {
@@ -465,10 +472,12 @@ const Header = forwardRef(function Header({
       {importDialogOpen && (
         <ImportProgressDialog
           jobs={importJobs}
+          deleteBanners={importDeleteBanners}
           onClose={() => setImportDialogOpen(false)}
           onDismissJob={dismissImportJob}
           onRestartJob={restartImportJob}
           onCancelJob={cancelImportJob}
+          onUndoDelete={undoImportDelete}
         />
       )}
     </>

--- a/src/components/ImportProgressDialog.css
+++ b/src/components/ImportProgressDialog.css
@@ -13,164 +13,212 @@
 
 .import-progress-dialog {
   background: white;
-  border-radius: 8px;
+  border-radius: 12px;
   width: 100%;
-  max-width: 420px;
+  max-width: 380px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+  box-shadow: 0 12px 32px rgba(20, 16, 12, 0.16);
 }
 
 .import-progress-dialog-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
-  border-bottom: 1px solid #e0e0e0;
+  padding: 14px 16px;
+  border-bottom: 1px solid #ececea;
+}
+
+.import-progress-dialog-title {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
 }
 
 .import-progress-dialog-header h2 {
   margin: 0;
-  font-size: 1.25rem;
-  color: #333;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.import-progress-dialog-count {
+  font-size: 0.78rem;
+  color: #6b5744;
+  flex-shrink: 0;
 }
 
 .import-progress-dialog-header .close-button {
-  background: transparent;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
   border: none;
-  font-size: 1.5rem;
-  line-height: 1;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   cursor: pointer;
-  color: #666;
-  padding: 4px 8px;
+  color: rgba(74, 52, 34, 0.55);
+  transition: background 0.16s ease, color 0.16s ease;
+}
+
+.import-progress-dialog-header .close-button:hover,
+.import-progress-dialog-header .close-button:focus-visible {
+  background: rgba(120, 84, 52, 0.08);
+  color: #1a1a1a;
 }
 
 .import-progress-dialog-content {
-  padding: 16px 20px;
+  padding: 4px 8px;
   overflow-y: auto;
 }
 
 .import-progress-empty {
-  color: #666;
+  color: #6b5744;
   text-align: center;
-  margin: 12px 0;
+  margin: 20px 0;
+  font-size: 0.9rem;
 }
 
 .import-progress-list {
   list-style: none;
   margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  padding: 4px 0;
 }
 
+/* One row per import: icon, title (+ error text below), status, actions —
+   stays a single line except when an error message needs a second line. */
 .import-progress-item {
-  border: 1px solid #e0e0e0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px;
   border-radius: 8px;
-  padding: 10px 12px;
 }
 
 .import-progress-item.status-error {
-  border-color: rgba(163, 58, 38, 0.4);
-  background: rgba(163, 58, 38, 0.05);
+  align-items: flex-start;
+  background: rgba(163, 58, 38, 0.045);
 }
 
-.import-progress-item-main {
+.import-progress-item.delete-row-hover-target:hover,
+.import-progress-item.delete-row-hover-target:focus-within {
+  background: rgba(120, 84, 52, 0.07);
+}
+
+.import-progress-item.status-error.delete-row-hover-target:hover,
+.import-progress-item.status-error.delete-row-hover-target:focus-within {
+  background: rgba(163, 58, 38, 0.09);
+}
+
+.import-row-icon {
+  flex-shrink: 0;
+}
+
+.import-progress-item.status-error .import-row-icon {
+  margin-top: 1px;
+}
+
+.import-row-icon-track {
+  stroke: rgba(26, 26, 26, 0.14);
+}
+
+.import-row-icon-fill {
+  stroke: #1a1a1a;
+  transition: stroke-dashoffset 0.2s ease;
+}
+
+.import-progress-item-body {
+  min-width: 0;
+  flex-grow: 1;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.9rem;
+  flex-direction: column;
 }
 
 .import-progress-item-label {
-  color: #1a1a1a;
+  font-size: 0.86rem;
   font-weight: 600;
+  color: #1a1a1a;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.import-progress-item-error-text {
+  font-size: 0.74rem;
+  color: #a33a26;
+  margin-top: 2px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .import-progress-item-status {
-  color: #666;
+  font-size: 0.74rem;
+  color: #6b5744;
   flex-shrink: 0;
-  font-size: 0.8rem;
-}
-
-.import-progress-item-bar {
-  margin-top: 8px;
-  height: 6px;
-  border-radius: 999px;
-  background: #eee;
-  overflow: hidden;
-}
-
-.import-progress-item-bar-fill {
-  height: 100%;
-  background: #1a1a1a;
-  transition: width 0.2s ease;
+  white-space: nowrap;
 }
 
 .import-progress-item-actions {
-  margin-top: 8px;
   display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.import-progress-item-error {
-  margin-top: 8px;
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 8px;
-  font-size: 0.8rem;
-  color: #a33a26;
-}
-
-.import-progress-item-error span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.import-progress-item-error-actions {
-  display: flex;
-  gap: 8px;
+  gap: 2px;
   flex-shrink: 0;
 }
 
-.import-progress-item-dismiss,
+.import-progress-item.status-error .import-progress-item-actions {
+  margin-top: 1px;
+}
+
 .import-progress-item-restart {
+  width: 26px;
+  height: 26px;
   border-radius: 999px;
-  padding: 2px 10px;
-  font-size: 0.75rem;
-  cursor: pointer;
-  flex-shrink: 0;
+  border: none;
   background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(74, 52, 34, 0.4);
+  cursor: pointer;
+  transition: background 0.16s ease, color 0.16s ease;
 }
 
-.import-progress-item-dismiss {
-  border: 1px solid #a33a26;
-  color: #a33a26;
+.import-progress-item.delete-row-hover-target:hover .import-progress-item-restart:not(:hover):not(:focus-visible),
+.import-progress-item.delete-row-hover-target:focus-within .import-progress-item-restart:not(:hover):not(:focus-visible) {
+  color: rgba(74, 52, 34, 0.62);
 }
 
-.import-progress-item-restart {
-  border: 1px solid #2196f3;
-  color: #2196f3;
+.import-progress-item-restart:hover,
+.import-progress-item-restart:focus-visible {
+  color: #DF7A00;
+  background: rgba(223, 122, 0, 0.12);
+}
+
+.import-progress-item-restart:focus-visible {
+  outline: 2px solid rgba(223, 122, 0, 0.5);
+  outline-offset: 2px;
+}
+
+.import-progress-item.status-error .import-progress-item-restart {
+  color: #DF7A00;
 }
 
 .import-progress-hint {
-  margin: 16px 0 4px;
-  color: #666;
-  font-size: 0.8rem;
+  margin: 12px 0 4px;
+  color: #6b5744;
+  font-size: 0.74rem;
   text-align: center;
 }
 
 [data-theme="dark"] .import-progress-dialog {
   background: #1e1e1e;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
 }
 
 [data-theme="dark"] .import-progress-dialog-header {
@@ -181,27 +229,85 @@
   color: #e8e8e8;
 }
 
-[data-theme="dark"] .import-progress-item {
-  border-color: #3d3d3d;
+[data-theme="dark"] .import-progress-dialog-count,
+[data-theme="dark"] .import-progress-empty,
+[data-theme="dark"] .import-progress-item-status,
+[data-theme="dark"] .import-progress-hint {
+  color: #b8ac9d;
+}
+
+[data-theme="dark"] .import-progress-dialog-header .close-button {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+[data-theme="dark"] .import-progress-dialog-header .close-button:hover,
+[data-theme="dark"] .import-progress-dialog-header .close-button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e8e8e8;
+}
+
+[data-theme="dark"] .import-progress-item.delete-row-hover-target:hover,
+[data-theme="dark"] .import-progress-item.delete-row-hover-target:focus-within {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 [data-theme="dark"] .import-progress-item.status-error {
   background: rgba(163, 58, 38, 0.12);
 }
 
+[data-theme="dark"] .import-progress-item.status-error.delete-row-hover-target:hover,
+[data-theme="dark"] .import-progress-item.status-error.delete-row-hover-target:focus-within {
+  background: rgba(163, 58, 38, 0.18);
+}
+
+[data-theme="dark"] .import-row-icon-track {
+  stroke: rgba(232, 232, 232, 0.2);
+}
+
+[data-theme="dark"] .import-row-icon-fill {
+  stroke: #e8e8e8;
+}
+
 [data-theme="dark"] .import-progress-item-label {
   color: #e8e8e8;
 }
 
-[data-theme="dark"] .import-progress-item-bar {
-  background: #3d3d3d;
+[data-theme="dark"] .import-progress-item-restart {
+  color: rgba(255, 255, 255, 0.4);
 }
 
-[data-theme="dark"] .import-progress-item-bar-fill {
-  background: #e8e8e8;
+[data-theme="dark"] .import-progress-item.delete-row-hover-target:hover .import-progress-item-restart:not(:hover):not(:focus-visible),
+[data-theme="dark"] .import-progress-item.delete-row-hover-target:focus-within .import-progress-item-restart:not(:hover):not(:focus-visible) {
+  color: rgba(255, 255, 255, 0.62);
 }
 
-[data-theme="dark"] .import-progress-empty,
-[data-theme="dark"] .import-progress-hint {
-  color: #aaa;
+[data-theme="dark"] .import-progress-item-restart:hover,
+[data-theme="dark"] .import-progress-item-restart:focus-visible {
+  color: #f0a341;
+  background: rgba(240, 163, 65, 0.16);
+}
+
+[data-theme="dark"] .import-progress-item.status-error .import-progress-item-restart {
+  color: #f0a341;
+}
+
+/* Narrow / touch viewports have no hover to reveal row actions, so keep the
+   restart icon reachably visible at rest instead of only on hover (matches
+   DeleteRowButton's own touch-viewport rule in the same file family). */
+@media (max-width: 768px), (hover: none), (pointer: coarse) {
+  .import-progress-item-restart {
+    color: rgba(74, 52, 34, 0.62);
+  }
+
+  [data-theme="dark"] .import-progress-item-restart {
+    color: rgba(255, 255, 255, 0.62);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .import-row-icon-fill,
+  .import-progress-item-restart,
+  .import-progress-dialog-header .close-button {
+    transition: none;
+  }
 }

--- a/src/components/ImportProgressDialog.js
+++ b/src/components/ImportProgressDialog.js
@@ -1,24 +1,75 @@
 import React, { useEffect } from 'react';
 import './ImportProgressDialog.css';
+import './UndoSnackbar.css';
+import DeleteRowButton from './DeleteRowButton';
+import RestartIcon from './icons/RestartIcon';
+import CloseThinIcon from './icons/CloseThinIcon';
 
-function statusLabel(status) {
+const RING_SIZE = 20;
+const RING_STROKE = 2.5;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+function statusLabel(status, progress) {
   switch (status) {
     case 'queued':
       return 'Wartet…';
     case 'processing':
-      return 'Wird analysiert…';
-    case 'error':
-      return 'Fehlgeschlagen';
+      return `Analysiert · ${Math.round(progress || 0)} %`;
     default:
       return '';
   }
+}
+
+// Compact per-row status glyph: a progress ring for queued/processing (empty
+// track while queued, filling as it processes), a solid warning dot for
+// error — replaces the old full-width status text + separate progress bar
+// so a row stays a single line.
+function RowStatusIcon({ status, progress }) {
+  if (status === 'error') {
+    return (
+      <svg width={RING_SIZE} height={RING_SIZE} viewBox="0 0 20 20" className="import-row-icon" aria-hidden="true">
+        <circle cx="10" cy="10" r="10" fill="#a33a26" />
+        <rect x="9" y="5" width="2" height="6" rx="1" fill="#fff" />
+        <circle cx="10" cy="14" r="1.2" fill="#fff" />
+      </svg>
+    );
+  }
+  const clamped = Math.max(0, Math.min(100, progress || 0));
+  const offset = RING_CIRCUMFERENCE * (1 - clamped / 100);
+  return (
+    <svg width={RING_SIZE} height={RING_SIZE} viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`} className="import-row-icon" aria-hidden="true">
+      <circle
+        cx={RING_SIZE / 2}
+        cy={RING_SIZE / 2}
+        r={RING_RADIUS}
+        strokeWidth={RING_STROKE}
+        fill="none"
+        className="import-row-icon-track"
+      />
+      {status === 'processing' && (
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={RING_RADIUS}
+          strokeWidth={RING_STROKE}
+          fill="none"
+          className="import-row-icon-fill"
+          strokeLinecap="round"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={offset}
+          transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+        />
+      )}
+    </svg>
+  );
 }
 
 // Detail view opened by clicking the header's import progress donut. Shows
 // every queued/running/failed background import job; finished imports leave
 // this list immediately and show up as pending reviews on "Neues Rezept
 // hinzufügen" instead.
-function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCancelJob }) {
+function ImportProgressDialog({ jobs, deleteBanners = [], onClose, onDismissJob, onRestartJob, onCancelJob, onUndoDelete }) {
   // Lock body scroll while this dialog is open (iOS Safari safe)
   useEffect(() => {
     const scrollY = window.scrollY;
@@ -43,8 +94,15 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCan
     <div className="modal-overlay" onClick={onClose}>
       <div className="import-progress-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="import-progress-dialog-header">
-          <h2>Rezept-Import</h2>
-          <button className="close-button" onClick={onClose} aria-label="Schließen">×</button>
+          <div className="import-progress-dialog-title">
+            <h2>Rezept-Import</h2>
+            {jobs.length > 0 && (
+              <span className="import-progress-dialog-count">{jobs.length} aktiv</span>
+            )}
+          </div>
+          <button className="close-button" onClick={onClose} aria-label="Schließen" title="Schließen">
+            <CloseThinIcon size={13} />
+          </button>
         </div>
 
         <div className="import-progress-dialog-content">
@@ -52,95 +110,42 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCan
             <p className="import-progress-empty">Kein Import aktiv.</p>
           ) : (
             <ul className="import-progress-list">
-              {jobs.map((job) => (
-                <li key={job.id} className={`import-progress-item status-${job.status}`}>
-                  <div className="import-progress-item-main">
-                    <span className="import-progress-item-label">{job.label || 'Rezept-Import'}</span>
-                    <span className="import-progress-item-status">{statusLabel(job.status)}</span>
-                  </div>
-                  {(job.status === 'processing' || job.status === 'queued') && (
-                    <div className="import-progress-item-bar">
-                      <div
-                        className="import-progress-item-bar-fill"
-                        style={{ width: `${job.progress || 0}%` }}
+              {jobs.map((job) => {
+                const label = job.label || 'Rezept-Import';
+                return (
+                  <li key={job.id} className={`import-progress-item status-${job.status} delete-row-hover-target`}>
+                    <RowStatusIcon status={job.status} progress={job.progress} />
+                    <div className="import-progress-item-body">
+                      <span className="import-progress-item-label">{label}</span>
+                      {job.status === 'error' && (
+                        <span className="import-progress-item-error-text">{job.error}</span>
+                      )}
+                    </div>
+                    {job.status !== 'error' && (
+                      <span className="import-progress-item-status">{statusLabel(job.status, job.progress)}</span>
+                    )}
+                    <div className="import-progress-item-actions">
+                      {job.canRestart && (
+                        <button
+                          type="button"
+                          className="import-progress-item-restart"
+                          onClick={() => onRestartJob(job.id)}
+                          title="Import neu starten"
+                          aria-label={`${label} neu starten`}
+                        >
+                          <RestartIcon size={14} />
+                        </button>
+                      )}
+                      <DeleteRowButton
+                        itemName={label}
+                        onClick={() => (
+                          job.status === 'error' ? onDismissJob(job.id, label) : onCancelJob(job.id, label)
+                        )}
                       />
                     </div>
-                  )}
-                  {job.status === 'queued' && (
-                    <div className="import-progress-item-actions">
-                      {job.canRestart && (
-                        <button
-                          type="button"
-                          className="import-progress-item-restart"
-                          onClick={() => onRestartJob(job.id)}
-                          title="Import neu starten"
-                          aria-label={`${job.label || 'Import'} neu starten`}
-                        >
-                          Neu starten
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        className="import-progress-item-dismiss"
-                        onClick={() => onCancelJob(job.id)}
-                        title="Import abbrechen"
-                        aria-label={`${job.label || 'Import'} abbrechen`}
-                      >
-                        Abbrechen
-                      </button>
-                    </div>
-                  )}
-                  {job.status === 'processing' && (
-                    <div className="import-progress-item-actions">
-                      {job.canRestart && (
-                        <button
-                          type="button"
-                          className="import-progress-item-restart"
-                          onClick={() => onRestartJob(job.id)}
-                          title="Import neu starten"
-                          aria-label={`${job.label || 'Import'} neu starten`}
-                        >
-                          Neu starten
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        className="import-progress-item-dismiss"
-                        onClick={() => onCancelJob(job.id)}
-                        title="Import abbrechen"
-                        aria-label={`${job.label || 'Import'} abbrechen`}
-                      >
-                        Abbrechen
-                      </button>
-                    </div>
-                  )}
-                  {job.status === 'error' && (
-                    <div className="import-progress-item-error">
-                      <span>{job.error}</span>
-                      <div className="import-progress-item-error-actions">
-                        {job.canRestart && (
-                          <button
-                            type="button"
-                            className="import-progress-item-restart"
-                            onClick={() => onRestartJob(job.id)}
-                            title="Import neu starten"
-                            aria-label={`${job.label || 'Import'} neu starten`}
-                          >
-                            Neu starten
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          className="import-progress-item-dismiss"
-                          onClick={() => onDismissJob(job.id)}
-                        >
-                          Verwerfen
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </li>
-              ))}
+                  </li>
+                );
+              })}
             </ul>
           )}
           <p className="import-progress-hint">
@@ -148,6 +153,21 @@ function ImportProgressDialog({ jobs, onClose, onDismissJob, onRestartJob, onCan
           </p>
         </div>
       </div>
+
+      {deleteBanners.map((banner, index) => (
+        <div
+          key={banner.id}
+          className="undo-snackbar"
+          role="status"
+          style={{ bottom: `${24 + index * 56}px` }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="undo-snackbar-message">{banner.message}</span>
+          <button type="button" className="undo-snackbar-action" onClick={() => onUndoDelete(banner.id)}>
+            Rückgängig
+          </button>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/icons/RestartIcon.js
+++ b/src/components/icons/RestartIcon.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+// Refresh/redo arrow used to restart a stuck or failed import job.
+const RestartIcon = ({ color = 'currentColor', size = 16 }) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 10a6 6 0 1 1 1.76 4.24"
+        stroke={color}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4 14.5V10h4.5"
+        stroke={color}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default RestartIcon;

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -8,16 +8,19 @@ import {
 } from '../utils/recipeFirestore';
 import { compressImage } from '../utils/imageUtils';
 import { runWebImport, runUniversalImport, runPhotoScanImport } from '../utils/importRunners';
+import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const RecipeImportQueueContext = createContext(null);
 
 const noopQueue = {
   jobs: [],
   reviewRecipes: [],
+  deleteBanners: [],
   enqueueImportJob: () => undefined,
   dismissJob: () => {},
   restartJob: () => {},
   cancelJob: () => {},
+  undoDelete: () => {},
 };
 
 // Images are compressed before being persisted as importSource (for
@@ -109,6 +112,10 @@ export function RecipeImportQueueProvider({ userId, children }) {
   // screenshot / AI calls), so a "cancel" can't actually stop the network
   // work in flight; it only makes sure the stale result is never persisted.
   const cancelledJobsRef = useRef(new Set());
+  // CLAUDE.md: every delete acts immediately + a 6s "Rückgängig" snackbar;
+  // the row disappears from `jobs` right away, the underlying Firestore
+  // delete only runs once the undo window passes unconfirmed.
+  const { banners: deleteBanners, pendingKeys: pendingDeleteKeys, scheduleDelete, undoDelete } = useUndoableDelete();
 
   useEffect(() => {
     const unsubscribe = subscribeToTempRecipes(userId, setTempRecipes);
@@ -117,6 +124,7 @@ export function RecipeImportQueueProvider({ userId, children }) {
 
   const jobs = useMemo(() => tempRecipes
     .filter(isPendingImport)
+    .filter((r) => !pendingDeleteKeys.has(r.id))
     .map((r) => ({
       id: r.id,
       label: r.title,
@@ -124,7 +132,7 @@ export function RecipeImportQueueProvider({ userId, children }) {
       progress: r.importProgress || 0,
       error: r.importError,
       canRestart: Boolean(r.importSource),
-    })), [tempRecipes]);
+    })), [tempRecipes, pendingDeleteKeys]);
 
   const reviewRecipes = useMemo(
     () => tempRecipes.filter((r) => !isPendingImport(r)),
@@ -228,23 +236,41 @@ export function RecipeImportQueueProvider({ userId, children }) {
     });
   }, [processQueue]);
 
-  const dismissJob = useCallback((id) => {
-    deleteRecipe(id).catch((error) => {
-      console.error('Fehler beim Verwerfen des Import-Jobs:', error);
+  const dismissJob = useCallback((id, label) => {
+    scheduleDelete({
+      key: id,
+      message: `„${label || 'Import'}" verworfen`,
+      onConfirm: () => {
+        deleteRecipe(id).catch((error) => {
+          console.error('Fehler beim Verwerfen des Import-Jobs:', error);
+        });
+      },
+      onUndo: () => {},
     });
-  }, []);
+  }, [scheduleDelete]);
 
-  // Cancels a queued or actively running job: the temp-recipe doc is
-  // removed right away, and if the job is mid-run its eventual result is
-  // discarded by processQueue instead of being written back (see
-  // cancelledJobsRef above — there's no way to actually abort the
-  // in-flight OCR/screenshot call itself).
-  const cancelJob = useCallback((id) => {
+  // Cancels a queued or actively running job: it disappears from the list
+  // immediately and, if the job is mid-run, its eventual result is discarded
+  // by processQueue right away instead of being written back (see
+  // cancelledJobsRef above — there's no way to actually abort the in-flight
+  // OCR/screenshot call itself). The temp-recipe doc itself is only deleted
+  // once the undo window passes; undoing puts the job back in the run
+  // discard-list so a still-in-flight attempt resumes being honored.
+  const cancelJob = useCallback((id, label) => {
     cancelledJobsRef.current.add(id);
-    deleteRecipe(id).catch((error) => {
-      console.error('Fehler beim Abbrechen des Import-Jobs:', error);
+    scheduleDelete({
+      key: id,
+      message: `„${label || 'Import'}" abgebrochen`,
+      onConfirm: () => {
+        deleteRecipe(id).catch((error) => {
+          console.error('Fehler beim Abbrechen des Import-Jobs:', error);
+        });
+      },
+      onUndo: () => {
+        cancelledJobsRef.current.delete(id);
+      },
     });
-  }, []);
+  }, [scheduleDelete]);
 
   // Requeues a job from its persisted importSource — shared by the manual
   // "Neu starten" button (restartJob) and the orphan-recovery effect below.
@@ -300,7 +326,7 @@ export function RecipeImportQueueProvider({ userId, children }) {
     });
   }, [tempRecipes, queueRestart]);
 
-  const value = { jobs, reviewRecipes, enqueueImportJob, dismissJob, restartJob, cancelJob };
+  const value = { jobs, reviewRecipes, deleteBanners, enqueueImportJob, dismissJob, restartJob, cancelJob, undoDelete };
 
   return (
     <RecipeImportQueueContext.Provider value={value}>


### PR DESCRIPTION
Jede Zeile jetzt einzeilig statt Kachel mit eigener Aktionsreihe: ein
20px-Fortschrittsring/Fehler-Punkt ersetzt den vollen Balken, "Neu starten"
wird zum Icon-Button, "Abbrechen"/"Verwerfen" nutzt DeleteRowButton statt
eigener Textbuttons (Icon-Farbe folgt dem App-Orange-Braun #DF7A00). Damit
folgt der Dialog auch dem CLAUDE.md-Löschmuster: sofortiges Entfernen aus
der Liste + 6s-Snackbar "Rückgängig", die eigentliche Firestore-Löschung
läuft erst danach.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PCZ2BPDcbkWbg7WXQoEnmo