### PR TITLE
Splash screen: wait for Startseite carousels, transparent logo background

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -23,7 +23,7 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#402C1C",
-  "background_color": "#ffffff",
+  "background_color": "transparent",
   "description": "brouBook - Eine Progressive Web App zum Verwalten deiner Lieblingsrezepte",
   "categories": ["food", "lifestyle", "productivity"],
   "orientation": "portrait-primary",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, Suspense, lazy } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback, Suspense, lazy } from 'react';
 import './App.css';
 import RecipeList from './components/RecipeList';
 import RecipeFilterSidebar from './components/RecipeFilterSidebar';
@@ -367,6 +367,14 @@ function App() {
   const [publicGroupId, setPublicGroupId] = useState(null);
   const [categoryFilter, setCategoryFilter] = useState('');
   const [recipesLoaded, setRecipesLoaded] = useState(false);
+  // Whether the Startseite's own carousels (Meine Kochideen, Im Trend) have
+  // finished loading their data, reported back via onCarouselsLoadedChange.
+  const [startseiteCarouselsLoaded, setStartseiteCarouselsLoaded] = useState(false);
+  // Latches to true the first time everything the initial "startseite" view
+  // needs (groups, recipes, its own carousels) has loaded, and never resets —
+  // used to keep the splash screen up through that first load without
+  // bringing it back on later visits to the start page.
+  const [initialStartseiteReady, setInitialStartseiteReady] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
   const [authView, setAuthView] = useState('login'); // 'login' or 'register'
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
@@ -914,6 +922,32 @@ function App() {
 
     return () => unsubscribe();
   }, [currentUser]);
