### PR TITLE
Fehlgeschlagene Webimporte beim Verwerfen protokollieren

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -375,6 +375,15 @@ service cloud.firestore {
       allow read: if isAdmin();
     }
 
+    // Failed web imports collection - logs URL + error message whenever a user dismisses
+    // a failed web import, so app development can investigate what went wrong on that
+    // site. Write-only debugging data for admins; regular users cannot read others' logs.
+    match /failedWebImports/{entryId} {
+      allow read: if isAdmin();
+      allow create: if isAnyUser();
+      allow update, delete: if isAdmin();
+    }
+
     // Cuisine proposals collection - tracks user-proposed cuisine types for admin review
     match /cuisineProposals/{proposalId} {
       // Any authenticated user can read proposals

--- a/src/contexts/RecipeImportQueueContext.js
+++ b/src/contexts/RecipeImportQueueContext.js
@@ -8,6 +8,7 @@ import {
 } from '../utils/recipeFirestore';
 import { compressImage } from '../utils/imageUtils';
 import { runWebImport, runUniversalImport, runPhotoScanImport } from '../utils/importRunners';
+import { logFailedWebImport } from '../utils/failedWebImportsFirestore';
 import useUndoableDelete from '../hooks/useUndoableDelete';
 
 const RecipeImportQueueContext = createContext(null);
@@ -237,17 +238,31 @@ export function RecipeImportQueueProvider({ userId, children }) {
   }, [processQueue]);
 
   const dismissJob = useCallback((id, label) => {
+    // Snapshot the job now (not inside onConfirm) — by the time the 6s undo
+    // window passes, this job may already have been removed from tempRecipes.
+    const tempRecipe = tempRecipes.find((r) => r.id === id);
     scheduleDelete({
       key: id,
       message: `„${label || 'Import'}" verworfen`,
       onConfirm: () => {
+        // Log dismissed, failed web imports (URL + error) so app development
+        // can look into what went wrong on that site. Only web imports have
+        // a meaningful source URL for this purpose.
+        if (tempRecipe?.importStatus === 'error' && tempRecipe.importSource?.type === 'web') {
+          logFailedWebImport({
+            url: tempRecipe.importSource.url,
+            error: tempRecipe.importError,
+            title: tempRecipe.title,
+            userId: tempRecipe.authorId,
+          });
+        }
         deleteRecipe(id).catch((error) => {
           console.error('Fehler beim Verwerfen des Import-Jobs:', error);
         });
       },
       onUndo: () => {},
     });
-  }, [scheduleDelete]);
+  }, [scheduleDelete, tempRecipes]);
 
   // Cancels a queued or actively running job: it disappears from the list
   // immediately and, if the job is mid-run, its eventual result is discarded

--- a/src/utils/failedWebImportsFirestore.js
+++ b/src/utils/failedWebImportsFirestore.js
@@ -1,0 +1,44 @@
+/**
+ * Failed Web Imports Firestore Utilities
+ *
+ * When a user dismisses a web import that ended up in `importStatus: 'error'`,
+ * the URL and error message are logged here so app development can look into
+ * what went wrong (broken parser for a given site, rate limiting, etc.).
+ * This is a write-only debugging log, not user-facing data.
+ *
+ * Data model: failedWebImports/{id}
+ *   - url:       string          – the recipe URL that failed to import
+ *   - error:     string          – the error message shown to the user
+ *   - title:     string          – the (fallback) recipe title/label at time of dismissal
+ *   - userId:    string | null   – authorId of the user who queued/dismissed the import
+ *   - createdAt: serverTimestamp
+ */
+
+import { db } from '../firebase';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+
+/**
+ * Log a dismissed, failed web import for later developer review.
+ * Never throws – logging failures must not block the dismiss action itself.
+ *
+ * @param {Object} params
+ * @param {string} params.url - The recipe URL that failed to import
+ * @param {string} [params.error] - Error message shown to the user
+ * @param {string} [params.title] - Recipe title/label at time of dismissal
+ * @param {string} [params.userId] - authorId of the user who queued the import
+ * @returns {Promise<void>}
+ */
+export async function logFailedWebImport({ url, error, title, userId }) {
+  if (!url) return;
+  try {
+    await addDoc(collection(db, 'failedWebImports'), {
+      url,
+      error: error || '',
+      title: title || '',
+      userId: userId || null,
+      createdAt: serverTimestamp(),
+    });
+  } catch (err) {
+    console.error('Fehler beim Protokollieren des fehlgeschlagenen Webimports:', err);
+  }
+}


### PR DESCRIPTION
URL, Fehlermeldung und Titel werden beim Verwerfen eines gescheiterten
Webimport-Jobs in der neuen Collection failedWebImports gespeichert,
damit sich die Appentwicklung ansehen kann, woran der Import lag.