### PR TITLE
Add microdata fallback and robuster JSON-LD detection to recipe import

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -12,6 +12,7 @@ const admin = require('firebase-admin');
 const nodemailer = require('nodemailer');
 const crypto = require('crypto');
 const sharp = require('sharp');
+const cheerio = require('cheerio');
 const {createNutritionNormalizationUtils} = require('./nutritionNormalization');
 const {requireWebImportUnlocked, requireShortcutPin} = require('./webImportPin');
 
@@ -2091,8 +2092,31 @@ exports.captureWebsiteScreenshot = onCall(
 // both importRecipeCallable (web app) and importRecipeShortcut (Apple Shortcut).
 
 /**
+ * @param {*} type - A JSON-LD `@type` value (string or array of strings).
+ * @returns {boolean} True if the type is (or includes) "Recipe".
+ */
+function isRecipeType(type) {
+  return type === 'Recipe' || (Array.isArray(type) && type.includes('Recipe'));
+}
+
+/**
+ * @param {Object} node - Candidate JSON-LD node.
+ * @returns {boolean} True if the node has enough content to be usable.
+ */
+function hasUsableRecipeContent(node) {
+  if (!node) return false;
+  const hasIngredients =
+    Array.isArray(node.recipeIngredient) && node.recipeIngredient.length > 0;
+  const hasInstructions =
+    Array.isArray(node.recipeInstructions) && node.recipeInstructions.length > 0;
+  return hasIngredients || hasInstructions;
+}
+
+/**
  * Extract the first Schema.org Recipe JSON-LD candidate from raw HTML.
  * Node-safe regex alternative to the browser-side findJsonLdRecipeCandidate.
+ * Handles both a bare Recipe node and one wrapped in `@graph` and/or nested
+ * under a WebPage's `mainEntity` (a common pattern on recipe blogs).
  *
  * @param {string} html
  * @returns {Object|null}
@@ -2108,30 +2132,153 @@ function extractJsonLdRecipeCandidateFromHtml(html) {
     } catch {
       continue;
     }
+    const roots = Array.isArray(json) ? json : [json];
     const candidates = [];
-    if (Array.isArray(json)) {
-      candidates.push(...json);
-    } else if (json['@graph'] && Array.isArray(json['@graph'])) {
-      candidates.push(...json['@graph']);
-    } else {
-      candidates.push(json);
+    for (const node of roots) {
+      if (node && Array.isArray(node['@graph'])) {
+        candidates.push(...node['@graph']);
+      } else if (node) {
+        candidates.push(node);
+      }
     }
     for (const candidate of candidates) {
-      const type = candidate['@type'];
-      const isRecipe =
-        type === 'Recipe' || (Array.isArray(type) && type.includes('Recipe'));
-      if (!isRecipe) continue;
-      const hasIngredients =
-        Array.isArray(candidate.recipeIngredient) &&
-        candidate.recipeIngredient.length > 0;
-      const hasInstructions =
-        Array.isArray(candidate.recipeInstructions) &&
-        candidate.recipeInstructions.length > 0;
-      if (!hasIngredients && !hasInstructions) continue;
-      return candidate;
+      const nodesToCheck = [candidate];
+      if (candidate && candidate.mainEntity) {
+        const mainEntity = candidate.mainEntity;
+        nodesToCheck.push(...(Array.isArray(mainEntity) ? mainEntity : [mainEntity]));
+      }
+      for (const node of nodesToCheck) {
+        if (!node || !isRecipeType(node['@type'])) continue;
+        if (!hasUsableRecipeContent(node)) continue;
+        return node;
+      }
     }
   }
   return null;
+}
+
+/**
+ * Read a Schema.org microdata `itemprop` element's effective value: the
+ * `content` attribute when present (used on `<meta>` and often duplicated
+ * elsewhere for machine-readable values), the `datetime` attribute for
+ * `<time>` elements (e.g. ISO-8601 durations), the `src` for `<img>`, and
+ * otherwise the element's trimmed text content.
+ *
+ * @param {import('cheerio').Cheerio<any>} $el
+ * @returns {string}
+ */
+function microdataPropValue($el) {
+  const tagName = ($el.get(0)?.tagName || '').toLowerCase();
+  if (tagName === 'meta') return ($el.attr('content') || '').trim();
+  if (tagName === 'time') {
+    return ($el.attr('datetime') || $el.attr('content') || $el.text()).trim();
+  }
+  if (tagName === 'img') return ($el.attr('src') || $el.attr('content') || '').trim();
+  if ($el.attr('content') !== undefined) return ($el.attr('content') || '').trim();
+  return $el.text().trim();
+}
+
+/**
+ * Find elements with `[itemprop="name"]` inside `$root` that belong directly
+ * to it (skipping any that fall inside a nested `[itemscope]`, e.g. an
+ * author, rating or nutrition sub-object, so a Recipe's own `name` isn't
+ * confused with the `name` of its author or of an ingredient sub-item).
+ *
+ * @param {import('cheerio').CheerioAPI} $
+ * @param {import('cheerio').Cheerio<any>} $root
+ * @param {string} propName
+ * @returns {import('cheerio').Cheerio<any>[]}
+ */
+function directItemProps($, $root, propName) {
+  const results = [];
+  $root.find(`[itemprop="${propName}"]`).each((_, el) => {
+    const $el = $(el);
+    let belongsToRoot = true;
+    $el.parentsUntil($root).each((__, ancestor) => {
+      if ($(ancestor).attr('itemscope') !== undefined) belongsToRoot = false;
+    });
+    if (belongsToRoot) results.push($el);
+  });
+  return results;
+}
+
+/**
+ * Extract `recipeInstructions` from a microdata Recipe root, supporting both
+ * plain text list items (`<li itemprop="recipeInstructions">…</li>`, common
+ * on WordPress recipe plugins) and nested HowToStep items
+ * (`<div itemprop="recipeInstructions" itemscope itemtype=".../HowToStep">`).
+ *
+ * @param {import('cheerio').CheerioAPI} $
+ * @param {import('cheerio').Cheerio<any>} $root
+ * @returns {string[]}
+ */
+function extractMicrodataInstructions($, $root) {
+  const steps = [];
+  for (const $el of directItemProps($, $root, 'recipeInstructions')) {
+    if ($el.attr('itemscope') !== undefined) {
+      const textEls = directItemProps($, $el, 'text');
+      const nameEls = directItemProps($, $el, 'name');
+      const text =
+        (textEls[0] && microdataPropValue(textEls[0])) ||
+        (nameEls[0] && microdataPropValue(nameEls[0])) ||
+        $el.text().trim();
+      if (text) steps.push(text);
+    } else {
+      const text = microdataPropValue($el);
+      if (text) steps.push(text);
+    }
+  }
+  return steps;
+}
+
+/**
+ * Extract a Schema.org Recipe candidate from HTML microdata
+ * (`itemscope`/`itemtype`/`itemprop` attributes), for sites that mark up
+ * recipes without JSON-LD. Returns the same node shape as
+ * {@link extractJsonLdRecipeCandidateFromHtml} so it can be fed through the
+ * same `jsonLdCandidateToText` conversion and Gemini normalization step.
+ *
+ * @param {string} html
+ * @returns {Object|null}
+ */
+function extractMicrodataRecipeCandidateFromHtml(html) {
+  let $;
+  try {
+    $ = cheerio.load(html);
+  } catch {
+    return null;
+  }
+  const $root = $('[itemscope][itemtype]')
+      .filter((_, el) => /schema\.org\/Recipe\/?$/i.test(($(el).attr('itemtype') || '').trim()))
+      .first();
+  if (!$root.length) return null;
+
+  const propValue = (name) => {
+    const els = directItemProps($, $root, name);
+    return els[0] ? microdataPropValue(els[0]) : undefined;
+  };
+  const propValueList = (name) => {
+    const list = directItemProps($, $root, name).map(microdataPropValue).filter(Boolean);
+    // Return undefined (not []) when absent, matching the JSON-LD candidate
+    // shape: jsonLdCandidateToText treats a present-but-empty array as truthy
+    // and would otherwise emit a blank "Küche:"/"Kategorie:" line.
+    return list.length ? list : undefined;
+  };
+
+  const candidate = {
+    '@type': 'Recipe',
+    name: propValue('name'),
+    description: propValue('description'),
+    recipeYield: propValue('recipeYield'),
+    prepTime: propValue('prepTime'),
+    cookTime: propValue('cookTime'),
+    totalTime: propValue('totalTime'),
+    recipeCuisine: propValueList('recipeCuisine'),
+    recipeCategory: propValueList('recipeCategory'),
+    recipeIngredient: propValueList('recipeIngredient'),
+    recipeInstructions: extractMicrodataInstructions($, $root),
+  };
+  return hasUsableRecipeContent(candidate) ? candidate : null;
 }
 
 /**
@@ -2359,6 +2506,52 @@ async function runImportFromUrl(url, {apiKey, cuisineTypes, mealCategories, sour
       console.warn(
           `[importRecipe:jsonld:error] host=${hostname} ` +
           `err=${jsonLdErr.message}`,
+      );
+    }
+
+    // ── Phase 2b: Microdata extraction ────────────────────────────────────
+    // Fallback for sites (often WordPress recipe plugins) that mark up
+    // recipes with itemscope/itemprop microdata instead of JSON-LD. Feeds
+    // through the same jsonLdCandidateToText → Gemini normalization step as
+    // Phase 2, so no app-specific normalization behavior changes.
+    try {
+      console.log(`[importRecipe:microdata:start] host=${hostname}`);
+      const candidate = extractMicrodataRecipeCandidateFromHtml(html);
+      if (candidate) {
+        console.log(`[importRecipe:microdata:found] host=${hostname}`);
+        const microdataText = jsonLdCandidateToText(candidate);
+        try {
+          const result = await callGeminiTextAPI(
+              microdataText, 'de', apiKey, cuisineTypes, mealCategories,
+          );
+          if (looksLikeIncompleteRecipe(result, microdataText)) {
+            console.warn(
+                `[importRecipe:microdata:incomplete] host=${hostname} ` +
+                `steps=${partialStepsCount(result)} – trying next phase`,
+            );
+            if (partialStepsCount(result) > partialStepsCount(bestPartialResult)) {
+              bestPartialResult = result;
+            }
+          } else {
+            console.log(
+                `[importRecipe:microdata:ai_ok] host=${hostname} ` +
+                `elapsed=${Date.now() - startMs}ms`,
+            );
+            return result;
+          }
+        } catch (aiErr) {
+          console.warn(
+              `[importRecipe:microdata:ai_fail] host=${hostname} ` +
+              `err=${aiErr.message}`,
+          );
+        }
+      } else {
+        console.log(`[importRecipe:microdata:not_found] host=${hostname}`);
+      }
+    } catch (microdataErr) {
+      console.warn(
+          `[importRecipe:microdata:error] host=${hostname} ` +
+          `err=${microdataErr.message}`,
       );
     }
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "@sparticuz/chromium": "^119.0.0",
+        "cheerio": "^1.0.0",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^7.3.2",
+        "firebase-functions": "^7.0.0",
         "nodemailer": "^7.0.13",
         "puppeteer": "^21.0.0",
         "sharp": "^0.34.5"
@@ -1592,6 +1593,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1704,6 +1711,48 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chromium-bidi": {
@@ -1878,6 +1927,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -1972,6 +2049,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2029,6 +2161,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -2036,6 +2193,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -3085,6 +3254,37 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3762,6 +3962,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3937,6 +4149,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -5034,6 +5295,15 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -5121,6 +5391,40 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "@sparticuz/chromium": "^119.0.0",
+    "cheerio": "^1.0.0",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^7.0.0",
     "nodemailer": "^7.0.13",


### PR DESCRIPTION
extractJsonLdRecipeCandidateFromHtml now also unwraps a Recipe nested
under a WebPage's mainEntity, a common pattern recipe-scrapers handles
that the previous @graph-only traversal missed.

Adds extractMicrodataRecipeCandidateFromHtml (via cheerio) as a new
Phase 2b for sites that mark up recipes with itemscope/itemprop
microdata instead of JSON-LD (common on older WordPress recipe
plugins), inspired by recipe-scrapers' schema.org fallback chain.
Both paths produce the same candidate shape and are fed through the
existing jsonLdCandidateToText + Gemini normalization step unchanged,
so app-specific field mapping (portionen, kulinarik, schwierigkeit,
etc.) is untouched — only extraction reliability improves, catching
more recipes before falling through to the expensive Puppeteer/Vision
screenshot phase.