### PR TITLE
Kurzbefehl-Download: PIN-Vergabe erzwingen, falls noch keine gesetzt ist

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2223,6 +2223,7 @@ function App() {
           interactiveLists={interactiveLists}
           startseiteEnabled={!!currentUser?.startseite}
           onChefkochClick={currentUser ? handleChefkochClick : undefined}
+          onProfileUpdated={(updatedUser) => setCurrentUser(prev => ({ ...prev, ...updatedUser }))}
         />
         <Suspense fallback={<ViewLoadingFallback />}>
         {isSettingsOpen ? (

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -652,6 +652,107 @@
   border-bottom: 1px solid #f0f0f0;
 }
 
+/* Shortcut-PIN Modal Styles */
+.shortcut-pin-modal {
+  max-width: 420px;
+}
+
+.shortcut-pin-modal-body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  overflow-y: auto;
+}
+
+.shortcut-pin-modal-hint {
+  margin: 0 0 1.2rem 0;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.shortcut-pin-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.shortcut-pin-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.shortcut-pin-modal-field label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.shortcut-pin-modal-field input {
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.shortcut-pin-modal-field input:focus {
+  outline: none;
+  border-color: #1a1a1a;
+}
+
+.shortcut-pin-modal-message {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: #fdecea;
+  color: #c62828;
+}
+
+.shortcut-pin-modal-actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.shortcut-pin-modal-cancel,
+.shortcut-pin-modal-submit {
+  flex: 1;
+  padding: 1rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.shortcut-pin-modal-cancel {
+  background: #f0f0f0;
+  color: #1a1a1a;
+}
+
+.shortcut-pin-modal-cancel:hover {
+  background: #e0e0e0;
+}
+
+.shortcut-pin-modal-submit {
+  background: linear-gradient(135deg, #402C1C 0%, #1a1a1a 100%);
+  color: white;
+}
+
+.shortcut-pin-modal-submit:hover:not(:disabled) {
+  background: linear-gradient(135deg, #1a1a1a 0%, #402C1C 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.shortcut-pin-modal-submit:active {
+  transform: translateY(0);
+}
+
+.shortcut-pin-modal-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .faq-item:last-child {
   border-bottom: none;
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,8 +6,10 @@ import SearchIcon from './icons/SearchIcon';
 import ImportProgressIndicator from './ImportProgressIndicator';
 import ImportProgressDialog from './ImportProgressDialog';
 import { useRecipeImportQueue } from '../contexts/RecipeImportQueueContext';
+import { setWebImportPin } from '../utils/webImportPin';
 
 const RECIPE_IMPORT_SHORTCUT_URL = 'https://www.icloud.com/shortcuts/7bf344e170574bbba4fb4cddc046ddba';
+const SHORTCUT_PIN_PATTERN = /^\d{4,8}$/;
 
 /**
  * Detects iPhone/iPad/Mac, the only platforms with a Shortcuts app that can
@@ -51,7 +53,8 @@ const Header = forwardRef(function Header({
   onSearchChange,
   interactiveLists = [],
   startseiteEnabled = false,
-  onChefkochClick
+  onChefkochClick,
+  onProfileUpdated
 }, ref) {
   const [headerSlogan, setHeaderSlogan] = useState('');
   const [appLogoImage, setAppLogoImage] = useState(null);
@@ -64,6 +67,11 @@ const Header = forwardRef(function Header({
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 768);
   const [isApple] = useState(isAppleDevice);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [shortcutPinModalOpen, setShortcutPinModalOpen] = useState(false);
+  const [shortcutPin, setShortcutPin] = useState('');
+  const [shortcutPinConfirm, setShortcutPinConfirm] = useState('');
+  const [savingShortcutPin, setSavingShortcutPin] = useState(false);
+  const [shortcutPinError, setShortcutPinError] = useState(null);
   const menuRef = useRef(null);
   const searchRef = useRef(null);
   const {
@@ -203,6 +211,46 @@ const Header = forwardRef(function Header({
       onViewChange('startseite');
     }
     setMenuOpen(false);
+  };
+
+  const handleInstallShortcutClick = () => {
+    setMenuOpen(false);
+    if (currentUser?.webImportPinEnabled) {
+      window.open(RECIPE_IMPORT_SHORTCUT_URL, '_blank', 'noopener,noreferrer');
+    } else {
+      setShortcutPin('');
+      setShortcutPinConfirm('');
+      setShortcutPinError(null);
+      setShortcutPinModalOpen(true);
+    }
+  };
+
+  const handleSetShortcutPin = async (e) => {
+    e.preventDefault();
+    setShortcutPinError(null);
+    if (!SHORTCUT_PIN_PATTERN.test(shortcutPin)) {
+      setShortcutPinError('PIN muss aus 4 bis 8 Ziffern bestehen.');
+      return;
+    }
+    if (shortcutPin !== shortcutPinConfirm) {
+      setShortcutPinError('Die PINs stimmen nicht überein.');
+      return;
+    }
+    setSavingShortcutPin(true);
+    try {
+      await setWebImportPin(shortcutPin);
+      if (onProfileUpdated) {
+        onProfileUpdated({ ...currentUser, webImportPinEnabled: true });
+      }
+      setShortcutPinModalOpen(false);
+      setShortcutPin('');
+      setShortcutPinConfirm('');
+      window.open(RECIPE_IMPORT_SHORTCUT_URL, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setShortcutPinError(err.message);
+    } finally {
+      setSavingShortcutPin(false);
+    }
   };
 
   const headerTitleContent = (
@@ -352,10 +400,7 @@ const Header = forwardRef(function Header({
                       {isApple && (
                         <button
                           className="menu-item"
-                          onClick={() => {
-                            window.open(RECIPE_IMPORT_SHORTCUT_URL, '_blank', 'noopener,noreferrer');
-                            setMenuOpen(false);
-                          }}
+                          onClick={handleInstallShortcutClick}
                         >
                           Kurzbefehl installieren
                         </button>
@@ -464,6 +509,70 @@ const Header = forwardRef(function Header({
                 </div>
                 )
               ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {shortcutPinModalOpen && (
+        <div className="faq-modal-overlay" onClick={() => setShortcutPinModalOpen(false)}>
+          <div className="faq-modal shortcut-pin-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="faq-modal-header">
+              <h2 className="faq-modal-title">Webimport-PIN erforderlich</h2>
+              <button
+                className="faq-modal-close"
+                onClick={() => setShortcutPinModalOpen(false)}
+                aria-label="Dialog schließen"
+              >
+                ×
+              </button>
+            </div>
+            <div className="faq-modal-body shortcut-pin-modal-body">
+              <p className="shortcut-pin-modal-hint">
+                Bevor du den Kurzbefehl herunterladen kannst, musst du einen Webimport-PIN vergeben.
+                Er schützt deinen Zugang davor, dass über den Kurzbefehl ungefragt Rezepte importiert werden.
+              </p>
+              <form className="shortcut-pin-modal-form" onSubmit={handleSetShortcutPin}>
+                <div className="shortcut-pin-modal-field">
+                  <label htmlFor="shortcutPin">PIN (4–8 Ziffern)</label>
+                  <input
+                    id="shortcutPin"
+                    type="password"
+                    inputMode="numeric"
+                    autoComplete="off"
+                    value={shortcutPin}
+                    onChange={(e) => setShortcutPin(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="shortcut-pin-modal-field">
+                  <label htmlFor="shortcutPinConfirm">PIN bestätigen</label>
+                  <input
+                    id="shortcutPinConfirm"
+                    type="password"
+                    inputMode="numeric"
+                    autoComplete="off"
+                    value={shortcutPinConfirm}
+                    onChange={(e) => setShortcutPinConfirm(e.target.value)}
+                    required
+                  />
+                </div>
+                {shortcutPinError && (
+                  <div className="shortcut-pin-modal-message">{shortcutPinError}</div>
+                )}
+                <div className="shortcut-pin-modal-actions">
+                  <button
+                    type="button"
+                    className="shortcut-pin-modal-cancel"
+                    onClick={() => setShortcutPinModalOpen(false)}
+                  >
+                    Abbrechen
+                  </button>
+                  <button type="submit" className="shortcut-pin-modal-submit" disabled={savingShortcutPin}>
+                    {savingShortcutPin ? 'Wird gespeichert…' : 'PIN setzen & herunterladen'}
+                  </button>
+                </div>
+              </form>
             </div>
           </div>
         </div>

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -1,5 +1,5 @@
 import React, { createRef, act } from 'react';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import Header from './Header';
 
 // Mock the custom lists utility
@@ -15,6 +15,12 @@ jest.mock('../utils/faqFirestore', () => ({
     return () => {};
   })
 }));
+
+jest.mock('../utils/webImportPin', () => ({
+  setWebImportPin: jest.fn(() => Promise.resolve()),
+}));
+
+const { setWebImportPin: mockSetWebImportPin } = jest.requireMock('../utils/webImportPin');
 
 const { subscribeToFaqs: mockSubscribeToFaqs } = jest.requireMock('../utils/faqFirestore');
 
@@ -439,5 +445,123 @@ describe('Header - Chefkoch user name click', () => {
     fireEvent.click(screen.getByLabelText('Menü öffnen'));
     const userNameBtn = screen.getByRole('button', { name: `${mockCurrentUser.vorname} ${mockCurrentUser.nachname}` });
     expect(userNameBtn).toBeDisabled();
+  });
+});
+
+describe('Header - Kurzbefehl download PIN requirement', () => {
+  const originalPlatform = window.navigator.platform;
+  const originalMaxTouchPoints = window.navigator.maxTouchPoints;
+  let windowOpenSpy;
+
+  beforeEach(() => {
+    Object.defineProperty(window.navigator, 'platform', { value: 'MacIntel', configurable: true });
+    Object.defineProperty(window.navigator, 'maxTouchPoints', { value: 0, configurable: true });
+    windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => {});
+    mockSetWebImportPin.mockClear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'platform', { value: originalPlatform, configurable: true });
+    Object.defineProperty(window.navigator, 'maxTouchPoints', { value: originalMaxTouchPoints, configurable: true });
+    windowOpenSpy.mockRestore();
+  });
+
+  test('opens the PIN dialog instead of downloading when no PIN is set yet', () => {
+    render(
+      <Header
+        currentView="recipes"
+        currentUser={{ ...mockCurrentUser, webImportPinEnabled: false }}
+        onViewChange={() => {}}
+        onLogout={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Menü öffnen'));
+    fireEvent.click(screen.getByText('Kurzbefehl installieren'));
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('Webimport-PIN erforderlich')).toBeInTheDocument();
+  });
+
+  test('downloads directly when a PIN is already set', () => {
+    render(
+      <Header
+        currentView="recipes"
+        currentUser={{ ...mockCurrentUser, webImportPinEnabled: true }}
+        onViewChange={() => {}}
+        onLogout={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Menü öffnen'));
+    fireEvent.click(screen.getByText('Kurzbefehl installieren'));
+
+    expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Webimport-PIN erforderlich')).not.toBeInTheDocument();
+  });
+
+  test('setting a valid PIN in the dialog saves it and then triggers the download', async () => {
+    const onProfileUpdated = jest.fn();
+    render(
+      <Header
+        currentView="recipes"
+        currentUser={{ ...mockCurrentUser, webImportPinEnabled: false }}
+        onViewChange={() => {}}
+        onLogout={() => {}}
+        onProfileUpdated={onProfileUpdated}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Menü öffnen'));
+    fireEvent.click(screen.getByText('Kurzbefehl installieren'));
+
+    fireEvent.change(screen.getByLabelText('PIN (4–8 Ziffern)'), { target: { value: '1234' } });
+    fireEvent.change(screen.getByLabelText('PIN bestätigen'), { target: { value: '1234' } });
+    fireEvent.click(screen.getByText('PIN setzen & herunterladen'));
+
+    await waitFor(() => expect(mockSetWebImportPin).toHaveBeenCalledWith('1234'));
+    await waitFor(() => expect(windowOpenSpy).toHaveBeenCalledTimes(1));
+    expect(onProfileUpdated).toHaveBeenCalledWith(expect.objectContaining({ webImportPinEnabled: true }));
+    expect(screen.queryByText('Webimport-PIN erforderlich')).not.toBeInTheDocument();
+  });
+
+  test('mismatched PINs show an error and do not save or download', async () => {
+    render(
+      <Header
+        currentView="recipes"
+        currentUser={{ ...mockCurrentUser, webImportPinEnabled: false }}
+        onViewChange={() => {}}
+        onLogout={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Menü öffnen'));
+    fireEvent.click(screen.getByText('Kurzbefehl installieren'));
+
+    fireEvent.change(screen.getByLabelText('PIN (4–8 Ziffern)'), { target: { value: '1234' } });
+    fireEvent.change(screen.getByLabelText('PIN bestätigen'), { target: { value: '5678' } });
+    fireEvent.click(screen.getByText('PIN setzen & herunterladen'));
+
+    expect(await screen.findByText('Die PINs stimmen nicht überein.')).toBeInTheDocument();
+    expect(mockSetWebImportPin).not.toHaveBeenCalled();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+  });
+
+  test('cancelling the PIN dialog closes it without downloading', () => {
+    render(
+      <Header
+        currentView="recipes"
+        currentUser={{ ...mockCurrentUser, webImportPinEnabled: false }}
+        onViewChange={() => {}}
+        onLogout={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Menü öffnen'));
+    fireEvent.click(screen.getByText('Kurzbefehl installieren'));
+    fireEvent.click(screen.getByText('Abbrechen'));
+
+    expect(screen.queryByText('Webimport-PIN erforderlich')).not.toBeInTheDocument();
+    expect(windowOpenSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Vor dem Download des Apple-Kurzbefehls prüft der Menüpunkt "Kurzbefehl
installieren" jetzt, ob der Nutzer bereits einen Webimport-PIN gesetzt hat.
Ist keiner vorhanden, öffnet sich ein Dialog, der erst eine gültige
4-8-stellige PIN verlangt (setWebImportPin) - erst danach startet der
Download. Ohne gesetzte PIN erfolgt kein Download.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UTTWBM2vQNUBiH3i81NAHu