### PR TITLE
Fix white background behind custom app logo icons

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -88,8 +88,9 @@ async function resizeImage(base64, targetSize) {
     const x = (targetSize - scaledWidth) / 2;
     const y = (targetSize - scaledHeight) / 2;
 
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, targetSize, targetSize);
+    // Leave the canvas transparent (its default) instead of filling it
+    // opaque white, so the app's light/dark splash background shows
+    // through around the logo like it does for the default brand logo.
     ctx.drawImage(imageBitmap, x, y, scaledWidth, scaledHeight);
 
     return await canvas.convertToBlob({ type: 'image/png' });


### PR DESCRIPTION
The service worker's on-the-fly logo192/logo512 resizer painted an
opaque white canvas before drawing the user's uploaded logo onto it,
so any custom app logo (even a transparent PNG, as recommended in the
upload hint) always showed a solid white square behind it on the
splash screen — in both light and dark mode. Drop the fill so the
canvas stays transparent, matching the bundled default logo.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fi4xp56DX4VX5LNmDqYLE8