### PR TITLE
Login-Screen im echten App-CI neu gestaltet

### DIFF
--- a/src/components/Login.css
+++ b/src/components/Login.css
@@ -4,160 +4,338 @@
   align-items: center;
   min-height: calc(100vh - 100px);
   padding: 20px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background:
+    radial-gradient(circle at 88% -8%, rgba(223, 122, 0, 0.12), transparent 55%),
+    radial-gradient(circle at -12% 32%, rgba(64, 44, 28, 0.09), transparent 50%),
+    #faf7f2;
 }
 
-.login-box {
-  background: white;
-  border-radius: 10px;
-  padding: 40px;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+.login-card {
+  background: #ffffff;
+  border-radius: 22px;
+  box-shadow: 0 24px 60px -14px rgba(64, 44, 28, 0.22), 0 4px 16px rgba(0, 0, 0, 0.05);
+  padding: 34px 30px;
   max-width: 400px;
   width: 100%;
 }
 
-.login-box h2 {
-  margin: 0 0 30px 0;
-  color: #333;
+.login-title {
+  margin: 0 0 26px 0;
+  color: #1a1a1a;
   text-align: center;
-  font-size: 28px;
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
 }
 
-.form-group {
-  margin-bottom: 20px;
+.login-field {
+  margin-bottom: 16px;
 }
 
-.form-group label {
+.login-label {
   display: block;
-  margin-bottom: 5px;
-  color: #555;
-  font-weight: 500;
+  margin-bottom: 7px;
+  color: #8a8378;
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-.form-group input {
+.login-input-wrap {
+  position: relative;
+}
+
+.login-input-icon {
+  position: absolute;
+  left: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #a39c92;
+  pointer-events: none;
+}
+
+.login-input {
   width: 100%;
-  padding: 12px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
+  padding: 14px 14px 14px 44px;
+  border: 1px solid #f7f4ef;
+  border-radius: 12px;
   font-size: 16px;
+  background: #f7f4ef;
+  color: #1a1a1a;
   box-sizing: border-box;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
 
-.form-group input:focus {
+.login-input::placeholder {
+  color: #a8a196;
+}
+
+.login-input:focus {
   outline: none;
-  border-color: #667eea;
-  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+  border-color: #DF7A00;
+  background: #ffffff;
+  box-shadow: 0 0 0 4px rgba(223, 122, 0, 0.12);
 }
 
-.error-message {
-  background: #fee;
-  color: #c33;
-  padding: 10px;
-  border-radius: 5px;
+.login-input:disabled {
+  opacity: 0.6;
+}
+
+.login-error {
+  background: #fdecea;
+  color: #c0392b;
+  padding: 10px 14px;
+  border-radius: 10px;
   margin-bottom: 15px;
   font-size: 14px;
 }
 
-.submit-btn {
-  width: 100%;
-  padding: 12px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  border-radius: 5px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s;
-}
-
-.submit-btn:hover {
-  transform: translateY(-2px);
-}
-
-.login-footer {
-  margin-top: 25px;
-  text-align: center;
-  padding-top: 20px;
-  border-top: 1px solid #eee;
-}
-
-.login-footer p {
-  margin: 0 0 10px 0;
-  color: #666;
+.login-success {
+  background: #eaf6ec;
+  color: #2f6b3a;
+  padding: 10px 14px;
+  border-radius: 10px;
+  margin-bottom: 15px;
   font-size: 14px;
 }
 
-.switch-btn {
+.login-cta-btn {
+  width: 100%;
+  margin-top: 4px;
+  padding: 16px;
+  border: none;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #402C1C 0%, #2a1c11 100%);
+  box-shadow: 0 10px 24px -6px rgba(64, 44, 28, 0.45);
+  color: #ffffff;
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.login-cta-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px -6px rgba(64, 44, 28, 0.5);
+}
+
+.login-cta-btn:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.login-cta-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.login-forgot-btn {
   background: none;
   border: none;
-  color: #667eea;
-  font-size: 14px;
+  color: #DF7A00;
+  font-size: 0.78rem;
   font-weight: 600;
   cursor: pointer;
-  text-decoration: underline;
-}
-
-.switch-btn:hover {
-  color: #764ba2;
-}
-
-.or-divider {
-  margin: 15px 0 10px 0;
-  color: #999;
-  font-size: 13px;
-  font-style: italic;
-}
-
-.guest-btn {
-  width: 100%;
-  padding: 10px;
-  background: #f0f0f0;
-  color: #555;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-  margin-top: 10px;
-}
-
-.guest-btn:hover {
-  background: #e0e0e0;
-  border-color: #ccc;
-}
-
-.forgot-password-btn {
-  background: none;
-  border: none;
-  color: #667eea;
-  font-size: 12px;
-  cursor: pointer;
-  padding: 4px 0 0 0;
+  padding: 8px 0 0 0;
   display: block;
   text-align: right;
   width: 100%;
-  text-decoration: underline;
 }
 
-.forgot-password-btn:hover {
-  color: #764ba2;
+.login-forgot-btn:hover {
+  color: #b8630a;
 }
 
-.reset-info {
-  color: #555;
+.login-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 22px 0 18px 0;
+}
+
+.login-divider span:first-child,
+.login-divider span:last-child {
+  flex: 1;
+  height: 1px;
+  background: #eee9e2;
+}
+
+.login-divider span:nth-child(2) {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: #a39c92;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.login-ghost-btn {
+  width: 100%;
+  padding: 14px;
+  border: 1.5px solid rgba(26, 26, 26, 0.14);
+  border-radius: 14px;
+  background: transparent;
+  color: #1a1a1a;
+  font-size: 0.92rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.login-ghost-btn:hover:not(:disabled) {
+  background: rgba(26, 26, 26, 0.04);
+  border-color: rgba(26, 26, 26, 0.22);
+}
+
+.login-ghost-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.login-footer {
+  margin-top: 22px;
+  padding-top: 20px;
+  border-top: 1px solid #eee9e2;
+  text-align: center;
+}
+
+.login-footer p {
+  margin: 0;
+  color: #6b6b6b;
+  font-size: 0.88rem;
+}
+
+.login-register-link,
+.login-back-link {
+  background: none;
+  border: none;
+  color: #DF7A00;
+  font-size: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+}
+
+.login-back-link {
+  font-size: 0.88rem;
+}
+
+.login-register-link:hover,
+.login-back-link:hover {
+  color: #b8630a;
+}
+
+.login-reset-info {
+  color: #6b6b6b;
   font-size: 14px;
-  margin-bottom: 20px;
   line-height: 1.5;
+  margin: 0 0 20px 0;
 }
 
-.success-message {
-  background: #efe;
-  color: #363;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 15px;
-  font-size: 14px;
+/* Dark mode */
+[data-theme="dark"] .login-container {
+  background:
+    radial-gradient(circle at 88% -8%, rgba(223, 122, 0, 0.10), transparent 55%),
+    radial-gradient(circle at -12% 32%, rgba(255, 255, 255, 0.05), transparent 50%),
+    #15130f;
 }
 
+[data-theme="dark"] .login-card {
+  background: #221d18;
+  box-shadow: 0 24px 60px -14px rgba(0, 0, 0, 0.55), 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .login-title {
+  color: #f0ece6;
+}
+
+[data-theme="dark"] .login-label {
+  color: #a89f92;
+}
+
+[data-theme="dark"] .login-input-icon {
+  color: #8a8378;
+}
+
+[data-theme="dark"] .login-input {
+  background: #2c2620;
+  border-color: #2c2620;
+  color: #f0ece6;
+}
+
+[data-theme="dark"] .login-input::placeholder {
+  color: #6f6a63;
+}
+
+[data-theme="dark"] .login-input:focus {
+  background: #2c2620;
+  border-color: #f0973a;
+  box-shadow: 0 0 0 4px rgba(240, 151, 58, 0.15);
+}
+
+[data-theme="dark"] .login-error {
+  background: #3a201c;
+  color: #ff8a72;
+}
+
+[data-theme="dark"] .login-success {
+  background: #1c3320;
+  color: #7fcf8f;
+}
+
+[data-theme="dark"] .login-cta-btn {
+  background: linear-gradient(135deg, #DF7A00 0%, #b8630a 100%);
+  box-shadow: 0 10px 24px -6px rgba(223, 122, 0, 0.35);
+}
+
+[data-theme="dark"] .login-cta-btn:hover:not(:disabled) {
+  box-shadow: 0 14px 28px -6px rgba(223, 122, 0, 0.4);
+}
+
+[data-theme="dark"] .login-forgot-btn {
+  color: #f0973a;
+}
+
+[data-theme="dark"] .login-forgot-btn:hover {
+  color: #ffb066;
+}
+
+[data-theme="dark"] .login-divider span:first-child,
+[data-theme="dark"] .login-divider span:last-child {
+  background: #332c24;
+}
+
+[data-theme="dark"] .login-divider span:nth-child(2) {
+  color: #7d766c;
+}
+
+[data-theme="dark"] .login-ghost-btn {
+  border-color: rgba(240, 236, 230, 0.16);
+  color: #f0ece6;
+}
+
+[data-theme="dark"] .login-ghost-btn:hover:not(:disabled) {
+  background: rgba(240, 236, 230, 0.06);
+  border-color: rgba(240, 236, 230, 0.26);
+}
+
+[data-theme="dark"] .login-footer {
+  border-top-color: #332c24;
+}
+
+[data-theme="dark"] .login-footer p {
+  color: #aaaaaa;
+}
+
+[data-theme="dark"] .login-register-link,
+[data-theme="dark"] .login-back-link {
+  color: #f0973a;
+}
+
+[data-theme="dark"] .login-register-link:hover,
+[data-theme="dark"] .login-back-link:hover {
+  color: #ffb066;
+}
+
+[data-theme="dark"] .login-reset-info {
+  color: #cccccc;
+}

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,6 +1,24 @@
 import React, { useState } from 'react';
 import './Login.css';
 
+function EmailIcon() {
+  return (
+    <svg className="login-input-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="4" width="20" height="16" rx="3"></rect>
+      <path d="M3 6.5l9 6 9-6"></path>
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg className="login-input-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="10" width="16" height="10" rx="2.5"></rect>
+      <path d="M8 10V7a4 4 0 0 1 8 0v3"></path>
+    </svg>
+  );
+}
+
 function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -15,7 +33,7 @@ function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
     e.preventDefault();
     setError('');
     setIsLoading(true);
-    
+
     try {
       // Trim email only; password must not be trimmed to preserve user-intended characters
       const result = await onLogin((email || '').trim(), password || '');
@@ -73,29 +91,34 @@ function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
   if (showResetForm) {
     return (
       <div className="login-container">
-        <div className="login-box">
-          <h2>Passwort zurücksetzen</h2>
+        <div className="login-card">
+          <h2 className="login-title">Passwort zurücksetzen</h2>
           {resetMessage ? (
-            <div className="success-message">{resetMessage}</div>
+            <div className="login-success">{resetMessage}</div>
           ) : (
             <form onSubmit={handleResetPassword}>
-              <p className="reset-info">
+              <p className="login-reset-info">
                 Geben Sie Ihre E-Mail-Adresse ein. Sie erhalten eine E-Mail mit einem Link zum Zurücksetzen Ihres Passworts.
               </p>
-              <div className="form-group">
-                <label htmlFor="reset-email">E-Mail-Adresse</label>
-                <input
-                  type="email"
-                  id="reset-email"
-                  value={resetEmail}
-                  onChange={(e) => setResetEmail(e.target.value)}
-                  autoComplete="email"
-                  required
-                  disabled={isLoading}
-                />
+              <div className="login-field">
+                <label htmlFor="reset-email" className="login-label">E-MAIL-ADRESSE</label>
+                <div className="login-input-wrap">
+                  <EmailIcon />
+                  <input
+                    type="email"
+                    id="reset-email"
+                    className="login-input"
+                    placeholder="name@beispiel.de"
+                    value={resetEmail}
+                    onChange={(e) => setResetEmail(e.target.value)}
+                    autoComplete="email"
+                    required
+                    disabled={isLoading}
+                  />
+                </div>
               </div>
-              {resetError && <div className="error-message">{resetError}</div>}
-              <button type="submit" className="submit-btn" disabled={isLoading}>
+              {resetError && <div className="login-error">{resetError}</div>}
+              <button type="submit" className="login-cta-btn" disabled={isLoading}>
                 {isLoading ? 'Wird gesendet...' : 'E-Mail senden'}
               </button>
             </form>
@@ -103,7 +126,7 @@ function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
           <div className="login-footer">
             <button
               type="button"
-              className="switch-btn"
+              className="login-back-link"
               onClick={handleBackToLogin}
               disabled={isLoading}
             >
@@ -117,36 +140,46 @@ function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
 
   return (
     <div className="login-container">
-      <div className="login-box">
-        <h2>Anmelden</h2>
+      <div className="login-card">
+        <h2 className="login-title">Anmelden</h2>
         <form onSubmit={handleSubmit}>
-          <div className="form-group">
-            <label htmlFor="email">E-Mail-Adresse</label>
-            <input
-              type="email"
-              id="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              autoComplete="email"
-              required
-              disabled={isLoading}
-            />
+          <div className="login-field">
+            <label htmlFor="email" className="login-label">E-MAIL-ADRESSE</label>
+            <div className="login-input-wrap">
+              <EmailIcon />
+              <input
+                type="email"
+                id="email"
+                className="login-input"
+                placeholder="name@beispiel.de"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+                disabled={isLoading}
+              />
+            </div>
           </div>
-          <div className="form-group">
-            <label htmlFor="password">Passwort</label>
-            <input
-              type="password"
-              id="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-              required
-              disabled={isLoading}
-            />
+          <div className="login-field">
+            <label htmlFor="password" className="login-label">PASSWORT</label>
+            <div className="login-input-wrap">
+              <LockIcon />
+              <input
+                type="password"
+                id="password"
+                className="login-input"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                required
+                disabled={isLoading}
+              />
+            </div>
             {onResetPassword && (
               <button
                 type="button"
-                className="forgot-password-btn"
+                className="login-forgot-btn"
                 onClick={() => setShowResetForm(true)}
                 disabled={isLoading}
               >
@@ -154,34 +187,42 @@ function Login({ onLogin, onSwitchToRegister, onGuestLogin, onResetPassword }) {
               </button>
             )}
           </div>
-          {error && <div className="error-message">{error}</div>}
-          <button type="submit" className="submit-btn" disabled={isLoading}>
+          {error && <div className="login-error">{error}</div>}
+          <button type="submit" className="login-cta-btn" disabled={isLoading}>
             {isLoading ? 'Anmeldung läuft...' : 'Anmelden'}
           </button>
         </form>
+
+        {onGuestLogin && (
+          <>
+            <div className="login-divider">
+              <span></span>
+              <span>oder</span>
+              <span></span>
+            </div>
+            <button
+              type="button"
+              className="login-ghost-btn"
+              onClick={handleGuestLogin}
+              disabled={isLoading}
+            >
+              Als Gast anmelden
+            </button>
+          </>
+        )}
+
         <div className="login-footer">
-          <p>Noch kein Konto?</p>
-          <button 
-            type="button" 
-            className="switch-btn"
-            onClick={onSwitchToRegister}
-            disabled={isLoading}
-          >
-            Jetzt registrieren
-          </button>
-          {onGuestLogin && (
-            <>
-              <p className="or-divider">oder</p>
-              <button 
-                type="button" 
-                className="guest-btn"
-                onClick={handleGuestLogin}
-                disabled={isLoading}
-              >
-                Als Gast anmelden
-              </button>
-            </>
-          )}
+          <p>
+            Noch kein Konto?{' '}
+            <button
+              type="button"
+              className="login-register-link"
+              onClick={onSwitchToRegister}
+              disabled={isLoading}
+            >
+              Jetzt registrieren
+            </button>
+          </p>
         </div>
       </div>
     </div>

--- a/src/darkMode.css
+++ b/src/darkMode.css
@@ -1128,14 +1128,12 @@
   color: #ccc;
 }
 
-/* ---- Login / Register ---- */
-[data-theme="dark"] .login-box,
+/* ---- Register ---- */
 [data-theme="dark"] .register-box {
   background: #1e1e1e;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
 }
 
-[data-theme="dark"] .login-box h2,
 [data-theme="dark"] .register-box h2 {
   color: #e8e8e8;
 }
@@ -1157,33 +1155,6 @@
 [data-theme="dark"] .form-group input:focus {
   background: #2a2a2a;
   border-color: #7a8fdf;
-}
-
-[data-theme="dark"] .login-footer {
-  border-top-color: #3d3d3d;
-}
-
-[data-theme="dark"] .login-footer p {
-  color: #aaa;
-}
-
-[data-theme="dark"] .guest-btn {
-  background: #2a2a2a;
-  color: #ccc;
-  border-color: #555;
-}
-
-[data-theme="dark"] .guest-btn:hover {
-  background: #333;
-  border-color: #666;
-}
-
-[data-theme="dark"] .or-divider {
-  color: #777;
-}
-
-[data-theme="dark"] .reset-info {
-  color: #ccc;
 }
 
 /* ---- Group List ---- */


### PR DESCRIPTION
Ersetzt den generischen Lila-Verlauf durch die tatsächliche brouBook-
Markensprache: warmer Farbverlauf-Hintergrund, Karten-/Button-Radien
und Farben (#402C1C/#DF7A00) wie im übrigen App-CI, Icon-Eingabefelder
sowie durchgängige Dark-Mode-Unterstützung. Login.css ist jetzt
eigenständig (eigene Dark-Mode-Regeln), veraltete Login-spezifische
Einträge wurden aus darkMode.css entfernt; Register bleibt unverändert.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4nSQrck8Z9adsbHucuYQ8