+
+  const handleStartseiteCarouselsLoadedChange = useCallback((ready) => {
+    setStartseiteCarouselsLoaded(ready);
+  }, []);
+
+  // Latch initialStartseiteReady once, the first time everything the initial
+  // "startseite" landing view needs has finished loading. Users who don't
+  // land on the start page (currentUser.startseite is off), and cases where
+  // something else (a deep link into the recipe form, an event reminder,
+  // settings, ...) takes over before Startseite ever finishes loading, latch
+  // it immediately instead — there's nothing left to wait for in that case.
+  useEffect(() => {
+    if (initialStartseiteReady || !currentUser) return;
+    const startseiteVisible = currentView === 'startseite'
+      && !isSettingsOpen && !selectedRecipe && !isFormOpen && !selectedMenu && !isMenuFormOpen;
+    if (!currentUser.startseite || !startseiteVisible) {
+      setInitialStartseiteReady(true);
+      return;
+    }
+    if (!groupsLoading && recipesLoaded && startseiteCarouselsLoaded) {
+      setInitialStartseiteReady(true);
+    }
+  }, [
+    currentUser, currentView, isSettingsOpen, selectedRecipe, isFormOpen, selectedMenu, isMenuFormOpen,
+    groupsLoading, recipesLoaded, startseiteCarouselsLoaded, initialStartseiteReady,
+  ]);
 
   const handleSelectRecipe = (recipe) => {
     // Save scroll position when opening a recipe from the recipe list (not from a menu)
@@ -2135,6 +2169,7 @@ function App() {
     <RecipeImportQueueProvider userId={currentUser?.id}>
       <AppNutritionRowsSync onRows={setNutritionReferenceRows} />
       <AppReviewRecipesSync onReviewRecipes={setPendingReviewRecipes} />
+      {!initialStartseiteReady && <SplashScreen />}
       <div className="App" style={appBottomNavStyle}>
         <Header
           ref={headerRef}
@@ -2330,7 +2365,7 @@ function App() {
           allUsers={allUsers}
         />
         ) : currentView === 'startseite' ? (
-        <Startseite currentUser={currentUser} onViewChange={handleViewChange} onSelectRecipe={handleSelectRecipe} recipes={recipes} groups={groups} groupsLoading={groupsLoading} onCreateInspirationList={handleCreateInspirationList} onSelectExistingInspirationList={handleSelectExistingInspirationList} onAssignEverydayClassicsList={handleAssignEverydayClassicsList} onOpenPrivateListRecipes={handleOpenPrivateListRecipes} onOpenSeasonalRecipes={handleOpenSeasonalRecipes} onAddRecipe={handleAddRecipe} />
+        <Startseite currentUser={currentUser} onViewChange={handleViewChange} onSelectRecipe={handleSelectRecipe} recipes={recipes} groups={groups} groupsLoading={groupsLoading} onCreateInspirationList={handleCreateInspirationList} onSelectExistingInspirationList={handleSelectExistingInspirationList} onAssignEverydayClassicsList={handleAssignEverydayClassicsList} onOpenPrivateListRecipes={handleOpenPrivateListRecipes} onOpenSeasonalRecipes={handleOpenSeasonalRecipes} onAddRecipe={handleAddRecipe} onCarouselsLoadedChange={handleStartseiteCarouselsLoadedChange} />
         ) : (
         // Recipe views
         <div className="recipe-overview-layout">

--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -1,7 +1,10 @@
 .splash-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
   width: 100%;
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
   box-sizing: border-box;
   background: #fafaf8;
   display: flex;

--- a/src/components/Startseite.js
+++ b/src/components/Startseite.js
@@ -22,7 +22,7 @@ const ALLTAGSKLASSIKER_TOP = 10;
 const KOCHIDEEN_KARUSSELL_MAX = 6;
 const SORT_STORAGE_KEY = 'recipebook_active_sort';
 
-function Startseite({ currentUser, onViewChange, onSelectRecipe, recipes = [], groups = [], groupsLoading = false, onCreateInspirationList, onSelectExistingInspirationList, onAssignEverydayClassicsList, onOpenPrivateListRecipes, onOpenSeasonalRecipes, onAddRecipe }) {
+function Startseite({ currentUser, onViewChange, onSelectRecipe, recipes = [], groups = [], groupsLoading = false, onCreateInspirationList, onSelectExistingInspirationList, onAssignEverydayClassicsList, onOpenPrivateListRecipes, onOpenSeasonalRecipes, onAddRecipe, onCarouselsLoadedChange }) {
   const { rows: nutritionReferenceRows } = useNutritionReference();
   const nutritionReferenceIndex = useMemo(
     () => buildNutritionReferenceIndex(nutritionReferenceRows),
@@ -455,6 +455,13 @@ function Startseite({ currentUser, onViewChange, onSelectRecipe, recipes = [], g
     }
     onViewChange?.('recipes');
   };
+
+  // Report whether all carousels that have their own async loading phase
+  // (Meine Kochideen, Im Trend) have finished, so the caller (App) can keep
+  // the splash screen visible until the start page is fully populated.
+  useEffect(() => {
+    onCarouselsLoadedChange?.(!loading && !kandidatenLoading);
+  }, [loading, kandidatenLoading, onCarouselsLoadedChange]);
 
   // Condition: show setup button when no default list or the list is not interactive
   const showInspirationSetupButton = !groupsLoading && (!defaultWebImportList || defaultWebImportList.listKind !== 'interactive');


### PR DESCRIPTION
- App.js keeps the splash screen visible until the Startseite's own
  carousels (Meine Kochideen, Im Trend) have finished loading, not just
  until auth resolves. Startseite reports readiness back via a new
  onCarouselsLoadedChange prop; a latch (initialStartseiteReady) ensures
  the splash only gates the very first load and never reappears later,
  and falls back gracefully if something else (deep link, event
  reminder, ...) takes over before Startseite ever mounts.
- SplashScreen is now a fixed full-screen overlay so it can sit on top
  of the mounting app instead of blocking it from rendering at all.
- manifest.json's PWA background_color was #ffffff, which painted a
  solid white canvas behind the (already transparent) logo icon in the
  native install/launch splash screen. Changed to transparent.