### PR TITLE
Fix splash screen sweep bar to fully exit right edge

### DIFF
--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -72,7 +72,7 @@
 
 @keyframes splash-screen-hairline-sweep {
   0%   { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  100% { transform: translateX(250%); }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Der orangefarbene Sweep-Balken auf dem Splashscreen blieb bei 80% der Containerbreite stehen statt vollständig nach rechts zu laufen.
- Ursache: `translateX(N%)` bezieht sich auf die Eigenbreite des Elements (40% des Containers), nicht auf den Container. `translateX(100%)` verschob den Balken also nur um 40% der Containerbreite.
- Fix: Endwert der Keyframe-Animation auf `translateX(250%)` gesetzt (250% von 40% Eigenbreite = 100% Containerbreite), sodass der Balken symmetrisch zum linken Start rechts vollständig aus dem Bild läuft.

## Test plan
- [x] CSS-Berechnung verifiziert (Balkenbreite × Prozentwert = vollständiger Austritt rechts)
- [ ] Splashscreen im Browser visuell prüfen (Desktop & Mobile, hell/dunkel)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMMTYzjFQabW3bUfmkXj44)_