### PR TITLE
Add branded splash screen shown while auth state loads

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import RecipeList from './components/RecipeList';
 import RecipeFilterSidebar from './components/RecipeFilterSidebar';
 import Header from './components/Header';
 import Login from './components/Login';
+import SplashScreen from './components/SplashScreen';
 import MobileSearchOverlay from './components/MobileSearchOverlay';
 import BottomNavigation from './components/BottomNavigation';
 import {
@@ -2029,16 +2030,9 @@ function App() {
     clearSharedDataFromDB();
   };
 
-  // Show loading state while checking auth
+  // Show splash screen while checking auth
   if (authLoading) {
-    return (
-      <div className="App" style={appBottomNavStyle}>
-        <Header />
-        <div style={{ padding: '2rem', textAlign: 'center' }}>
-          Laden...
-        </div>
-      </div>
-    );
+    return <SplashScreen />;
   }
 
   // If accessing a share URL, show SharePage (no login required)

--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -1,0 +1,95 @@
+.splash-screen {
+  width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  box-sizing: border-box;
+  background: #fafaf8;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.splash-screen__content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding-top: 48px;
+}
+
+.splash-screen__logo {
+  width: 116px;
+  height: 116px;
+  object-fit: contain;
+  display: block;
+  animation: splash-screen-logo-in 600ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.splash-screen__tagline {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #402C1C;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  animation: splash-screen-fade-up 480ms ease-out 260ms both;
+}
+
+.splash-screen__hairline {
+  width: 100%;
+  height: 2px;
+  background: rgba(64, 44, 28, 0.08);
+  overflow: hidden;
+  margin-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+  animation: splash-screen-fade-in 400ms ease-out 500ms both;
+}
+
+.splash-screen__sweep {
+  width: 40%;
+  height: 100%;
+  background: #DF7A00;
+  animation: splash-screen-hairline-sweep 1.6s ease-in-out infinite;
+}
+
+@keyframes splash-screen-logo-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes splash-screen-fade-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes splash-screen-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes splash-screen-hairline-sweep {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splash-screen__logo,
+  .splash-screen__tagline,
+  .splash-screen__hairline,
+  .splash-screen__sweep {
+    animation: none;
+  }
+}
+
+[data-theme="dark"] .splash-screen {
+  background: #121212;
+}
+
+[data-theme="dark"] .splash-screen__tagline {
+  color: #e8e8e8;
+  opacity: 0.85;
+}
+
+[data-theme="dark"] .splash-screen__hairline {
+  background: rgba(255, 255, 255, 0.08);
+}

--- a/src/components/SplashScreen.js
+++ b/src/components/SplashScreen.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import './SplashScreen.css';
+
+const SplashScreen = () => (
+  <div className="splash-screen">
+    <div className="splash-screen__content">
+      <img
+        className="splash-screen__logo"
+        src={`${process.env.PUBLIC_URL}/logo512.png`}
+        alt="brouBook Logo"
+      />
+      <div className="splash-screen__tagline">Unsere besten Momente</div>
+    </div>
+    <div className="splash-screen__hairline">
+      <div className="splash-screen__sweep" />
+    </div>
+  </div>
+);
+
+export default SplashScreen;


### PR DESCRIPTION
Replaces the plain "Laden..." fallback with a SplashScreen component
matching the finalized Modern-Minimal design: logo, tracked tagline,
and a hairline sweep loader, with dark mode support.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017iW3XgiC9bSAAvCp3LfSvs