### PR TITLE
Splashscreen: sanften Fade/Scale-Übergang zur Startseite

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -375,6 +375,11 @@ function App() {
   // used to keep the splash screen up through that first load without
   // bringing it back on later visits to the start page.
   const [initialStartseiteReady, setInitialStartseiteReady] = useState(false);
+  // Mirrors initialStartseiteReady but latches one animation frame later, so the
+  // splash screen keeps rendering (with the --exiting class) for the duration of
+  // its fade/scale-out transition instead of being unmounted mid-animation. See
+  // SPLASH_EXIT_DURATION_MS below and splash-screen--exiting in SplashScreen.css.
+  const [splashDismissed, setSplashDismissed] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
   const [authView, setAuthView] = useState('login'); // 'login' or 'register'
   const [requiresPasswordChange, setRequiresPasswordChange] = useState(false);
@@ -948,6 +953,17 @@ function App() {
     currentUser, currentView, isSettingsOpen, selectedRecipe, isFormOpen, selectedMenu, isMenuFormOpen,
     groupsLoading, recipesLoaded, startseiteCarouselsLoaded, initialStartseiteReady,
   ]);
+
+  // Keep the splash screen mounted just long enough to play its exit
+  // transition (fade + slight scale-out) once initialStartseiteReady latches,
+  // instead of cutting it away instantly. Duration matches the CSS transition
+  // on .splash-screen in SplashScreen.css.
+  useEffect(() => {
+    if (!initialStartseiteReady || splashDismissed) return undefined;
+    const SPLASH_EXIT_DURATION_MS = 380;
+    const timer = setTimeout(() => setSplashDismissed(true), SPLASH_EXIT_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [initialStartseiteReady, splashDismissed]);
 
   const handleSelectRecipe = (recipe) => {
     // Save scroll position when opening a recipe from the recipe list (not from a menu)
@@ -2187,7 +2203,7 @@ function App() {
 
   return (
     <>
-      {!initialStartseiteReady && <SplashScreen />}
+      {!splashDismissed && <SplashScreen exiting={initialStartseiteReady} />}
       <NutritionReferenceProvider enabled={!!currentUser}>
     <RecipeImportQueueProvider userId={currentUser?.id}>
       <AppNutritionRowsSync onRows={setNutritionReferenceRows} />

--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -10,6 +10,16 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 380ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 380ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.splash-screen--exiting {
+  opacity: 0;
+  transform: scale(1.025);
+  pointer-events: none;
 }
 
 .splash-screen__content {
@@ -81,6 +91,14 @@
   .splash-screen__hairline,
   .splash-screen__sweep {
     animation: none;
+  }
+
+  .splash-screen {
+    transition: opacity 150ms linear;
+  }
+
+  .splash-screen--exiting {
+    transform: none;
   }
 }
 

--- a/src/components/SplashScreen.js
+++ b/src/components/SplashScreen.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import './SplashScreen.css';
 
-const SplashScreen = () => (
-  <div className="splash-screen">
+const SplashScreen = ({ exiting = false }) => (
+  <div className={`splash-screen${exiting ? ' splash-screen--exiting' : ''}`}>
     <div className="splash-screen__content">
       <img
         className="splash-screen__logo"


### PR DESCRIPTION
Der Splashscreen wurde bisher hart unmontiert, sobald die Startseite fertig
geladen war. Jetzt bleibt er kurz gemountet und spielt einen minimalistischen
Fade+Scale-out (380ms), bevor er verschwindet – die bereits dahinter
gerenderte Startseite blendet dadurch sanft durch statt hart einzuschneiden.
Respektiert prefers-reduced-motion mit einer kurzen, transformationslosen
Fade-Variante.