### PR TITLE
Rezept-Privatbutton auf einheitliches Braun angleichen

### DIFF
--- a/src/components/RecipeDetail.css
+++ b/src/components/RecipeDetail.css
@@ -295,9 +295,10 @@
   justify-content: center;
   flex-shrink: 0;
 
-  background: #fff;
+  background: rgba(64, 44, 28, 0.9);
   border: 1px solid #f0f0f0 !important;
   border-radius: 12px !important;
+  color: #fff;
 
   line-height: 1;
   font-size: 1.4rem;


### PR DESCRIPTION
Der .private-badge-button hatte in RecipeDetail.css einen weißen
Hintergrund statt des braunen rgba(64, 44, 28, 0.9) aus MenuDetail.css.